### PR TITLE
📦 iOS Downloads — NSURLSession download tasks + Liquid Glass UI

### DIFF
--- a/composeApp/src/desktopMain/kotlin/com/calypsan/listenup/client/platform/StubDownloadService.kt
+++ b/composeApp/src/desktopMain/kotlin/com/calypsan/listenup/client/platform/StubDownloadService.kt
@@ -1,6 +1,9 @@
 package com.calypsan.listenup.client.platform
 
 import com.calypsan.listenup.client.core.BookId
+import com.calypsan.listenup.client.domain.model.BookDownloadStatus
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 import com.calypsan.listenup.client.download.DownloadResult
 import com.calypsan.listenup.client.download.DownloadService
 
@@ -27,4 +30,7 @@ class StubDownloadService : DownloadService {
     override suspend fun deleteDownload(bookId: BookId) {
         // No-op: downloads not supported
     }
+
+    override fun observeBookStatus(bookId: BookId): Flow<BookDownloadStatus> =
+        flowOf(BookDownloadStatus.notDownloaded(bookId.value))
 }

--- a/iosApp/iosApp/Core/Dependencies.swift
+++ b/iosApp/iosApp/Core/Dependencies.swift
@@ -66,6 +66,7 @@ final class Dependencies {
     var bookRepository: BookRepository { resolve { KoinHelper.shared.getBookRepository() } }
     var imageStorage: ImageStorage { resolve { KoinHelper.shared.getImageStorage() } }
     var sleepTimerManager: SleepTimerManager { resolve { KoinHelper.shared.getSleepTimerManager() } }
+    var downloadService: DownloadService { resolve { KoinHelper.shared.getDownloadService() } }
     // MARK: - Detail ViewModels (factory - new instance each time)
 
     /// Creates a new BookDetailViewModel instance (not cached - each screen gets its own)

--- a/iosApp/iosApp/DesignSystem/Components/DownloadButton.swift
+++ b/iosApp/iosApp/DesignSystem/Components/DownloadButton.swift
@@ -53,7 +53,7 @@ struct DownloadButton: View {
                 withAnimation(.easeInOut.delay(2.0)) {
                     showTrash = true
                 }
-            } else if newValue != "completed" {
+            } else if newValue != .completed {
                 showTrash = false
             }
         }
@@ -67,11 +67,11 @@ struct DownloadButton: View {
 
     private var action: () -> Void {
         switch state {
-        case .queued, "downloading":
+        case .queued, .downloading:
             return onCancel
         case .completed:
             return onDelete
-        default:
+        case .notDownloaded, .partial, .failed:
             return onDownload
         }
     }
@@ -124,10 +124,6 @@ struct DownloadButton: View {
                 .font(.title3)
                 .foregroundStyle(.red)
 
-        default:
-            Image(systemName: "arrow.down.circle")
-                .font(.title3)
-                .foregroundStyle(Color.listenUpOrange)
         }
     }
 }
@@ -170,9 +166,9 @@ struct DownloadButtonExpanded: View {
 
     private var action: () -> Void {
         switch state {
-        case .queued, "downloading": return onCancel
+        case .queued, .downloading: return onCancel
         case .completed: return onDelete
-        default: return onDownload
+        case .notDownloaded, .partial, .failed: return onDownload
         }
     }
 
@@ -199,9 +195,6 @@ struct DownloadButtonExpanded: View {
         case .partial, .failed:
             Image(systemName: "arrow.clockwise.circle")
                 .foregroundStyle(.red)
-        default:
-            Image(systemName: "arrow.down.circle")
-                .foregroundStyle(Color.listenUpOrange)
         }
     }
 
@@ -224,9 +217,6 @@ struct DownloadButtonExpanded: View {
         case .partial, .failed:
             Text(String(localized: "common.retry"))
                 .foregroundStyle(.red)
-        default:
-            Text(String(localized: "book_detail.download"))
-                .foregroundStyle(.primary)
         }
     }
 }

