### PR TITLE
🔧 Resilient sync pipeline with persistent cover downloads

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
@@ -290,11 +290,7 @@ class ListenUp :
      * Called once by Coil to initialize the app-wide ImageLoader.
      * Configured to load book covers from local file storage.
      */
-    override fun newImageLoader(context: PlatformContext): ImageLoader =
-        ImageLoaderFactory.create(
-            context = this,
-            debug = false, // TODO: Enable in debug builds when BuildConfig is available
-        )
+    override fun newImageLoader(context: PlatformContext): ImageLoader = ImageLoaderFactory.create(context = this)
 
     /**
      * Verify that all critical Koin singletons can be resolved.

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/core/ImageLoaderFactory.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/core/ImageLoaderFactory.kt
@@ -18,36 +18,27 @@ import okio.Path.Companion.toOkioPath
  * - Memory cache for fast repeated access (25% of available memory)
  * - Disk cache for decoded bitmaps (50 MB, separate from source images)
  * - Crossfade animation for smooth UX
+ *
+ * Note: Server URL fallback for missing covers is handled directly in
+ * BookCoverImage via produceState, not through Coil interceptors.
  */
 object ImageLoaderFactory {
-    /**
-     * Create and configure an ImageLoader for the application.
-     *
-     * Since covers are stored locally by ImageStorage, Coil loads directly
-     * from file paths (e.g., file:///data/user/0/.../covers/book123.jpg).
-     *
-     * @param context Android application context
-     * @param debug Enable debug logging (default: false)
-     * @return Configured ImageLoader instance
-     */
     fun create(
         context: Context,
         debug: Boolean = false,
     ): ImageLoader =
         ImageLoader
             .Builder(context)
-            .components {
-                // No special components needed - Coil handles file:// URIs natively
-            }.memoryCache {
+            .memoryCache {
                 MemoryCache
                     .Builder()
-                    .maxSizePercent(context, percent = 0.25) // 25% of app memory
+                    .maxSizePercent(context, percent = 0.25)
                     .build()
             }.diskCache {
                 DiskCache
                     .Builder()
                     .directory(context.cacheDir.resolve("image_cache").toOkioPath())
-                    .maxSizeBytes(50 * 1024 * 1024) // 50 MB for decoded bitmaps
+                    .maxSizeBytes(50 * 1024 * 1024)
                     .build()
             }.crossfade(enable = true)
             .apply {

--- a/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/BookCoverImage.kt
+++ b/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/BookCoverImage.kt
@@ -1,47 +1,48 @@
 package com.calypsan.listenup.client.design.components
 
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.layout.ContentScale
+import coil3.compose.AsyncImage
 import coil3.compose.AsyncImagePainter
+import coil3.compose.LocalPlatformContext
+import coil3.network.NetworkHeaders
+import coil3.network.httpHeaders
+import coil3.request.ImageRequest
 import com.calypsan.listenup.client.core.BookId
+import com.calypsan.listenup.client.design.util.decodeBlurHash
+import com.calypsan.listenup.client.domain.repository.AuthSession
 import com.calypsan.listenup.client.domain.repository.ImageRepository
+import com.calypsan.listenup.client.domain.repository.ServerConfig
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.koin.compose.koinInject
+import androidx.compose.runtime.produceState
+
+private val logger = KotlinLogging.logger {}
 
 /**
- * In-memory set of book IDs that have already been attempted for lazy cover fetch.
- * Prevents re-fetching every recomposition. Cleared on app restart.
+ * Smart book cover image with server URL fallback.
+ *
+ * Loading strategy:
+ * 1. If cover exists locally -> display from disk (fast, works offline)
+ * 2. If missing locally -> load directly from server URL via Coil with auth
+ * 3. Once the download queue saves the cover to disk, subsequent renders use disk
+ *
+ * Covers are NEVER blank when online.
  */
-private val attemptedBookIds = mutableSetOf<String>()
-
-/**
- * Smart book cover image that lazily fetches missing covers from the server.
- *
- * Wraps [ListenUpAsyncImage] with cover resolution logic:
- * 1. If the cover exists locally, displays it immediately
- * 2. If missing, triggers an async download from the server
- * 3. On successful download, the image refreshes automatically
- * 4. Each book ID is only attempted once per session to avoid loops
- *
- * Use this instead of [ListenUpAsyncImage] wherever a book cover is displayed
- * and a bookId is available. For non-book images (contributors, avatars, etc.),
- * continue using [ListenUpAsyncImage] directly.
- *
- * @param bookId The book's unique identifier, used for lazy fetching
- * @param coverPath Local file path to the cover image, or null if unknown
- * @param contentDescription Accessibility description
- * @param modifier Optional modifier
- * @param blurHash BlurHash string for placeholder, or null
- * @param contentScale How to scale the image (default: Crop)
- * @param onState Optional callback for loading state changes
- */
+@Suppress("CognitiveComplexMethod")
 @Composable
 fun BookCoverImage(
     bookId: String,
@@ -53,34 +54,100 @@ fun BookCoverImage(
     onState: ((AsyncImagePainter.State) -> Unit)? = null,
 ) {
     val imageRepository: ImageRepository = koinInject()
+    val serverConfig: ServerConfig = koinInject()
+    val authSession: AuthSession = koinInject()
+    val context = LocalPlatformContext.current
 
-    // Track refresh key to bust Coil cache after download
-    var refreshKey by remember(bookId) { mutableIntStateOf(0) }
+    var imageLoaded by remember(bookId) { mutableStateOf(false) }
 
-    // Resolve cover path — use provided path or fall back to repository path
-    val resolvedPath = coverPath ?: imageRepository.getBookCoverPath(BookId(bookId))
-
-    // Lazy fetch if cover is missing and not yet attempted
-    LaunchedEffect(bookId) {
-        if (bookId !in attemptedBookIds && !imageRepository.bookCoverExists(BookId(bookId))) {
-            attemptedBookIds.add(bookId)
+    // Resolve: local file or server URL
+    val imageRequest by produceState<ImageRequest?>(
+        initialValue = null,
+        key1 = bookId,
+        key2 = coverPath,
+    ) {
+        value =
             withContext(Dispatchers.IO) {
-                val result = imageRepository.downloadBookCover(BookId(bookId))
-                if (result is com.calypsan.listenup.client.core.Result.Success && result.data) {
-                    // Download succeeded — bump refresh key to trigger recomposition
-                    refreshKey++
+                val localPath = coverPath ?: imageRepository.getBookCoverPath(BookId(bookId))
+
+                val exists = imageRepository.bookCoverExists(BookId(bookId))
+                logger.info { "BookCoverImage: bookId=$bookId, exists=$exists" }
+                if (exists) {
+                    // Local file — load from disk
+                    ImageRequest
+                        .Builder(context)
+                        .data(localPath)
+                        .memoryCacheKey("$bookId:cover")
+                        .diskCacheKey("$bookId:cover")
+                        .build()
+                } else {
+                    // No local file — server URL fallback
+                    val baseUrl = serverConfig.getActiveUrl()?.value
+                    val token = authSession.getAccessToken()?.value
+                    logger.info { "BookCoverImage: FALLBACK bookId=$bookId, url=$baseUrl/api/v1/covers/$bookId" }
+                    if (baseUrl != null) {
+                        ImageRequest
+                            .Builder(context)
+                            .data("$baseUrl/api/v1/covers/$bookId")
+                            .apply {
+                                if (token != null) {
+                                    httpHeaders(
+                                        NetworkHeaders
+                                            .Builder()
+                                            .set("Authorization", "Bearer $token")
+                                            .build(),
+                                    )
+                                }
+                            }.build()
+                    } else {
+                        ImageRequest
+                            .Builder(context)
+                            .data(localPath)
+                            .build()
+                    }
                 }
             }
-        }
     }
 
-    ListenUpAsyncImage(
-        path = resolvedPath,
-        contentDescription = contentDescription,
-        modifier = modifier,
-        blurHash = blurHash,
-        contentScale = contentScale,
-        refreshKey = refreshKey,
-        onState = onState,
-    )
+    if (blurHash != null) {
+        Box(modifier = modifier.background(MaterialTheme.colorScheme.surfaceContainerHighest)) {
+            if (!imageLoaded) {
+                val bitmap: ImageBitmap? =
+                    remember(blurHash) {
+                        decodeBlurHash(blurHash, width = 32, height = 32)
+                    }
+                if (bitmap != null) {
+                    Image(
+                        bitmap = bitmap,
+                        contentDescription = null,
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                }
+            }
+
+            if (imageRequest != null) {
+                AsyncImage(
+                    model = imageRequest,
+                    contentDescription = contentDescription,
+                    modifier = Modifier.fillMaxSize(),
+                    contentScale = contentScale,
+                    onState = { state ->
+                        if (state is AsyncImagePainter.State.Success) {
+                            imageLoaded = true
+                        }
+                        onState?.invoke(state)
+                    },
+                )
+            }
+        }
+    } else if (imageRequest != null) {
+        AsyncImage(
+            model = imageRequest,
+            contentDescription = contentDescription,
+            modifier = modifier,
+            contentScale = contentScale,
+            onState = onState,
+        )
+    }
 }

--- a/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/library/BookCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/library/BookCard.kt
@@ -338,39 +338,14 @@ private fun BookCardCover(
                     ),
             contentAlignment = Alignment.Center,
         ) {
-            if (coverPath != null || blurHash != null) {
-                BookCoverImage(
-                    bookId = bookId,
-                    coverPath = coverPath,
-                    blurHash = blurHash,
-                    contentDescription = contentDescription,
-                    modifier = Modifier.matchParentSize(),
-                )
-            } else {
-                // Gradient placeholder
-                Box(
-                    modifier =
-                        Modifier
-                            .matchParentSize()
-                            .background(
-                                Brush.linearGradient(
-                                    colors =
-                                        listOf(
-                                            MaterialTheme.colorScheme.primaryContainer,
-                                            MaterialTheme.colorScheme.surfaceContainer,
-                                        ),
-                                ),
-                            ),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    Icon(
-                        imageVector = Icons.Default.Book,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.6f),
-                        modifier = Modifier.padding(24.dp),
-                    )
-                }
-            }
+            // Always render BookCoverImage — handles server URL fallback for missing local files
+            BookCoverImage(
+                bookId = bookId,
+                coverPath = coverPath,
+                blurHash = blurHash,
+                contentDescription = contentDescription,
+                modifier = Modifier.matchParentSize(),
+            )
 
             // Progress overlay
             if (progress != null && progress > 0f) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -52,8 +52,10 @@ detekt = "1.23.8"
 spotless = "8.2.1"
 ktlint = "1.8.0" # Used by Spotless plugin at runtime
 kover = "0.9.7"
+atomicfu = "0.31.0"
 
 [libraries]
+atomicfu = { module = "org.jetbrains.kotlinx:atomicfu", version.ref = "atomicfu" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
 androidx-lifecycle-viewmodelCompose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -112,6 +112,7 @@ kotlin {
             implementation(libs.kotlinx.datetime)
             implementation(libs.kotlinx.collections.immutable)
             implementation(libs.kotlinx.io.core)
+            implementation(libs.atomicfu)
 
             api(libs.koin.core)
             implementation(libs.kotlin.logging)

--- a/shared/schemas/com.calypsan.listenup.client.data.local.db.ListenUpDatabase/1.json
+++ b/shared/schemas/com.calypsan.listenup.client.data.local.db.ListenUpDatabase/1.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 1,
-    "identityHash": "8dc4f812c1ff90cdb9c5aef5bfa130d3",
+    "identityHash": "4eedb11d2de9bd8f1c0dc2f800074eda",
     "entities": [
       {
         "tableName": "users",
@@ -2075,11 +2075,57 @@
             "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_reading_sessions_bookId_oduserId` ON `${TABLE_NAME}` (`bookId`, `oduserId`)"
           }
         ]
+      },
+      {
+        "tableName": "cover_download_queue",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookId` TEXT NOT NULL, `status` TEXT NOT NULL, `attempts` INTEGER NOT NULL, `lastAttemptAt` INTEGER, `error` TEXT, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`bookId`))",
+        "fields": [
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attempts",
+            "columnName": "attempts",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAttemptAt",
+            "columnName": "lastAttemptAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "error",
+            "columnName": "error",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "bookId"
+          ]
+        }
       }
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '8dc4f812c1ff90cdb9c5aef5bfa130d3')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '4eedb11d2de9bd8f1c0dc2f800074eda')"
     ]
   }
 }

--- a/shared/src/androidHostTest/kotlin/com/calypsan/listenup/client/di/KoinModuleVerifyTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/calypsan/listenup/client/di/KoinModuleVerifyTest.kt
@@ -107,6 +107,7 @@ class KoinModuleVerifyTest {
                     PlaybackPositionDao::class,
                     PendingOperationDao::class,
                     DownloadDao::class,
+                    com.calypsan.listenup.client.data.local.db.CoverDownloadDao::class,
                     SearchDao::class,
                     ServerDao::class,
                     // Playback and download services

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/CoverDownloadQueue.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/CoverDownloadQueue.kt
@@ -1,0 +1,168 @@
+package com.calypsan.listenup.client.data.local.db
+
+import androidx.room.Dao
+import androidx.room.Entity
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.PrimaryKey
+import androidx.room.Query
+import com.calypsan.listenup.client.core.BookId
+import com.calypsan.listenup.client.core.Timestamp
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Status of a cover download task in the persistent queue.
+ */
+enum class CoverDownloadStatus {
+    /** Waiting to be processed. */
+    PENDING,
+
+    /** Currently downloading. */
+    IN_PROGRESS,
+
+    /** Successfully downloaded and saved to disk. */
+    COMPLETED,
+
+    /** Download failed — will be retried with backoff. */
+    FAILED,
+}
+
+/**
+ * Persistent cover download task.
+ *
+ * Tracks individual cover downloads so they survive app backgrounding,
+ * crashes, and restarts. Part of the sync resilience architecture —
+ * replaces the old fire-and-forget coroutine approach.
+ */
+@Entity(tableName = "cover_download_queue")
+data class CoverDownloadTaskEntity(
+    @PrimaryKey
+    val bookId: BookId,
+    val status: CoverDownloadStatus = CoverDownloadStatus.PENDING,
+    val attempts: Int = 0,
+    val lastAttemptAt: Timestamp? = null,
+    val error: String? = null,
+    val createdAt: Timestamp = Timestamp.now(),
+)
+
+/**
+ * DAO for the cover download queue.
+ */
+@Dao
+interface CoverDownloadDao {
+    /**
+     * Enqueue cover downloads. Existing entries are ignored (IGNORE strategy)
+     * so re-syncing doesn't reset in-progress or completed tasks.
+     */
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun enqueueAll(tasks: List<CoverDownloadTaskEntity>)
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun enqueue(task: CoverDownloadTaskEntity)
+
+    /**
+     * Get the next batch of tasks to process.
+     * Picks PENDING tasks first, then FAILED tasks that haven't exceeded max retries.
+     * Orders by creation time so oldest tasks are processed first.
+     */
+    @Query(
+        """
+        SELECT * FROM cover_download_queue 
+        WHERE status = 'PENDING' 
+           OR (status = 'FAILED' AND attempts < :maxRetries)
+        ORDER BY 
+            CASE status WHEN 'PENDING' THEN 0 ELSE 1 END,
+            createdAt ASC
+        LIMIT :limit
+        """,
+    )
+    suspend fun getNextBatch(
+        limit: Int = 5,
+        maxRetries: Int = 5,
+    ): List<CoverDownloadTaskEntity>
+
+    @Query("UPDATE cover_download_queue SET status = :status WHERE bookId = :bookId")
+    suspend fun updateStatus(
+        bookId: BookId,
+        status: CoverDownloadStatus,
+    )
+
+    @Query(
+        """
+        UPDATE cover_download_queue 
+        SET status = 'FAILED', attempts = attempts + 1, lastAttemptAt = :now, error = :error 
+        WHERE bookId = :bookId
+        """,
+    )
+    suspend fun markFailed(
+        bookId: BookId,
+        error: String?,
+        now: Timestamp = Timestamp.now(),
+    )
+
+    @Query(
+        """
+        UPDATE cover_download_queue 
+        SET status = 'COMPLETED', lastAttemptAt = :now 
+        WHERE bookId = :bookId
+        """,
+    )
+    suspend fun markCompleted(
+        bookId: BookId,
+        now: Timestamp = Timestamp.now(),
+    )
+
+    @Query("UPDATE cover_download_queue SET status = 'IN_PROGRESS' WHERE bookId = :bookId")
+    suspend fun markInProgress(bookId: BookId)
+
+    /**
+     * Reset any IN_PROGRESS tasks back to PENDING.
+     * Called on app startup to recover from interrupted downloads.
+     */
+    @Query("UPDATE cover_download_queue SET status = 'PENDING' WHERE status = 'IN_PROGRESS'")
+    suspend fun resetInProgress()
+
+    /**
+     * Count of pending + failed (retryable) tasks.
+     * Used for UI progress display.
+     */
+    @Query(
+        """
+        SELECT COUNT(*) FROM cover_download_queue 
+        WHERE status = 'PENDING' OR (status = 'FAILED' AND attempts < 5)
+        """,
+    )
+    fun observeRemainingCount(): Flow<Int>
+
+    @Query("SELECT COUNT(*) FROM cover_download_queue WHERE status = 'COMPLETED'")
+    fun observeCompletedCount(): Flow<Int>
+
+    @Query("SELECT COUNT(*) FROM cover_download_queue")
+    fun observeTotalCount(): Flow<Int>
+
+    /**
+     * Remove completed tasks older than the given timestamp.
+     * Housekeeping to prevent the queue from growing forever.
+     */
+    @Query("DELETE FROM cover_download_queue WHERE status = 'COMPLETED' AND lastAttemptAt < :before")
+    suspend fun purgeCompleted(before: Timestamp)
+
+    /**
+     * Remove a specific task (e.g., when book is deleted).
+     */
+    @Query("DELETE FROM cover_download_queue WHERE bookId = :bookId")
+    suspend fun remove(bookId: BookId)
+
+    /**
+     * Re-enqueue a cover for download (e.g., when cover changed on server).
+     * Resets status to PENDING and clears attempts.
+     */
+    @Query(
+        """
+        UPDATE cover_download_queue 
+        SET status = 'PENDING', attempts = 0, error = null, lastAttemptAt = null 
+        WHERE bookId = :bookId
+        """,
+    )
+    suspend fun reenqueue(bookId: BookId)
+}

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/ListenUpDatabase.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/ListenUpDatabase.kt
@@ -43,6 +43,7 @@ import androidx.room.TypeConverters
         ActivityEntity::class,
         UserStatsEntity::class,
         ReadingSessionEntity::class,
+        CoverDownloadTaskEntity::class,
     ],
     version = 1,
     exportSchema = true,
@@ -52,8 +53,10 @@ import androidx.room.TypeConverters
     Converters::class,
     PendingOperationConverters::class,
     StringListConverter::class,
+    CoverDownloadStatusConverter::class,
 )
 @ConstructedBy(ListenUpDatabaseConstructor::class)
+@Suppress("TooManyFunctions")
 abstract class ListenUpDatabase : RoomDatabase() {
     abstract fun userDao(): UserDao
 
@@ -102,6 +105,8 @@ abstract class ListenUpDatabase : RoomDatabase() {
     abstract fun userStatsDao(): UserStatsDao
 
     abstract fun readingSessionDao(): ReadingSessionDao
+
+    abstract fun coverDownloadDao(): CoverDownloadDao
 }
 
 /**

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/TypeConverters.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/TypeConverters.kt
@@ -169,3 +169,15 @@ class StringListConverter {
     @TypeConverter
     fun toStringList(value: String): List<String> = if (value.isEmpty()) emptyList() else value.split("|||")
 }
+
+/**
+ * Room type converter for [CoverDownloadStatus] enum.
+ * Uses string names (not ordinals) for readable queries and forward compatibility.
+ */
+class CoverDownloadStatusConverter {
+    @TypeConverter
+    fun fromStatus(value: CoverDownloadStatus): String = value.name
+
+    @TypeConverter
+    fun toStatus(value: String): CoverDownloadStatus = CoverDownloadStatus.valueOf(value)
+}

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/SyncApi.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/SyncApi.kt
@@ -424,14 +424,14 @@ class SyncApi(
     /**
      * Get all reading sessions for offline-first book detail pages.
      *
-     * Endpoint: GET /api/v1/sync/reading-sessions
+     * Endpoint: GET /api/v1/sync/active-sessions
      * Auth: Required
      */
     override suspend fun getReadingSessions(): Result<SyncReadingSessionsResponse> =
         suspendRunCatching {
             val client = clientFactory.getClient()
             val response: ApiResponse<ApiReadingSessions> =
-                client.get("/api/v1/sync/reading-sessions").body()
+                client.get("/api/v1/sync/active-sessions").body()
             val apiSessions = response.toResult().getOrThrow()
             SyncReadingSessionsResponse(
                 readers =

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/api/ListenUpApi.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/api/ListenUpApi.kt
@@ -103,9 +103,9 @@ class ListenUpApi(
 
             // Request timeout configuration
             install(HttpTimeout) {
-                requestTimeoutMillis = 30_000
+                requestTimeoutMillis = 90_000
                 connectTimeoutMillis = 10_000
-                socketTimeoutMillis = 30_000
+                socketTimeoutMillis = 90_000
             }
 
             // Default request configuration

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/CoverDownloadWorker.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/CoverDownloadWorker.kt
@@ -1,0 +1,138 @@
+package com.calypsan.listenup.client.data.sync
+
+import com.calypsan.listenup.client.core.Result
+import com.calypsan.listenup.client.core.Timestamp
+import com.calypsan.listenup.client.data.local.db.CoverDownloadDao
+import com.calypsan.listenup.client.data.local.db.CoverDownloadStatus
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * Processes the persistent cover download queue.
+ *
+ * Unlike the old fire-and-forget coroutine approach, this worker:
+ * - Reads tasks from a Room-backed queue that survives app lifecycle
+ * - Processes one at a time (individual downloads, not batch tar)
+ * - Marks each task as completed/failed in the DB
+ * - Can be stopped and resumed at any point
+ * - Tracks progress for UI display
+ *
+ * Triggered by: initial sync, app resume, manual refresh, SSE cover change.
+ */
+class CoverDownloadWorker(
+    private val coverDownloadDao: CoverDownloadDao,
+    private val imageDownloader: ImageDownloaderContract,
+) {
+    private val _isProcessing = MutableStateFlow(false)
+    val isProcessing: StateFlow<Boolean> = _isProcessing.asStateFlow()
+
+    /** Remaining tasks (pending + retryable failed). */
+    val remainingCount: Flow<Int> = coverDownloadDao.observeRemainingCount()
+
+    /** Completed tasks. */
+    val completedCount: Flow<Int> = coverDownloadDao.observeCompletedCount()
+
+    /** Total tasks ever enqueued (for progress denominator). */
+    val totalCount: Flow<Int> = coverDownloadDao.observeTotalCount()
+
+    /**
+     * Reset any tasks that were IN_PROGRESS when the app was killed.
+     * Call this on app startup before processing.
+     */
+    suspend fun recoverInterrupted() {
+        coverDownloadDao.resetInProgress()
+    }
+
+    /**
+     * Process the download queue until empty or cancelled.
+     *
+     * Downloads covers one at a time using individual requests (not batch tar).
+     * Each successful download is immediately marked COMPLETED in Room.
+     * Failed downloads are marked FAILED with attempt count incremented.
+     *
+     * This method is safe to call multiple times — it's a no-op if already processing
+     * or if the queue is empty.
+     */
+    @Suppress("NestedBlockDepth")
+    suspend fun processQueue() {
+        if (_isProcessing.value) {
+            logger.debug { "Cover download worker already processing, skipping" }
+            return
+        }
+
+        _isProcessing.value = true
+        logger.info { "Cover download worker started" }
+
+        try {
+            var processedCount = 0
+
+            while (true) {
+                val batch = coverDownloadDao.getNextBatch(limit = 5)
+                if (batch.isEmpty()) break
+
+                for (task in batch) {
+                    try {
+                        coverDownloadDao.markInProgress(task.bookId)
+
+                        val result = imageDownloader.downloadCover(task.bookId)
+
+                        when {
+                            result is Result.Success && result.data -> {
+                                // Cover downloaded and saved
+                                coverDownloadDao.markCompleted(task.bookId)
+                                processedCount++
+
+                                // Extract and save palette colors
+                                // (color extraction happens inside imageDownloader.downloadCover)
+                                logger.debug { "Cover downloaded: ${task.bookId.value}" }
+                            }
+
+                            result is Result.Success && !result.data -> {
+                                // Cover already exists locally or not available on server
+                                coverDownloadDao.markCompleted(task.bookId)
+                                processedCount++
+                            }
+
+                            result is Result.Failure -> {
+                                coverDownloadDao.markFailed(
+                                    task.bookId,
+                                    result.message,
+                                )
+                                logger.debug {
+                                    "Cover download failed: ${task.bookId.value} " +
+                                        "(attempt ${task.attempts + 1}): ${result.message}"
+                                }
+                            }
+                        }
+                    } catch (e: CancellationException) {
+                        // App is backgrounding — mark task back to pending so it resumes later
+                        coverDownloadDao.updateStatus(task.bookId, CoverDownloadStatus.PENDING)
+                        throw e
+                    } catch (e: Exception) {
+                        coverDownloadDao.markFailed(task.bookId, e.message)
+                        logger.warn(e) { "Cover download error: ${task.bookId.value}" }
+                    }
+                }
+            }
+
+            logger.info { "Cover download worker finished: $processedCount covers processed" }
+        } finally {
+            _isProcessing.value = false
+        }
+    }
+
+    /**
+     * Clean up old completed tasks to prevent unbounded queue growth.
+     */
+    suspend fun purgeOldCompleted() {
+        // Remove completed tasks older than 7 days
+        val sevenDaysAgo = Timestamp(Timestamp.now().epochMillis - 7 * 24 * 60 * 60 * 1000L)
+        coverDownloadDao.purgeCompleted(sevenDaysAgo)
+    }
+}

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/ImageDownloader.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/ImageDownloader.kt
@@ -10,7 +10,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 
 private val logger = KotlinLogging.logger {}
 
-private const val BATCH_SIZE = 10
+private const val BATCH_SIZE = 3
 
 /**
  * Orchestrates downloading and storing book cover images during sync.

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/model/SyncStatus.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/model/SyncStatus.kt
@@ -36,17 +36,29 @@ sealed interface SyncStatus {
     /**
      * Sync in progress with detailed progress information.
      *
+     * Reports both per-phase and aggregate progress. The aggregate values
+     * let UI show "Syncing: 180 of 350 items" across all phases, while
+     * phase-specific values enable "Syncing books: 50 of 131".
+     *
      * @property phase Current sync phase
-     * @property current Current progress within phase
-     * @property total Total items in phase (-1 if unknown)
+     * @property phaseItemsSynced Items completed in current phase
+     * @property phaseTotalItems Total items expected in current phase (-1 if unknown)
+     * @property totalItemsSynced Items completed across ALL phases so far
+     * @property totalItems Total items expected across ALL phases (-1 if unknown)
      * @property message Human-readable progress message
      */
     data class Progress(
         val phase: SyncPhase,
-        val current: Int,
-        val total: Int,
+        val phaseItemsSynced: Int = 0,
+        val phaseTotalItems: Int = -1,
+        val totalItemsSynced: Int = 0,
+        val totalItems: Int = -1,
         val message: String,
-    ) : SyncStatus
+    ) : SyncStatus {
+        /** For backward compatibility with old current/total pattern */
+        val current: Int get() = totalItemsSynced
+        val total: Int get() = totalItems
+    }
 
     /**
      * Retrying after a transient failure.

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/pull/ActiveSessionsPuller.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/pull/ActiveSessionsPuller.kt
@@ -57,8 +57,8 @@ class ActiveSessionsPuller(
         onProgress(
             SyncStatus.Progress(
                 phase = SyncPhase.SYNCING_LISTENING_EVENTS,
-                current = 0,
-                total = -1,
+                phaseItemsSynced = 0,
+                phaseTotalItems = -1,
                 message = "Syncing active sessions...",
             ),
         )

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/pull/GenrePuller.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/pull/GenrePuller.kt
@@ -36,8 +36,8 @@ class GenrePuller(
         onProgress(
             SyncStatus.Progress(
                 phase = SyncPhase.SYNCING_GENRES,
-                current = 0,
-                total = -1,
+                phaseItemsSynced = 0,
+                phaseTotalItems = -1,
                 message = "Syncing genres...",
             ),
         )

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/pull/ListeningEventPuller.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/pull/ListeningEventPuller.kt
@@ -61,8 +61,8 @@ class ListeningEventPuller(
         onProgress(
             SyncStatus.Progress(
                 phase = SyncPhase.SYNCING_LISTENING_EVENTS,
-                current = 0,
-                total = -1,
+                phaseItemsSynced = 0,
+                phaseTotalItems = -1,
                 message = "Syncing listening events...",
             ),
         )

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/pull/ProgressPuller.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/pull/ProgressPuller.kt
@@ -44,8 +44,8 @@ class ProgressPuller(
         onProgress(
             SyncStatus.Progress(
                 phase = SyncPhase.SYNCING_LISTENING_EVENTS,
-                current = 0,
-                total = -1,
+                phaseItemsSynced = 0,
+                phaseTotalItems = -1,
                 message = "Syncing playback progress...",
             ),
         )

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/pull/ReadingSessionPuller.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/pull/ReadingSessionPuller.kt
@@ -46,8 +46,8 @@ class ReadingSessionPuller(
         onProgress(
             SyncStatus.Progress(
                 phase = SyncPhase.SYNCING_LISTENING_EVENTS,
-                current = 0,
-                total = -1,
+                phaseItemsSynced = 0,
+                phaseTotalItems = -1,
                 message = "Syncing reading sessions...",
             ),
         )

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/pull/TagPuller.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/pull/TagPuller.kt
@@ -35,8 +35,8 @@ class TagPuller(
         onProgress(
             SyncStatus.Progress(
                 phase = SyncPhase.SYNCING_TAGS,
-                current = 0,
-                total = -1,
+                phaseItemsSynced = 0,
+                phaseTotalItems = -1,
                 message = "Syncing tags...",
             ),
         )

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/SyncStatusTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/SyncStatusTest.kt
@@ -42,8 +42,8 @@ class SyncStatusTest {
         val status =
             SyncStatus.Progress(
                 phase = SyncPhase.SYNCING_BOOKS,
-                current = 5,
-                total = 10,
+                totalItemsSynced = 5,
+                totalItems = 10,
                 message = "Syncing books...",
             )
 
@@ -55,8 +55,8 @@ class SyncStatusTest {
         val status =
             SyncStatus.Progress(
                 phase = SyncPhase.SYNCING_SERIES,
-                current = 3,
-                total = 20,
+                totalItemsSynced = 3,
+                totalItems = 20,
                 message = "Progress message",
             )
 
@@ -69,8 +69,8 @@ class SyncStatusTest {
         val status =
             SyncStatus.Progress(
                 phase = SyncPhase.SYNCING_CONTRIBUTORS,
-                current = 1,
-                total = -1, // Unknown total
+                totalItemsSynced = 1,
+                totalItems = -1, // Unknown total
                 message = "Syncing...",
             )
 
@@ -83,8 +83,8 @@ class SyncStatusTest {
         val status =
             SyncStatus.Progress(
                 phase = SyncPhase.SYNCING_BOOKS,
-                current = 3,
-                total = 10,
+                totalItemsSynced = 3,
+                totalItems = 10,
                 message = message,
             )
 
@@ -207,8 +207,8 @@ class SyncStatusTest {
         states.add(
             SyncStatus.Progress(
                 phase = SyncPhase.FETCHING_METADATA,
-                current = 0,
-                total = 3,
+                totalItemsSynced = 0,
+                totalItems = 3,
                 message = "Preparing...",
             ),
         )
@@ -216,8 +216,8 @@ class SyncStatusTest {
         states.add(
             SyncStatus.Progress(
                 phase = SyncPhase.SYNCING_BOOKS,
-                current = 1,
-                total = 3,
+                totalItemsSynced = 1,
+                totalItems = 3,
                 message = "Syncing books...",
             ),
         )

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/pull/BookPullerTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/pull/BookPullerTest.kt
@@ -124,6 +124,7 @@ class BookPullerTest {
         val tagDao: TagDao = mock()
         val conflictDetector: ConflictDetectorContract = mock()
         val imageDownloader: ImageDownloaderContract = mock()
+        val coverDownloadDao: com.calypsan.listenup.client.data.local.db.CoverDownloadDao = mock()
 
         init {
             // Default stubs
@@ -143,6 +144,7 @@ class BookPullerTest {
             everySuspend { conflictDetector.shouldPreserveLocalChanges(any()) } returns false
             everySuspend { imageDownloader.deleteCover(any()) } returns Result.Success(Unit)
             everySuspend { imageDownloader.downloadCovers(any()) } returns Result.Success(emptyList())
+            everySuspend { coverDownloadDao.enqueueAll(any()) } returns Unit
         }
 
         fun build(): BookPuller =
@@ -155,7 +157,7 @@ class BookPullerTest {
                 tagDao = tagDao,
                 conflictDetector = conflictDetector,
                 imageDownloader = imageDownloader,
-                scope = scope,
+                coverDownloadDao = coverDownloadDao,
             )
     }
 
@@ -478,7 +480,7 @@ class BookPullerTest {
             advanceUntilIdle()
 
             // Then
-            verifySuspend { fixture.imageDownloader.downloadCovers(any()) }
+            verifySuspend { fixture.coverDownloadDao.enqueueAll(any()) }
         }
 
     // ========== Progress Reporting Tests ==========

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/pull/PullSyncOrchestratorTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/pull/PullSyncOrchestratorTest.kt
@@ -43,6 +43,7 @@ class PullSyncOrchestratorTest {
         val activeSessionsPuller: Puller = mock()
         val readingSessionsPuller: Puller = mock()
         val syncDao: SyncDao = mock()
+        val syncApi: com.calypsan.listenup.client.data.remote.SyncApiContract = mock()
 
         // Use real coordinator for simpler testing
         val coordinator = SyncCoordinator()
@@ -60,6 +61,9 @@ class PullSyncOrchestratorTest {
             everySuspend { activeSessionsPuller.pull(any(), any()) } returns Unit
             everySuspend { readingSessionsPuller.pull(any(), any()) } returns Unit
             everySuspend { syncDao.getValue(SyncDao.KEY_LAST_SYNC_BOOKS) } returns null
+            everySuspend { syncApi.getManifest() } returns
+                com.calypsan.listenup.client.core.Result
+                    .Failure(message = "no manifest")
         }
 
         fun build(): PullSyncOrchestrator =
@@ -75,6 +79,7 @@ class PullSyncOrchestratorTest {
                 activeSessionsPuller = activeSessionsPuller,
                 readingSessionsPuller = readingSessionsPuller,
                 coordinator = coordinator,
+                syncApi = syncApi,
                 syncDao = syncDao,
             )
     }


### PR DESCRIPTION
## Summary
- **Persistent cover download queue** — Room-backed queue survives app backgrounding, crashes, and restarts. Replaces fire-and-forget coroutine approach.
- **Server URL fallback** — BookCoverImage resolves via produceState: local file first, server URL with auth if missing. Covers are never blank when online.
- **BookCard always renders covers** — Removed null guard that prevented fallback when coverPath and blurHash were both null.
- **Manifest-first progress** — PullSyncOrchestrator fetches manifest for total counts, all pullers report real item counts (not page numbers).
- **Sync endpoint fix** — reading-sessions → active-sessions (was silently failing).
- **Timeout/batch tuning** — HTTP timeouts 30s→90s, batch size 10→3 for Tailscale Funnel reliability.
- **Dead code cleanup** — Removed CoverFallbackInterceptor and Coil interceptor wiring (BookCoverImage handles fallback directly).
- **kotlinx.atomicfu** — Thread-safe aggregate sync counters across parallel pulls.