### PR TITLE
🔗 Add book sharing + deep link handling

### DIFF
--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -58,6 +58,14 @@
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="listenup" android:host="join" />
             </intent-filter>
+
+            <!-- Deep link: listenup://book/{bookId} -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="listenup" android:host="book" />
+            </intent-filter>
         </activity>
 
         <service

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
@@ -219,6 +219,7 @@ val downloadModule =
         // Platform actions for BookDetailScreen (download + playback integration)
         single<BookDetailPlatformActions> {
             AndroidBookDetailPlatformActions(
+                context = androidContext(),
                 downloadManager = get(),
                 playerViewModel = get(),
                 localPreferences = get(),

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/MainActivity.kt
@@ -36,6 +36,7 @@ import com.calypsan.listenup.client.data.repository.ShortcutAction
 import com.calypsan.listenup.client.data.repository.ShortcutActionManager
 import com.calypsan.listenup.client.data.sync.SSEManager
 import com.calypsan.listenup.client.deeplink.DeepLinkParser
+import com.calypsan.listenup.client.deeplink.BookDeepLink
 import com.calypsan.listenup.client.design.components.ListenUpLoadingIndicator
 import com.calypsan.listenup.client.design.theme.ListenUpTheme
 import com.calypsan.listenup.client.domain.model.Instance
@@ -113,6 +114,13 @@ class MainActivity : ComponentActivity() {
         DeepLinkParser.parse(intent)?.let { inviteLink ->
             println("MainActivity: Received invite deep link - server=${inviteLink.serverUrl}, code=${inviteLink.code}")
             deepLinkManager.setInviteLink(inviteLink.serverUrl, inviteLink.code)
+            return
+        }
+
+        // Check for book deep link: listenup://book/{bookId}
+        DeepLinkParser.parseBookDeepLink(intent)?.let { bookLink ->
+            println("MainActivity: Received book deep link - bookId=${'$'}{bookLink.bookId}")
+            shortcutActionManager.setPendingAction(ShortcutAction.NavigateToBook(bookLink.bookId))
             return
         }
 

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/deeplink/DeepLinkParser.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/deeplink/DeepLinkParser.kt
@@ -7,6 +7,11 @@ import android.net.Uri
 import com.calypsan.listenup.client.data.repository.InviteDeepLink
 
 /**
+ * Parsed book deep link: listenup://book/{bookId}
+ */
+data class BookDeepLink(val bookId: String)
+
+/**
  * Parses deep link intents into structured data.
  *
  * Handles two types of invite URLs:
@@ -24,6 +29,7 @@ import com.calypsan.listenup.client.data.repository.InviteDeepLink
 object DeepLinkParser {
     private const val CUSTOM_SCHEME = "listenup"
     private const val JOIN_HOST = "join"
+    private const val BOOK_HOST = "book"
     private const val JOIN_PATH_PREFIX = "/join/"
 
     /**
@@ -37,6 +43,19 @@ object DeepLinkParser {
 
         val uri = intent.data ?: return null
         return parseUri(uri)
+    }
+
+    /**
+     * Parses a book deep link from an intent.
+     * Handles: listenup://book/{bookId}
+     */
+    fun parseBookDeepLink(intent: Intent?): BookDeepLink? {
+        if (intent?.action != Intent.ACTION_VIEW) return null
+        val uri = intent.data ?: return null
+        if (uri.scheme?.lowercase() != CUSTOM_SCHEME) return null
+        if (uri.host?.lowercase() != BOOK_HOST) return null
+        val bookId = uri.pathSegments?.firstOrNull()?.takeIf { it.isNotBlank() } ?: return null
+        return BookDeepLink(bookId)
     }
 
     /**

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/deeplink/DeepLinkParser.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/deeplink/DeepLinkParser.kt
@@ -9,7 +9,9 @@ import com.calypsan.listenup.client.data.repository.InviteDeepLink
 /**
  * Parsed book deep link: listenup://book/{bookId}
  */
-data class BookDeepLink(val bookId: String)
+data class BookDeepLink(
+    val bookId: String,
+)
 
 /**
  * Parses deep link intents into structured data.

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/bookdetail/AndroidBookDetailPlatformActions.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/bookdetail/AndroidBookDetailPlatformActions.kt
@@ -42,15 +42,20 @@ class AndroidBookDetailPlatformActions(
 
     override suspend fun checkServerReachable(): Boolean = playbackManager.isServerReachable()
 
-    override fun shareText(text: String, url: String) {
-        val sendIntent = Intent().apply {
-            action = Intent.ACTION_SEND
-            putExtra(Intent.EXTRA_TEXT, text)
-            type = "text/plain"
-        }
-        val shareIntent = Intent.createChooser(sendIntent, null).apply {
-            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        }
+    override fun shareText(
+        text: String,
+        url: String,
+    ) {
+        val sendIntent =
+            Intent().apply {
+                action = Intent.ACTION_SEND
+                putExtra(Intent.EXTRA_TEXT, text)
+                type = "text/plain"
+            }
+        val shareIntent =
+            Intent.createChooser(sendIntent, null).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
         context.startActivity(shareIntent)
     }
 }

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/bookdetail/AndroidBookDetailPlatformActions.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/bookdetail/AndroidBookDetailPlatformActions.kt
@@ -7,6 +7,8 @@ import com.calypsan.listenup.client.domain.repository.NetworkMonitor
 import com.calypsan.listenup.client.download.DownloadManager
 import com.calypsan.listenup.client.download.DownloadResult
 import com.calypsan.listenup.client.playback.PlaybackManager
+import android.content.Context
+import android.content.Intent
 import com.calypsan.listenup.client.playback.PlayerViewModel
 import kotlinx.coroutines.flow.Flow
 
@@ -15,6 +17,7 @@ import kotlinx.coroutines.flow.Flow
  * Delegates to DownloadManager (WorkManager) and PlayerViewModel (Media3).
  */
 class AndroidBookDetailPlatformActions(
+    private val context: Context,
     private val downloadManager: DownloadManager,
     private val playerViewModel: PlayerViewModel,
     private val localPreferences: LocalPreferences,
@@ -38,4 +41,16 @@ class AndroidBookDetailPlatformActions(
     override fun observeIsOnUnmeteredNetwork(): Flow<Boolean> = networkMonitor.isOnUnmeteredNetworkFlow
 
     override suspend fun checkServerReachable(): Boolean = playbackManager.isServerReachable()
+
+    override fun shareText(text: String, url: String) {
+        val sendIntent = Intent().apply {
+            action = Intent.ACTION_SEND
+            putExtra(Intent.EXTRA_TEXT, text)
+            type = "text/plain"
+        }
+        val shareIntent = Intent.createChooser(sendIntent, null).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        context.startActivity(shareIntent)
+    }
 }

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/ListenUpNavigation.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/ListenUpNavigation.kt
@@ -483,6 +483,16 @@ private fun AuthenticatedNavigation(
                 currentShellDestination = ShellDestination.Library
             }
 
+            is ShortcutAction.NavigateToBook -> {
+                logger.info { "Navigating to book: ${'$'}{action.bookId}" }
+                // Ensure we're on Shell first, then navigate to book detail
+                if (backStack.lastOrNull() != Shell) {
+                    backStack.clear()
+                    backStack.add(Shell)
+                }
+                backStack.add(BookDetail(action.bookId))
+            }
+
             is ShortcutAction.SleepTimer -> {
                 // If playing, show sleep timer; otherwise resume + set timer
                 val result = homeRepository.getContinueListening(1)

--- a/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/BookDetailPlatformActions.kt
+++ b/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/BookDetailPlatformActions.kt
@@ -39,6 +39,9 @@ interface BookDetailPlatformActions {
 
     /** Check if the server is reachable (quick health check) */
     suspend fun checkServerReachable(): Boolean
+
+    /** Share text via platform share sheet (Android) or clipboard (Desktop) */
+    fun shareText(text: String, url: String)
 }
 
 /**
@@ -64,4 +67,6 @@ class NoOpBookDetailPlatformActions : BookDetailPlatformActions {
     override fun observeIsOnUnmeteredNetwork(): Flow<Boolean> = flowOf(true)
 
     override suspend fun checkServerReachable(): Boolean = true
+
+    override fun shareText(text: String, url: String) {}
 }

--- a/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/BookDetailPlatformActions.kt
+++ b/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/BookDetailPlatformActions.kt
@@ -41,7 +41,10 @@ interface BookDetailPlatformActions {
     suspend fun checkServerReachable(): Boolean
 
     /** Share text via platform share sheet (Android) or clipboard (Desktop) */
-    fun shareText(text: String, url: String)
+    fun shareText(
+        text: String,
+        url: String,
+    )
 }
 
 /**
@@ -68,5 +71,8 @@ class NoOpBookDetailPlatformActions : BookDetailPlatformActions {
 
     override suspend fun checkServerReachable(): Boolean = true
 
-    override fun shareText(text: String, url: String) {}
+    override fun shareText(
+        text: String,
+        url: String,
+    ) {}
 }

--- a/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/BookDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/BookDetailScreen.kt
@@ -57,6 +57,8 @@ import com.calypsan.listenup.client.presentation.bookdetail.BookDetailViewModel
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
+import com.calypsan.listenup.client.domain.repository.InstanceRepository
+import com.calypsan.listenup.client.core.Success as ResultSuccess
 import org.jetbrains.compose.resources.stringResource
 import listenup.composeapp.generated.resources.Res
 import listenup.composeapp.generated.resources.book_detail_server_is_unreachable_connect_to
@@ -91,6 +93,7 @@ fun BookDetailScreen(
 ) {
     val platformActions: BookDetailPlatformActions = koinInject()
     val userRepository: UserRepository = koinInject()
+    val instanceRepository: InstanceRepository = koinInject()
     val scope = rememberCoroutineScope()
     val snackbarHostState = LocalSnackbarHostState.current
 
@@ -187,6 +190,19 @@ fun BookDetailScreen(
                     onDiscardProgressClick = { viewModel.discardProgress() },
                     onAddToShelfClick = { viewModel.showShelfPicker() },
                     onAddToCollectionClick = { /* TODO: Implement */ },
+                    onShareClick = {
+                        val book = state.book ?: return@BookDetailContent
+                        scope.launch {
+                            val result = instanceRepository.getInstance()
+                            if (result is ResultSuccess) {
+                                val instance = result.data
+                                val baseUrl = (instance.remoteUrl ?: instance.localUrl)?.trimEnd('/') ?: return@launch
+                                val url = "${'$'}baseUrl/share/book/${'$'}{book.id.value}"
+                                val text = "Check out ${'$'}{book.title} on ListenUp!\n${'$'}url"
+                                platformActions.shareText(text, url)
+                            }
+                        }
+                    },
                     onDeleteBookClick = { /* TODO: Implement */ },
                     onPlayClick = { platformActions.playBook(BookId(bookId)) },
                     canPlay = canPlay,
@@ -303,6 +319,7 @@ fun BookDetailContent(
     onDiscardProgressClick: () -> Unit,
     onAddToShelfClick: () -> Unit,
     onAddToCollectionClick: () -> Unit,
+    onShareClick: () -> Unit,
     onDeleteBookClick: () -> Unit,
     onPlayClick: () -> Unit,
     canPlay: Boolean,
@@ -340,6 +357,7 @@ fun BookDetailContent(
             onDiscardProgressClick = onDiscardProgressClick,
             onAddToShelfClick = onAddToShelfClick,
             onAddToCollectionClick = onAddToCollectionClick,
+            onShareClick = onShareClick,
             onDeleteBookClick = onDeleteBookClick,
             onPlayClick = onPlayClick,
             onDownloadClick = onDownloadClick,
@@ -369,6 +387,7 @@ fun BookDetailContent(
             onDiscardProgressClick = onDiscardProgressClick,
             onAddToShelfClick = onAddToShelfClick,
             onAddToCollectionClick = onAddToCollectionClick,
+            onShareClick = onShareClick,
             onDeleteBookClick = onDeleteBookClick,
             onPlayClick = onPlayClick,
             canPlay = canPlay,
@@ -410,6 +429,7 @@ private fun ImmersiveBookDetail(
     onDiscardProgressClick: () -> Unit,
     onAddToShelfClick: () -> Unit,
     onAddToCollectionClick: () -> Unit,
+    onShareClick: () -> Unit,
     onDeleteBookClick: () -> Unit,
     onPlayClick: () -> Unit,
     canPlay: Boolean,
@@ -460,6 +480,7 @@ private fun ImmersiveBookDetail(
                 onDiscardProgressClick = onDiscardProgressClick,
                 onAddToShelfClick = onAddToShelfClick,
                 onAddToCollectionClick = onAddToCollectionClick,
+                onShareClick = onShareClick,
                 onDeleteClick = onDeleteBookClick,
             )
         }

--- a/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/components/BookActionsMenu.kt
+++ b/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/components/BookActionsMenu.kt
@@ -5,6 +5,7 @@ import androidx.compose.material.icons.automirrored.filled.PlaylistAdd
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.RadioButtonUnchecked
 import androidx.compose.material.icons.filled.RestartAlt
 import androidx.compose.material.icons.filled.Search
@@ -24,6 +25,7 @@ import listenup.composeapp.generated.resources.common_delete_name
 import listenup.composeapp.generated.resources.book_detail_discard_progress
 import listenup.composeapp.generated.resources.book_detail_edit_book
 import listenup.composeapp.generated.resources.book_detail_find_metadata
+import listenup.composeapp.generated.resources.common_share
 
 /**
  * Dropdown menu for book actions.
@@ -57,6 +59,7 @@ fun BookActionsMenu(
     onDiscardProgressClick: () -> Unit,
     onAddToShelfClick: () -> Unit,
     onAddToCollectionClick: () -> Unit,
+    onShareClick: () -> Unit,
     onDeleteClick: () -> Unit,
 ) {
     DropdownMenu(
@@ -147,6 +150,18 @@ fun BookActionsMenu(
                 onClick = onAddToCollectionClick,
             )
         }
+
+        // Share
+        DropdownMenuItem(
+            text = { Text(stringResource(Res.string.common_share)) },
+            leadingIcon = {
+                Icon(
+                    imageVector = Icons.Default.Share,
+                    contentDescription = null,
+                )
+            },
+            onClick = onShareClick,
+        )
 
         // Delete Book (admin only, stubbed for now)
         if (isAdmin) {

--- a/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/components/HeroSection.kt
+++ b/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/components/HeroSection.kt
@@ -68,6 +68,7 @@ fun HeroSection(
     onDiscardProgressClick: () -> Unit,
     onAddToShelfClick: () -> Unit,
     onAddToCollectionClick: () -> Unit,
+    onShareClick: () -> Unit,
     onDeleteClick: () -> Unit,
 ) {
     val surfaceColor = MaterialTheme.colorScheme.surface
@@ -124,6 +125,7 @@ fun HeroSection(
                 onDiscardProgressClick = onDiscardProgressClick,
                 onAddToShelfClick = onAddToShelfClick,
                 onAddToCollectionClick = onAddToCollectionClick,
+                onShareClick = onShareClick,
                 onDeleteClick = onDeleteClick,
             )
 
@@ -188,6 +190,7 @@ private fun HeroNavigationBar(
     onDiscardProgressClick: () -> Unit,
     onAddToShelfClick: () -> Unit,
     onAddToCollectionClick: () -> Unit,
+    onShareClick: () -> Unit,
     onDeleteClick: () -> Unit,
 ) {
     var showMenu by remember { mutableStateOf(false) }
@@ -266,6 +269,10 @@ private fun HeroNavigationBar(
                 onAddToCollectionClick = {
                     showMenu = false
                     onAddToCollectionClick()
+                },
+                onShareClick = {
+                    showMenu = false
+                    onShareClick()
                 },
                 onDeleteClick = {
                     showMenu = false

--- a/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/components/TwoPaneLayout.kt
+++ b/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/components/TwoPaneLayout.kt
@@ -83,6 +83,7 @@ fun TwoPaneBookDetail(
     onDiscardProgressClick: () -> Unit,
     onAddToShelfClick: () -> Unit,
     onAddToCollectionClick: () -> Unit,
+    onShareClick: () -> Unit = {},
     onDeleteBookClick: () -> Unit,
     onPlayClick: () -> Unit,
     onDownloadClick: () -> Unit,
@@ -122,6 +123,7 @@ fun TwoPaneBookDetail(
             onDiscardProgressClick = onDiscardProgressClick,
             onAddToShelfClick = onAddToShelfClick,
             onAddToCollectionClick = onAddToCollectionClick,
+            onShareClick = onShareClick,
             onDeleteBookClick = onDeleteBookClick,
             onPlayClick = onPlayClick,
             onDownloadClick = onDownloadClick,
@@ -170,6 +172,7 @@ private fun TwoPaneLeftPane(
     onDiscardProgressClick: () -> Unit,
     onAddToShelfClick: () -> Unit,
     onAddToCollectionClick: () -> Unit,
+    onShareClick: () -> Unit = {},
     onDeleteBookClick: () -> Unit,
     onPlayClick: () -> Unit,
     onDownloadClick: () -> Unit,
@@ -289,6 +292,10 @@ private fun TwoPaneLeftPane(
                         onAddToCollectionClick = {
                             showMenu = false
                             onAddToCollectionClick()
+                        },
+                        onShareClick = {
+                            showMenu = false
+                            onShareClick()
                         },
                         onDeleteClick = {
                             showMenu = false

--- a/composeApp/src/desktopMain/kotlin/com/calypsan/listenup/client/features/bookdetail/DesktopBookDetailPlatformActions.kt
+++ b/composeApp/src/desktopMain/kotlin/com/calypsan/listenup/client/features/bookdetail/DesktopBookDetailPlatformActions.kt
@@ -38,8 +38,14 @@ class DesktopBookDetailPlatformActions(
 
     override suspend fun checkServerReachable(): Boolean = true
 
-    override fun shareText(text: String, url: String) {
+    override fun shareText(
+        text: String,
+        url: String,
+    ) {
         val selection = java.awt.datatransfer.StringSelection(text)
-        java.awt.Toolkit.getDefaultToolkit().systemClipboard.setContents(selection, null)
+        java.awt.Toolkit
+            .getDefaultToolkit()
+            .systemClipboard
+            .setContents(selection, null)
     }
 }

--- a/composeApp/src/desktopMain/kotlin/com/calypsan/listenup/client/features/bookdetail/DesktopBookDetailPlatformActions.kt
+++ b/composeApp/src/desktopMain/kotlin/com/calypsan/listenup/client/features/bookdetail/DesktopBookDetailPlatformActions.kt
@@ -37,4 +37,9 @@ class DesktopBookDetailPlatformActions(
     override fun observeIsOnUnmeteredNetwork(): Flow<Boolean> = flowOf(true)
 
     override suspend fun checkServerReachable(): Boolean = true
+
+    override fun shareText(text: String, url: String) {
+        val selection = java.awt.datatransfer.StringSelection(text)
+        java.awt.Toolkit.getDefaultToolkit().systemClipboard.setContents(selection, null)
+    }
 }

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/ShortcutActionManager.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/ShortcutActionManager.kt
@@ -36,6 +36,15 @@ sealed interface ShortcutAction {
     data class SleepTimer(
         val timerMinutes: Int? = null,
     ) : ShortcutAction
+
+    /**
+     * Navigate to a specific book's detail screen (from deep link).
+     *
+     * @property bookId The ID of the book to view
+     */
+    data class NavigateToBook(
+        val bookId: String,
+    ) : ShortcutAction
 }
 
 /**

--- a/shared/src/commonMain/resources/strings/en.json
+++ b/shared/src/commonMain/resources/strings/en.json
@@ -87,6 +87,8 @@
     "server": "Server",
     "settings": "Settings",
     "share": "Share",
+    "share_book_text": "Check out %1$s on ListenUp!",
+    "share_copied_to_clipboard": "Share link copied to clipboard",
     "shelf_name_hint": "e.g., To Read, Favorites, Mystery...",
     "sign_out": "Sign Out",
     "sort_by": "Sort by %1$s",


### PR DESCRIPTION
Share button on book detail page + Android deep link support.

## What
- Share option in BookActionsMenu → native share sheet (Android) / clipboard (desktop)
- Share URL: `{remoteUrl || localUrl}/share/book/{bookId}`
- Share text: "Check out {title} on ListenUp!"
- Android: `listenup://book/{bookId}` intent filter + deep link parsing → navigates to book detail
- New localization strings for share feature

14 files changed, +132 lines. All tests pass.