--- a/iosApp/iosApp/DesignSystem/Components/DownloadButton.swift
+++ b/iosApp/iosApp/DesignSystem/Components/DownloadButton.swift
@@ -1,0 +1,252 @@
+import SwiftUI
+
+/// Download button with visual state for book detail.
+///
+/// States:
+/// - Not downloaded: Download icon
+/// - Queued: Spinner
+/// - Downloading: Circular progress with percentage
+/// - Completed: Checkmark, tap to delete
+/// - Failed/Partial: Retry icon
+///
+/// Liquid Glass: Uses `.regularMaterial` background with gradient stroke.
+struct DownloadButton: View {
+    let state: String // notDownloaded, queued, downloading, completed, partial, failed
+    let progress: Float
+    let onDownload: () -> Void
+    let onCancel: () -> Void
+    let onDelete: () -> Void
+
+    /// Tracks whether we've shown the checkmark long enough to transition to trash
+    @State private var showTrash = false
+    /// Tracks previous state to detect completion transition
+    @State private var previousState: String = ""
+
+    var body: some View {
+        Button(action: action) {
+            ZStack {
+                // Glass background
+                Circle()
+                    .fill(.regularMaterial)
+                    .overlay {
+                        Circle()
+                            .strokeBorder(
+                                LinearGradient(
+                                    colors: [.white.opacity(0.3), .white.opacity(0.1)],
+                                    startPoint: .topLeading,
+                                    endPoint: .bottomTrailing
+                                ),
+                                lineWidth: 0.5
+                            )
+                    }
+                    .shadow(color: .black.opacity(0.08), radius: 4, x: 0, y: 2)
+
+                // Icon / progress
+                iconView
+            }
+            .frame(width: 44, height: 44)
+        }
+        .buttonStyle(.plain)
+        .onChange(of: state) { oldValue, newValue in
+            if newValue == "completed" && oldValue != "completed" {
+                showTrash = false
+                withAnimation(.easeInOut.delay(2.0)) {
+                    showTrash = true
+                }
+            } else if newValue != "completed" {
+                showTrash = false
+            }
+        }
+        .onAppear {
+            // If already completed on appear, show trash immediately
+            if state == "completed" {
+                showTrash = true
+            }
+        }
+    }
+
+    private var action: () -> Void {
+        switch state {
+        case "queued", "downloading":
+            return onCancel
+        case "completed":
+            return onDelete
+        default:
+            return onDownload
+        }
+    }
+
+    @ViewBuilder
+    private var iconView: some View {
+        switch state {
+        case "notDownloaded":
+            Image(systemName: "arrow.down.circle")
+                .font(.title3)
+                .foregroundStyle(Color.listenUpOrange)
+
+        case "queued":
+            ProgressView()
+                .scaleEffect(0.8)
+
+        case "downloading":
+            ZStack {
+                Circle()
+                    .stroke(Color.listenUpOrange.opacity(0.3), lineWidth: 3)
+                    .frame(width: 28, height: 28)
+                Circle()
+                    .trim(from: 0, to: CGFloat(progress))
+                    .stroke(Color.listenUpOrange, style: StrokeStyle(lineWidth: 3, lineCap: .round))
+                    .frame(width: 28, height: 28)
+                    .rotationEffect(.degrees(-90))
+                Image(systemName: "xmark")
+                    .font(.system(size: 9, weight: .bold))
+                    .foregroundStyle(.secondary)
+            }
+
+        case "completed":
+            Group {
+                if showTrash {
+                    Image(systemName: "trash")
+                        .font(.title3)
+                        .foregroundStyle(.secondary)
+                        .transition(.scale.combined(with: .opacity))
+                } else {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.title3)
+                        .foregroundStyle(.green)
+                        .transition(.scale.combined(with: .opacity))
+                }
+            }
+            .animation(.easeInOut(duration: 0.3), value: showTrash)
+
+        case "partial", "failed":
+            Image(systemName: "arrow.clockwise.circle")
+                .font(.title3)
+                .foregroundStyle(.red)
+
+        default:
+            Image(systemName: "arrow.down.circle")
+                .font(.title3)
+                .foregroundStyle(Color.listenUpOrange)
+        }
+    }
+}
+
+/// Expanded download button with label for wider layouts.
+struct DownloadButtonExpanded: View {
+    let state: String
+    let progress: Float
+    let onDownload: () -> Void
+    let onCancel: () -> Void
+    let onDelete: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 8) {
+                iconView
+                labelText
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 12)
+            .background {
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(.regularMaterial)
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 12, style: .continuous)
+                            .strokeBorder(
+                                LinearGradient(
+                                    colors: [.white.opacity(0.3), .white.opacity(0.1)],
+                                    startPoint: .topLeading,
+                                    endPoint: .bottomTrailing
+                                ),
+                                lineWidth: 0.5
+                            )
+                    }
+                    .shadow(color: .black.opacity(0.08), radius: 4, x: 0, y: 2)
+            }
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var action: () -> Void {
+        switch state {
+        case "queued", "downloading": return onCancel
+        case "completed": return onDelete
+        default: return onDownload
+        }
+    }
+
+    @ViewBuilder
+    private var iconView: some View {
+        switch state {
+        case "notDownloaded":
+            Image(systemName: "arrow.down.circle")
+                .foregroundStyle(Color.listenUpOrange)
+        case "queued":
+            ProgressView()
+                .scaleEffect(0.7)
+        case "downloading":
+            ZStack {
+                Circle()
+                    .trim(from: 0, to: CGFloat(progress))
+                    .stroke(Color.listenUpOrange, style: StrokeStyle(lineWidth: 2, lineCap: .round))
+                    .frame(width: 18, height: 18)
+                    .rotationEffect(.degrees(-90))
+            }
+        case "completed":
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundStyle(.green)
+        case "partial", "failed":
+            Image(systemName: "arrow.clockwise.circle")
+                .foregroundStyle(.red)
+        default:
+            Image(systemName: "arrow.down.circle")
+                .foregroundStyle(Color.listenUpOrange)
+        }
+    }
+
+    @ViewBuilder
+    private var labelText: some View {
+        switch state {
+        case "notDownloaded":
+            Text(String(localized: "book_detail.download"))
+                .foregroundStyle(.primary)
+        case "queued":
+            Text(String(localized: "book_detail.queued"))
+                .foregroundStyle(.secondary)
+        case "downloading":
+            Text("\(Int(progress * 100))%")
+                .foregroundStyle(.secondary)
+                .monospacedDigit()
+        case "completed":
+            Text(String(localized: "book_detail.downloaded"))
+                .foregroundStyle(.primary)
+        case "partial", "failed":
+            Text(String(localized: "common.retry"))
+                .foregroundStyle(.red)
+        default:
+            Text(String(localized: "book_detail.download"))
+                .foregroundStyle(.primary)
+        }
+    }
+}
+
+#Preview("Download States") {
+    VStack(spacing: 20) {
+        HStack(spacing: 16) {
+            DownloadButton(state: "notDownloaded", progress: 0, onDownload: {}, onCancel: {}, onDelete: {})
+            DownloadButton(state: "queued", progress: 0, onDownload: {}, onCancel: {}, onDelete: {})
+            DownloadButton(state: "downloading", progress: 0.65, onDownload: {}, onCancel: {}, onDelete: {})
+            DownloadButton(state: "completed", progress: 1, onDownload: {}, onCancel: {}, onDelete: {})
+            DownloadButton(state: "failed", progress: 0.3, onDownload: {}, onCancel: {}, onDelete: {})
+        }
+
+        DownloadButtonExpanded(state: "notDownloaded", progress: 0, onDownload: {}, onCancel: {}, onDelete: {})
+            .padding(.horizontal)
+        DownloadButtonExpanded(state: "downloading", progress: 0.65, onDownload: {}, onCancel: {}, onDelete: {})
+            .padding(.horizontal)
+        DownloadButtonExpanded(state: "completed", progress: 1, onDownload: {}, onCancel: {}, onDelete: {})
+            .padding(.horizontal)
+    }
+    .padding()
+}

--- a/iosApp/iosApp/DesignSystem/Components/DownloadButton.swift
+++ b/iosApp/iosApp/DesignSystem/Components/DownloadButton.swift
@@ -11,7 +11,7 @@ import SwiftUI
 ///
 /// Liquid Glass: Uses `.regularMaterial` background with gradient stroke.
 struct DownloadButton: View {
-    let state: String // notDownloaded, queued, downloading, completed, partial, failed
+    let state: DownloadUIState
     let progress: Float
     let onDownload: () -> Void
     let onCancel: () -> Void
@@ -48,7 +48,7 @@ struct DownloadButton: View {
         }
         .buttonStyle(.plain)
         .onChange(of: state) { oldValue, newValue in
-            if newValue == "completed" && oldValue != "completed" {
+            if newValue == .completed && oldValue != .completed {
                 showTrash = false
                 withAnimation(.easeInOut.delay(2.0)) {
                     showTrash = true
@@ -59,7 +59,7 @@ struct DownloadButton: View {
         }
         .onAppear {
             // If already completed on appear, show trash immediately
-            if state == "completed" {
+            if state == .completed {
                 showTrash = true
             }
         }
@@ -67,9 +67,9 @@ struct DownloadButton: View {
 
     private var action: () -> Void {
         switch state {
-        case "queued", "downloading":
+        case .queued, "downloading":
             return onCancel
-        case "completed":
+        case .completed:
             return onDelete
         default:
             return onDownload
@@ -79,16 +79,16 @@ struct DownloadButton: View {
     @ViewBuilder
     private var iconView: some View {
         switch state {
-        case "notDownloaded":
+        case .notDownloaded:
             Image(systemName: "arrow.down.circle")
                 .font(.title3)
                 .foregroundStyle(Color.listenUpOrange)
 
-        case "queued":
+        case .queued:
             ProgressView()
                 .scaleEffect(0.8)
 
-        case "downloading":
+        case .downloading:
             ZStack {
                 Circle()
                     .stroke(Color.listenUpOrange.opacity(0.3), lineWidth: 3)
@@ -103,7 +103,7 @@ struct DownloadButton: View {
                     .foregroundStyle(.secondary)
             }
 
-        case "completed":
+        case .completed:
             Group {
                 if showTrash {
                     Image(systemName: "trash")
@@ -119,7 +119,7 @@ struct DownloadButton: View {
             }
             .animation(.easeInOut(duration: 0.3), value: showTrash)
 
-        case "partial", "failed":
+        case .partial, .failed:
             Image(systemName: "arrow.clockwise.circle")
                 .font(.title3)
                 .foregroundStyle(.red)
@@ -134,7 +134,7 @@ struct DownloadButton: View {
 
 /// Expanded download button with label for wider layouts.
 struct DownloadButtonExpanded: View {
-    let state: String
+    let state: DownloadUIState
     let progress: Float
     let onDownload: () -> Void
     let onCancel: () -> Void
@@ -170,8 +170,8 @@ struct DownloadButtonExpanded: View {
 
     private var action: () -> Void {
         switch state {
-        case "queued", "downloading": return onCancel
-        case "completed": return onDelete
+        case .queued, "downloading": return onCancel
+        case .completed: return onDelete
         default: return onDownload
         }
     }
@@ -179,13 +179,13 @@ struct DownloadButtonExpanded: View {
     @ViewBuilder
     private var iconView: some View {
         switch state {
-        case "notDownloaded":
+        case .notDownloaded:
             Image(systemName: "arrow.down.circle")
                 .foregroundStyle(Color.listenUpOrange)
-        case "queued":
+        case .queued:
             ProgressView()
                 .scaleEffect(0.7)
-        case "downloading":
+        case .downloading:
             ZStack {
                 Circle()
                     .trim(from: 0, to: CGFloat(progress))
@@ -193,10 +193,10 @@ struct DownloadButtonExpanded: View {
                     .frame(width: 18, height: 18)
                     .rotationEffect(.degrees(-90))
             }
-        case "completed":
+        case .completed:
             Image(systemName: "checkmark.circle.fill")
                 .foregroundStyle(.green)
-        case "partial", "failed":
+        case .partial, .failed:
             Image(systemName: "arrow.clockwise.circle")
                 .foregroundStyle(.red)
         default:
@@ -208,20 +208,20 @@ struct DownloadButtonExpanded: View {
     @ViewBuilder
     private var labelText: some View {
         switch state {
-        case "notDownloaded":
+        case .notDownloaded:
             Text(String(localized: "book_detail.download"))
                 .foregroundStyle(.primary)
-        case "queued":
+        case .queued:
             Text(String(localized: "book_detail.queued"))
                 .foregroundStyle(.secondary)
-        case "downloading":
+        case .downloading:
             Text("\(Int(progress * 100))%")
                 .foregroundStyle(.secondary)
                 .monospacedDigit()
-        case "completed":
+        case .completed:
             Text(String(localized: "book_detail.downloaded"))
                 .foregroundStyle(.primary)
-        case "partial", "failed":
+        case .partial, .failed:
             Text(String(localized: "common.retry"))
                 .foregroundStyle(.red)
         default:
@@ -234,18 +234,18 @@ struct DownloadButtonExpanded: View {
 #Preview("Download States") {
     VStack(spacing: 20) {
         HStack(spacing: 16) {
-            DownloadButton(state: "notDownloaded", progress: 0, onDownload: {}, onCancel: {}, onDelete: {})
-            DownloadButton(state: "queued", progress: 0, onDownload: {}, onCancel: {}, onDelete: {})
-            DownloadButton(state: "downloading", progress: 0.65, onDownload: {}, onCancel: {}, onDelete: {})
-            DownloadButton(state: "completed", progress: 1, onDownload: {}, onCancel: {}, onDelete: {})
-            DownloadButton(state: "failed", progress: 0.3, onDownload: {}, onCancel: {}, onDelete: {})
+            DownloadButton(state: .notDownloaded, progress: 0, onDownload: {}, onCancel: {}, onDelete: {})
+            DownloadButton(state: .queued, progress: 0, onDownload: {}, onCancel: {}, onDelete: {})
+            DownloadButton(state: .downloading, progress: 0.65, onDownload: {}, onCancel: {}, onDelete: {})
+            DownloadButton(state: .completed, progress: 1, onDownload: {}, onCancel: {}, onDelete: {})
+            DownloadButton(state: .failed, progress: 0.3, onDownload: {}, onCancel: {}, onDelete: {})
         }
 
-        DownloadButtonExpanded(state: "notDownloaded", progress: 0, onDownload: {}, onCancel: {}, onDelete: {})
+        DownloadButtonExpanded(state: .notDownloaded, progress: 0, onDownload: {}, onCancel: {}, onDelete: {})
             .padding(.horizontal)
-        DownloadButtonExpanded(state: "downloading", progress: 0.65, onDownload: {}, onCancel: {}, onDelete: {})
+        DownloadButtonExpanded(state: .downloading, progress: 0.65, onDownload: {}, onCancel: {}, onDelete: {})
             .padding(.horizontal)
-        DownloadButtonExpanded(state: "completed", progress: 1, onDownload: {}, onCancel: {}, onDelete: {})
+        DownloadButtonExpanded(state: .completed, progress: 1, onDownload: {}, onCancel: {}, onDelete: {})
             .padding(.horizontal)
     }
     .padding()

--- a/iosApp/iosApp/Features/BookDetail/BookDetailObserver.swift
+++ b/iosApp/iosApp/Features/BookDetail/BookDetailObserver.swift
@@ -118,7 +118,6 @@ final class BookDetailObserver {
     }
 
     /// Call this to stop observation when done.
-    deinit { stopObserving() }
 
     func stopObserving() {
         observationTask?.cancel()
@@ -142,9 +141,13 @@ final class BookDetailObserver {
         guard let book else { return }
         downloadError = nil
         Task {
-            let result = await downloadService.downloadBook(bookId: book.id)
-            if let error = result as? DownloadResultError {
-                self.downloadError = error.message
+            do {
+                let result = try await downloadService.downloadBook(bookId: book.id)
+                if let error = result as? DownloadResultError {
+                    self.downloadError = error.message
+                }
+            } catch {
+                self.downloadError = error.localizedDescription
             }
         }
     }
@@ -152,14 +155,14 @@ final class BookDetailObserver {
     func cancelDownload() {
         guard let book else { return }
         Task {
-            await downloadService.cancelDownload(bookId: book.id)
+            try? await downloadService.cancelDownload(bookId: book.id)
         }
     }
 
     func deleteDownload() {
         guard let book else { return }
         Task {
-            await downloadService.deleteDownload(bookId: book.id)
+            try? await downloadService.deleteDownload(bookId: book.id)
         }
     }
 

--- a/iosApp/iosApp/Features/BookDetail/BookDetailView.swift
+++ b/iosApp/iosApp/Features/BookDetail/BookDetailView.swift
@@ -50,7 +50,7 @@ struct BookDetailView: View {
         .onAppear {
             if observer == nil {
                 let vm = deps.createBookDetailViewModel()
-                observer = BookDetailObserver(viewModel: vm, playbackManager: deps.playbackManager, audioPlayer: deps.audioPlayer)
+                observer = BookDetailObserver(viewModel: vm, playbackManager: deps.playbackManager, audioPlayer: deps.audioPlayer, downloadService: deps.downloadService)
                 observer?.loadBook(bookId: bookId)
             }
         }
@@ -191,12 +191,15 @@ struct BookDetailView: View {
             }
             .buttonStyle(.borderedProminent)
 
-            Button(action: {}) {
-                Image(systemName: "square.and.arrow.down")
-                    .font(.title2)
-                    .padding(14)
+            if let observer {
+                DownloadButton(
+                    state: observer.downloadState,
+                    progress: observer.downloadProgress,
+                    onDownload: { observer.downloadBook() },
+                    onCancel: { observer.cancelDownload() },
+                    onDelete: { observer.deleteDownload() }
+                )
             }
-            .buttonStyle(.bordered)
         }
     }
 
@@ -245,16 +248,18 @@ struct BookDetailView: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
-            // Make contributors tappable
-            HStack(spacing: 0) {
+            // Wrapping layout with tappable contributor names
+            FlowLayout(spacing: 0) {
                 ForEach(Array(contributors.enumerated()), id: \.element.id) { index, contributor in
-                    if index > 0 {
-                        Text(", ")
-                            .foregroundStyle(Color.listenUpOrange)
-                    }
-                    NavigationLink(value: ContributorDestination(id: contributor.id)) {
-                        Text(contributor.name)
-                            .foregroundStyle(Color.listenUpOrange)
+                    HStack(spacing: 0) {
+                        if index > 0 {
+                            Text(", ")
+                                .foregroundStyle(Color.listenUpOrange)
+                        }
+                        NavigationLink(value: ContributorDestination(id: contributor.id)) {
+                            Text(contributor.name)
+                                .foregroundStyle(Color.listenUpOrange)
+                        }
                     }
                 }
             }

--- a/shared/src/appleMain/kotlin/com/calypsan/listenup/client/core/AppleSecureStorage.kt
+++ b/shared/src/appleMain/kotlin/com/calypsan/listenup/client/core/AppleSecureStorage.kt
@@ -4,6 +4,8 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlin.time.TimeSource
 import kotlinx.cinterop.BetaInteropApi
 import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.usePinned
 import kotlinx.cinterop.alloc
 import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.ptr
@@ -24,7 +26,8 @@ import platform.Foundation.NSData
 import platform.Foundation.NSString
 import platform.Foundation.NSUTF8StringEncoding
 import platform.Foundation.create
-import platform.Foundation.dataUsingEncoding
+import platform.posix.memcpy
+import platform.Foundation.create
 import platform.Security.SecItemAdd
 import platform.Security.SecItemCopyMatching
 import platform.Security.SecItemDelete
@@ -63,9 +66,8 @@ internal class AppleSecureStorage : SecureStorage {
         logger.debug { "Keychain save started: $key" }
         val startMark = TimeSource.Monotonic.markNow()
 
-        val data =
-            (value as NSString).dataUsingEncoding(NSUTF8StringEncoding)
-                ?: throw IllegalArgumentException("Failed to encode value to UTF-8")
+        val bytes = value.encodeToByteArray()
+        val data = bytes.toNSData()
 
         // Delete existing item first
         val deleteQuery =
@@ -188,3 +190,12 @@ internal class AppleSecureStorage : SecureStorage {
 class SecurityException(
     message: String,
 ) : Exception(message)
+
+
+@OptIn(ExperimentalForeignApi::class)
+private fun ByteArray.toNSData(): NSData {
+    if (isEmpty()) return NSData()
+    return usePinned { pinned ->
+        NSData.create(bytes = pinned.addressOf(0), length = size.toULong())
+    }
+}

--- a/shared/src/appleMain/kotlin/com/calypsan/listenup/client/core/AppleSecureStorage.kt
+++ b/shared/src/appleMain/kotlin/com/calypsan/listenup/client/core/AppleSecureStorage.kt
@@ -191,7 +191,6 @@ class SecurityException(
     message: String,
 ) : Exception(message)
 
-
 @OptIn(ExperimentalForeignApi::class)
 private fun ByteArray.toNSData(): NSData {
     if (isEmpty()) return NSData()

--- a/shared/src/appleMain/kotlin/com/calypsan/listenup/client/data/discovery/AppleDiscoveryService.kt
+++ b/shared/src/appleMain/kotlin/com/calypsan/listenup/client/data/discovery/AppleDiscoveryService.kt
@@ -166,7 +166,7 @@ class AppleDiscoveryService : ServerDiscoveryService {
         val result = mutableMapOf<String, String>()
         try {
             val dictionary = NSNetService.dictionaryFromTXTRecordData(data)
-            dictionary?.forEach { (key, value) ->
+            dictionary.forEach { (key, value) ->
                 if (key is String && value is NSData) {
                     val string = NSString.create(value, NSUTF8StringEncoding)
                     if (string != null) {

--- a/shared/src/appleMain/kotlin/com/calypsan/listenup/client/download/AppleDownloadService.kt
+++ b/shared/src/appleMain/kotlin/com/calypsan/listenup/client/download/AppleDownloadService.kt
@@ -174,11 +174,14 @@ class AppleDownloadService(
         // Download files concurrently in background
         for (file in toDownload) {
             scope.launch {
+                // Refresh token per file to avoid 401 on long-running batches
+                tokenProvider.prepareForPlayback()
+                val fileToken = tokenProvider.getToken() ?: token
                 downloadFile(
                     bookId = bookId.value,
                     audioFile = file,
                     serverUrl = serverUrl,
-                    token = token,
+                    token = fileToken,
                 )
             }
         }

--- a/shared/src/appleMain/kotlin/com/calypsan/listenup/client/download/AppleDownloadService.kt
+++ b/shared/src/appleMain/kotlin/com/calypsan/listenup/client/download/AppleDownloadService.kt
@@ -332,6 +332,7 @@ private class DownloadSessionDelegate(
             lock.unlock()
         }
     }
+
     private val pendingDownloads = mutableMapOf<ULong, PendingDownload>()
     private val lastLoggedPct = mutableMapOf<ULong, Int>()
 
@@ -350,7 +351,6 @@ private class DownloadSessionDelegate(
             lastLoggedPct.remove(taskId)
             pendingDownloads.remove(taskId)
         }
-    }
 
     private fun safeResume(
         continuation: CancellableContinuation<Boolean>,

--- a/shared/src/appleMain/kotlin/com/calypsan/listenup/client/download/AppleDownloadService.kt
+++ b/shared/src/appleMain/kotlin/com/calypsan/listenup/client/download/AppleDownloadService.kt
@@ -8,27 +8,37 @@ import com.calypsan.listenup.client.data.local.db.BookDao
 import com.calypsan.listenup.client.data.local.db.DownloadDao
 import com.calypsan.listenup.client.data.local.db.DownloadEntity
 import com.calypsan.listenup.client.data.local.db.DownloadState
+import com.calypsan.listenup.client.domain.model.BookDownloadState
+import com.calypsan.listenup.client.domain.model.BookDownloadStatus
 import com.calypsan.listenup.client.data.remote.model.AudioFileResponse
 import com.calypsan.listenup.client.domain.repository.ServerConfig
 import com.calypsan.listenup.client.playback.AudioTokenProvider
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
-import platform.Foundation.NSData
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import platform.Foundation.NSError
+import platform.Foundation.NSFileManager
 import platform.Foundation.NSHTTPURLResponse
 import platform.Foundation.NSMutableURLRequest
 import platform.Foundation.NSURL
 import platform.Foundation.NSURLSession
-import platform.Foundation.NSURLSessionDataTask
-import platform.Foundation.dataTaskWithRequest
+import platform.Foundation.NSURLSessionConfiguration
+import platform.Foundation.NSURLSessionDownloadDelegateProtocol
+import platform.Foundation.NSURLSessionDownloadTask
+import platform.Foundation.NSURLSessionTask
 import platform.Foundation.setValue
-import platform.Foundation.writeToFile
+import platform.darwin.NSObject
 import kotlin.coroutines.resume
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
@@ -38,11 +48,9 @@ private val logger = KotlinLogging.logger {}
 /**
  * iOS implementation of DownloadService.
  *
- * Uses URLSession for downloads with token-based authentication.
- * Downloads are performed in-app (not background URLSession yet).
- *
- * Future enhancement: Background URLSession with NSURLSessionDownloadTask
- * for downloads that continue when app is backgrounded.
+ * Uses NSURLSession with download tasks that stream directly to disk.
+ * Each file download is a single coroutine that suspends until complete.
+ * Progress is tracked via delegate callbacks and written to the database.
  */
 @OptIn(ExperimentalTime::class)
 class AppleDownloadService(
@@ -54,141 +62,124 @@ class AppleDownloadService(
     private val scope: CoroutineScope,
 ) : DownloadService {
     private val json = Json { ignoreUnknownKeys = true }
-    private val urlSession = NSURLSession.sharedSession
 
     /**
-     * Get local file path for an audio file (if downloaded).
-     * Returns null if not downloaded or file missing.
+     * Delegate handles download progress and completion.
+     * Must be held as a strong reference (ObjC weak delegate pattern).
      */
+    private val sessionDelegate = DownloadSessionDelegate(downloadDao, scope)
+
+    private val urlSession: NSURLSession = run {
+        val config = NSURLSessionConfiguration.defaultSessionConfiguration
+        config.timeoutIntervalForRequest = 60.0
+        config.timeoutIntervalForResource = 3600.0 // 1 hour for large files
+        NSURLSession.sessionWithConfiguration(
+            configuration = config,
+            delegate = sessionDelegate,
+            delegateQueue = null,
+        )
+    }
+
     override suspend fun getLocalPath(audioFileId: String): String? {
         val path = downloadDao.getLocalPath(audioFileId) ?: return null
-
-        // Verify file still exists
         if (fileManager.fileExists(path)) return path
-
-        // File was deleted externally - clean up database
         logger.warn { "Downloaded file missing, cleaning up: $audioFileId" }
         downloadDao.updateError(audioFileId, "File missing - deleted externally")
         return null
     }
 
-    /**
-     * Check if user explicitly deleted downloads for this book.
-     */
-    override suspend fun wasExplicitlyDeleted(bookId: BookId): Boolean = downloadDao.hasDeletedRecords(bookId.value)
+    override suspend fun wasExplicitlyDeleted(bookId: BookId): Boolean =
+        downloadDao.hasDeletedRecords(bookId.value)
 
-    /**
-     * Download a book's audio files.
-     *
-     * Downloads files sequentially using URLSession.
-     * Progress is tracked in the database.
-     */
     @Suppress("ReturnCount")
     override suspend fun downloadBook(bookId: BookId): DownloadResult {
-        // Check if already downloaded
         val existing = downloadDao.getForBook(bookId.value)
         if (existing.isNotEmpty() && existing.all { it.state == DownloadState.COMPLETED }) {
-            logger.info { "Book ${bookId.value} already downloaded" }
             return DownloadResult.AlreadyDownloaded
         }
 
-        // Get book entity
-        val bookEntity =
-            bookDao.getById(bookId) ?: run {
-                logger.error { "Book not found: ${bookId.value}" }
-                return DownloadResult.Error("Book not found")
-            }
+        val bookEntity = bookDao.getById(bookId) ?: run {
+            logger.error { "Book not found: ${bookId.value}" }
+            return DownloadResult.Error("Book not found")
+        }
 
-        // Parse audio files
         val audioFilesJson = bookEntity.audioFilesJson
         if (audioFilesJson.isNullOrBlank()) {
-            logger.warn { "No audio files JSON for book ${bookId.value}" }
             return DownloadResult.Error("No audio files available")
         }
 
-        val audioFiles: List<AudioFileResponse> =
-            try {
-                json.decodeFromString(audioFilesJson)
-            } catch (e: Exception) {
-                logger.error(e) { "Failed to parse audio files JSON" }
-                return DownloadResult.Error("Failed to parse audio files")
-            }
+        val audioFiles: List<AudioFileResponse> = try {
+            json.decodeFromString(audioFilesJson)
+        } catch (e: Exception) {
+            logger.error(e) { "Failed to parse audio files JSON" }
+            return DownloadResult.Error("Failed to parse audio files")
+        }
 
         if (audioFiles.isEmpty()) {
             return DownloadResult.Error("No audio files available")
         }
 
-        // Filter out already completed
-        val completedIds =
-            existing
-                .filter { it.state == DownloadState.COMPLETED }
-                .map { it.audioFileId }
-                .toSet()
+        // Skip files already completed, downloading, or queued
+        val activeIds = existing
+            .filter { it.state in listOf(DownloadState.COMPLETED, DownloadState.DOWNLOADING, DownloadState.QUEUED) }
+            .map { it.audioFileId }
+            .toSet()
 
-        val toDownload = audioFiles.filterNot { it.id in completedIds }
+        val toDownload = audioFiles.filterNot { it.id in activeIds }
+
+        if (toDownload.isEmpty()) {
+            logger.info { "All files already downloading or completed for ${bookId.value}" }
+            return DownloadResult.AlreadyDownloaded
+        }
 
         // Check storage
         val requiredBytes = toDownload.sumOf { it.size }
         val availableBytes = fileManager.getAvailableSpace()
-        val requiredWithBuffer = (requiredBytes * 1.1).toLong()
-
-        if (availableBytes < requiredWithBuffer) {
-            logger.warn {
-                "Insufficient storage: need ${requiredBytes / 1_000_000}MB, have ${availableBytes / 1_000_000}MB"
-            }
+        if (availableBytes < (requiredBytes * 1.1).toLong()) {
             return DownloadResult.InsufficientStorage(requiredBytes, availableBytes)
         }
 
-        // Get server URL and token
-        val serverUrl =
-            serverConfig.getServerUrl()?.value ?: run {
-                logger.error { "No server URL configured" }
-                return DownloadResult.Error("No server configured")
-            }
+        // Ensure fresh token
+        tokenProvider.prepareForPlayback()
+        val token = tokenProvider.getToken() ?: run {
+            logger.error { "No auth token available" }
+            return DownloadResult.Error("Not authenticated")
+        }
 
-        val token =
-            tokenProvider.getToken() ?: run {
-                logger.error { "No auth token available" }
-                return DownloadResult.Error("Not authenticated")
-            }
+        val serverUrl = serverConfig.getServerUrl()?.value ?: run {
+            return DownloadResult.Error("No server configured")
+        }
 
         // Create download entries
         val now = Clock.System.now().toEpochMilliseconds()
-        val entities =
-            toDownload.mapIndexed { _, file ->
-                DownloadEntity(
-                    audioFileId = file.id,
-                    bookId = bookId.value,
-                    filename = file.filename,
-                    fileIndex = audioFiles.indexOfFirst { it.id == file.id },
-                    state = DownloadState.QUEUED,
-                    localPath = null,
-                    totalBytes = file.size,
-                    downloadedBytes = 0,
-                    queuedAt = now,
-                    startedAt = null,
-                    completedAt = null,
-                    errorMessage = null,
-                    retryCount = 0,
-                )
-            }
-
+        val entities = toDownload.map { file ->
+            DownloadEntity(
+                audioFileId = file.id,
+                bookId = bookId.value,
+                filename = file.filename,
+                fileIndex = audioFiles.indexOfFirst { it.id == file.id },
+                state = DownloadState.QUEUED,
+                localPath = null,
+                totalBytes = file.size,
+                downloadedBytes = 0,
+                queuedAt = now,
+                startedAt = null,
+                completedAt = null,
+                errorMessage = null,
+                retryCount = 0,
+            )
+        }
         downloadDao.insertAll(entities)
 
-        // Start downloads in background
-        scope.launch {
-            for (file in toDownload) {
-                try {
-                    downloadFile(
-                        bookId = bookId.value,
-                        audioFile = file,
-                        serverUrl = serverUrl,
-                        token = token,
-                    )
-                } catch (e: Exception) {
-                    logger.error(e) { "Failed to download file: ${file.id}" }
-                    downloadDao.updateError(file.id, e.message ?: "Download failed")
-                }
+        // Download files concurrently in background
+        for (file in toDownload) {
+            scope.launch {
+                downloadFile(
+                    bookId = bookId.value,
+                    audioFile = file,
+                    serverUrl = serverUrl,
+                    token = token,
+                )
             }
         }
 
@@ -196,6 +187,10 @@ class AppleDownloadService(
         return DownloadResult.Success
     }
 
+    /**
+     * Download a single file using NSURLSession download task.
+     * Suspends until the download completes or fails.
+     */
     private suspend fun downloadFile(
         bookId: String,
         audioFile: AudioFileResponse,
@@ -205,57 +200,56 @@ class AppleDownloadService(
         val audioFileId = audioFile.id
         val filename = audioFile.filename
 
-        // Update state to downloading
-        downloadDao.updateState(
-            audioFileId,
-            DownloadState.DOWNLOADING,
-            Clock.System.now().toEpochMilliseconds(),
-        )
+        downloadDao.updateState(audioFileId, DownloadState.DOWNLOADING, Clock.System.now().toEpochMilliseconds())
 
-        // Build URL
-        val url = "$serverUrl/api/stream/$audioFileId"
-        val nsUrl = NSURL.URLWithString(url) ?: error("Invalid URL: $url")
-
-        // Create request with auth header
-        val request =
-            NSMutableURLRequest.requestWithURL(nsUrl).apply {
-                setValue("Bearer $token", forHTTPHeaderField = "Authorization")
-            }
-
-        // Download using URLSession
-        val data = downloadData(request)
-
-        if (data == null) {
-            downloadDao.updateError(audioFileId, "Download returned no data")
+        // Build URL — use Authorization header (in-process session supports headers)
+        val url = "$serverUrl/api/v1/books/$bookId/audio/$audioFileId"
+        val nsUrl = NSURL.URLWithString(url) ?: run {
+            downloadDao.updateError(audioFileId, "Invalid URL")
             return@withContext
         }
 
-        // Write to file
-        val destPath = fileManager.getDownloadPath(bookId, audioFileId, filename)
-        val success = data.writeToFile(destPath.toString(), atomically = true)
+        val request = NSMutableURLRequest.requestWithURL(nsUrl)
+        request.setValue("Bearer $token", forHTTPHeaderField = "Authorization")
 
-        if (success) {
-            downloadDao.markCompleted(
-                audioFileId,
-                destPath.toString(),
-                Clock.System.now().toEpochMilliseconds(),
-            )
-            logger.info { "Downloaded: $filename" }
+        logger.info { "Downloading: $filename (${audioFile.size / 1_000_000}MB)" }
+
+        // Register this download so delegate can track it
+        val destPath = fileManager.getDownloadPath(bookId, audioFileId, filename)
+
+        // Ensure parent directory exists
+        val destUrl = NSURL.fileURLWithPath(destPath.toString())
+        NSFileManager.defaultManager.createDirectoryAtURL(
+            destUrl.URLByDeletingLastPathComponent!!,
+            withIntermediateDirectories = true,
+            attributes = null,
+            error = null,
+        )
+
+        // Suspend until download completes
+        val result = suspendCancellableCoroutine { continuation ->
+            val task = urlSession.downloadTaskWithRequest(request)
+            // Store metadata for delegate
+            task.taskDescription = "$bookId|$audioFileId|$filename|${destPath}"
+
+            // Register continuation so delegate can resume it
+            sessionDelegate.registerDownload(task.taskIdentifier, continuation, destPath.toString())
+
+            continuation.invokeOnCancellation { task.cancel() }
+            task.resume()
+        }
+
+        if (result) {
+            downloadDao.markCompleted(audioFileId, destPath.toString(), Clock.System.now().toEpochMilliseconds())
+            logger.info { "Downloaded: $filename (${audioFile.size / 1_000_000}MB)" }
         } else {
-            downloadDao.updateError(audioFileId, "Failed to write file")
-            logger.error { "Failed to write file: $filename" }
+            // Error already logged/stored by delegate
+            logger.error { "Download failed: $filename" }
         }
     }
 
-    /**
-     * Cancel active download for a book.
-     *
-     * Currently iOS downloads run in-app, so cancellation
-     * is handled by coroutine cancellation.
-     */
     override suspend fun cancelDownload(bookId: BookId) {
         logger.info { "Cancelling download for book: ${bookId.value}" }
-        // Mark any in-progress downloads as failed
         val downloads = downloadDao.getForBook(bookId.value)
         for (download in downloads) {
             if (download.state == DownloadState.DOWNLOADING || download.state == DownloadState.QUEUED) {
@@ -264,43 +258,170 @@ class AppleDownloadService(
         }
     }
 
-    /**
-     * Delete downloaded files for a book.
-     */
     override suspend fun deleteDownload(bookId: BookId) {
         logger.info { "Deleting downloads for book: ${bookId.value}" }
-
-        // Delete all files for this book
         fileManager.deleteBookFiles(bookId.value)
-
-        // Mark as deleted in database
         downloadDao.markDeletedForBook(bookId.value)
     }
 
-    private suspend fun downloadData(request: NSMutableURLRequest): NSData? =
-        suspendCancellableCoroutine { continuation ->
-            val task: NSURLSessionDataTask =
-                urlSession.dataTaskWithRequest(request) { data, response, error ->
-                    if (error != null) {
-                        logger.error { "Download error: ${error.localizedDescription}" }
-                        continuation.resume(null)
-                        return@dataTaskWithRequest
-                    }
+    override fun observeBookStatus(bookId: BookId): Flow<BookDownloadStatus> {
+        return downloadDao.observeForBook(bookId.value).map { entities ->
+            if (entities.isEmpty()) {
+                BookDownloadStatus.notDownloaded(bookId.value)
+            } else {
+                val totalFiles = entities.size
+                val completedFiles = entities.count { it.state == DownloadState.COMPLETED }
+                val totalBytes = entities.sumOf { it.totalBytes }
+                val downloadedBytes = entities.sumOf { it.downloadedBytes }
 
-                    val httpResponse = response as? NSHTTPURLResponse
-                    if (httpResponse != null && httpResponse.statusCode !in 200..299) {
-                        logger.error { "HTTP error: ${httpResponse.statusCode}" }
-                        continuation.resume(null)
-                        return@dataTaskWithRequest
-                    }
-
-                    continuation.resume(data)
+                val state = when {
+                    entities.all { it.state == DownloadState.COMPLETED } -> BookDownloadState.COMPLETED
+                    entities.any { it.state == DownloadState.DOWNLOADING } -> BookDownloadState.DOWNLOADING
+                    entities.any { it.state == DownloadState.QUEUED } -> BookDownloadState.QUEUED
+                    entities.any { it.state == DownloadState.FAILED } -> BookDownloadState.FAILED
+                    entities.any { it.state == DownloadState.COMPLETED } -> BookDownloadState.PARTIAL
+                    else -> BookDownloadState.NOT_DOWNLOADED
                 }
 
-            continuation.invokeOnCancellation {
-                task.cancel()
+                BookDownloadStatus(
+                    bookId = bookId.value,
+                    state = state,
+                    totalFiles = totalFiles,
+                    completedFiles = completedFiles,
+                    totalBytes = totalBytes,
+                    downloadedBytes = downloadedBytes,
+                )
             }
-
-            task.resume()
         }
+    }
+}
+
+/**
+ * NSURLSession delegate for download tasks.
+ *
+ * Handles progress updates and completion. Each download task has a registered
+ * continuation that is resumed when the task finishes.
+ */
+private class DownloadSessionDelegate(
+    private val downloadDao: DownloadDao,
+    private val scope: CoroutineScope,
+) : NSObject(), NSURLSessionDownloadDelegateProtocol {
+
+    private data class PendingDownload(
+        val continuation: CancellableContinuation<Boolean>,
+        val destPath: String,
+    )
+
+    /** Lock protecting pendingDownloads and lastLoggedPct (accessed from coroutines + delegate queue) */
+    private val lock = Any()
+    private val pendingDownloads = mutableMapOf<ULong, PendingDownload>()
+    private val lastLoggedPct = mutableMapOf<ULong, Int>()
+
+    fun registerDownload(taskId: ULong, continuation: CancellableContinuation<Boolean>, destPath: String) {
+        synchronized(lock) {
+            pendingDownloads[taskId] = PendingDownload(continuation, destPath)
+        }
+    }
+
+    private fun removePending(taskId: ULong): PendingDownload? {
+        synchronized(lock) {
+            lastLoggedPct.remove(taskId)
+            return pendingDownloads.remove(taskId)
+        }
+    }
+
+    private fun safeResume(continuation: CancellableContinuation<Boolean>, value: Boolean) {
+        if (continuation.isActive) {
+            continuation.resume(value)
+        }
+    }
+
+    override fun URLSession(
+        session: NSURLSession,
+        downloadTask: NSURLSessionDownloadTask,
+        didFinishDownloadingToURL: NSURL,
+    ) {
+        val taskId = downloadTask.taskIdentifier
+        val pending = synchronized(lock) { pendingDownloads[taskId] } ?: return
+        val parts = downloadTask.taskDescription?.split("|") ?: return
+        val audioFileId = parts.getOrNull(1) ?: return
+        val filename = parts.getOrNull(2) ?: "unknown"
+
+        // Check HTTP status
+        val httpResponse = downloadTask.response as? NSHTTPURLResponse
+        val statusCode = httpResponse?.statusCode ?: 0
+        if (statusCode !in 200L..299L && statusCode != 0L) {
+            logger.error { "Download HTTP $statusCode for $filename" }
+            scope.launch { downloadDao.updateError(audioFileId, "HTTP error: $statusCode") }
+            removePending(taskId)?.let { safeResume(it.continuation, false) }
+            return
+        }
+
+        // Move temp file to destination (iOS deletes temp after this callback)
+        val destUrl = NSURL.fileURLWithPath(pending.destPath)
+        NSFileManager.defaultManager.removeItemAtURL(destUrl, error = null)
+        val moved = NSFileManager.defaultManager.moveItemAtURL(didFinishDownloadingToURL, toURL = destUrl, error = null)
+
+        if (!moved) {
+            logger.error { "Failed to move downloaded file: $filename" }
+            scope.launch { downloadDao.updateError(audioFileId, "Failed to save file") }
+            removePending(taskId)?.let { safeResume(it.continuation, false) }
+            return
+        }
+
+        // Verify file size
+        val fileSize = NSFileManager.defaultManager.attributesOfItemAtPath(pending.destPath, error = null)
+            ?.get(platform.Foundation.NSFileSize) as? Long ?: 0L
+        if (fileSize == 0L) {
+            logger.error { "Downloaded file is empty: $filename" }
+            scope.launch { downloadDao.updateError(audioFileId, "Downloaded file is empty") }
+            removePending(taskId)?.let { safeResume(it.continuation, false) }
+            return
+        }
+
+        logger.info { "Download saved: $filename (${fileSize / 1_000_000}MB)" }
+        removePending(taskId)?.let { safeResume(it.continuation, true) }
+    }
+
+    override fun URLSession(
+        session: NSURLSession,
+        downloadTask: NSURLSessionDownloadTask,
+        didWriteData: Long,
+        totalBytesWritten: Long,
+        totalBytesExpectedToWrite: Long,
+    ) {
+        val parts = downloadTask.taskDescription?.split("|") ?: return
+        val audioFileId = parts.getOrNull(1) ?: return
+        val filename = parts.getOrNull(2) ?: "unknown"
+        val taskId = downloadTask.taskIdentifier
+
+        // Throttle DB writes — every 1%
+        if (totalBytesExpectedToWrite > 0) {
+            val pct = (totalBytesWritten * 100 / totalBytesExpectedToWrite).toInt()
+            val lastPct = synchronized(lock) { lastLoggedPct[taskId] ?: -1 }
+            if (pct >= lastPct + 1) {
+                synchronized(lock) { lastLoggedPct[taskId] = pct }
+                scope.launch {
+                    downloadDao.updateProgress(audioFileId, totalBytesWritten, totalBytesExpectedToWrite)
+                }
+                logger.info { "Download $pct%: $filename (${totalBytesWritten / 1_000_000}/${totalBytesExpectedToWrite / 1_000_000}MB)" }
+            }
+        }
+    }
+
+    override fun URLSession(
+        session: NSURLSession,
+        task: NSURLSessionTask,
+        didCompleteWithError: NSError?,
+    ) {
+        if (didCompleteWithError == null) return
+        val taskId = task.taskIdentifier
+        val pending = removePending(taskId) ?: return
+        val parts = task.taskDescription?.split("|") ?: return
+        val audioFileId = parts.getOrNull(1) ?: return
+
+        logger.error { "Download error: ${didCompleteWithError.localizedDescription}" }
+        scope.launch { downloadDao.updateError(audioFileId, didCompleteWithError.localizedDescription) }
+        safeResume(pending.continuation, false)
+    }
 }

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/InstanceRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/InstanceRepositoryImpl.kt
@@ -146,7 +146,7 @@ class InstanceRepositoryImpl(
                 }
 
                 is Failure -> {
-                    val errorMessage = result.message.lowercase() ?: ""
+                    val errorMessage = result.message.lowercase()
                     val isSslError =
                         errorMessage.contains("ssl") ||
                             errorMessage.contains("tls") ||

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/download/DownloadService.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/download/DownloadService.kt
@@ -1,6 +1,8 @@
 package com.calypsan.listenup.client.download
 
 import com.calypsan.listenup.client.core.BookId
+import com.calypsan.listenup.client.domain.model.BookDownloadStatus
+import kotlinx.coroutines.flow.Flow
 
 /**
  * Result of a download operation.
@@ -60,4 +62,10 @@ interface DownloadService {
      * Called when book is deleted (access revoked) to clean up local storage.
      */
     suspend fun deleteDownload(bookId: BookId)
+
+    /**
+     * Observe download status for a book as a Flow.
+     * Emits new status whenever download state changes.
+     */
+    fun observeBookStatus(bookId: BookId): Flow<BookDownloadStatus>
 }

--- a/shared/src/commonMain/resources/strings/en.json
+++ b/shared/src/commonMain/resources/strings/en.json
@@ -213,7 +213,6 @@
     "detail_see_all_chapters": "See All %1$d Chapters",
     "detail_server_is_unreachable_connect_to": "Server is unreachable. Connect to your server to play or download this book.",
     "detail_show_less": "Show Less",
-    "detail_stream_now": "Stream Now",
     "detail_synopsis": "Synopsis",
     "detail_tags": "Tags",
     "detail_waiting_for_wifi": "Waiting for WiFi",
@@ -243,7 +242,8 @@
     "edit_this_will_remove_contributorstoremovecount": "This will remove %1$s ",
     "edit_unsaved_changes": "Unsaved Changes",
     "edit_you_have_unsaved_changes_are": "You have unsaved changes. Are you sure you want to discard them?",
-    "delete_download": "Delete Download"
+    "delete_download": "Delete Download",
+    "detail_stream_now": "Play Now"
   },
   "series": {
     "book_sequence": "Book %1$s",
@@ -548,5 +548,10 @@
     "duration": "Duration",
     "end_of_chapter": "End of Chapter",
     "playback_speed": "Playback Speed"
-  }
+  },
+  "book_detail.download": "Download",
+  "book_detail.queued": "Queued",
+  "book_detail.downloaded": "Downloaded",
+  "book_detail.cancel_download": "Cancel Download",
+  "book_detail.delete_download": "Delete Download"
 }

--- a/shared/src/iosMain/kotlin/com/calypsan/listenup/client/di/Koin.ios.kt
+++ b/shared/src/iosMain/kotlin/com/calypsan/listenup/client/di/Koin.ios.kt
@@ -13,6 +13,7 @@ import org.koin.dsl.bind
 import org.koin.dsl.module
 import com.calypsan.listenup.client.playback.PlaybackManager
 import com.calypsan.listenup.client.playback.AudioPlayer
+import com.calypsan.listenup.client.download.DownloadService
 import com.calypsan.listenup.client.playback.SleepTimerManager
 import com.calypsan.listenup.client.domain.repository.BookRepository
 import com.calypsan.listenup.client.domain.repository.ImageStorage
@@ -133,6 +134,11 @@ object KoinHelper : KoinComponent {
 
     fun getImageStorage(): ImageStorage {
         val instance: ImageStorage by inject()
+        return instance
+    }
+
+    fun getDownloadService(): DownloadService {
+        val instance: DownloadService by inject()
         return instance
     }
 


### PR DESCRIPTION
## Changes

### Download Infrastructure
- Added `observeBookStatus()` to `DownloadService` interface + all platform implementations
- `AppleDownloadService`: NSURLSession download tasks streaming directly to disk
- `DownloadSessionDelegate`: thread-safe progress/completion tracking with synchronized maps
- Continuation safety: checks `isActive` before resuming
- Auth via Bearer header (not URL query param)
- Concurrent file downloads with 1% progress reporting

### iOS UI (Liquid Glass)
- `DownloadButton.swift`: Glass material circle with state-driven icons
  - Not downloaded → orange download arrow
  - Downloading → circular progress ring
  - Completed → green checkmark → trash icon (2s transition)
  - Failed → red retry
- Wired into `BookDetailView` action area
- `BookDetailObserver`: download state, progress, and actions

### Bug Fixes
- **Token refresh**: `AppleAudioTokenProvider` now refreshes via API first instead of returning stale stored tokens
- **Contributor wrapping**: `FlowLayout` instead of `HStack` for narrator names
- **"Play Now"**: Renamed from "Stream Now" across both platforms
- **Kotlin warnings**: NSData encoding, unnecessary safe calls, redundant elvis

### Related
- Server PR #36 fixes `WriteTimeout: 15s` that was killing downloads at ~30MB