### PR TITLE
✨ Async analysis with progress UI (#109)

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/backup/ABSImportScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/backup/ABSImportScreen.kt
@@ -38,10 +38,12 @@ import androidx.compose.material.icons.outlined.PhoneAndroid
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -171,6 +173,9 @@ fun ABSImportScreen(
 
             ABSImportStep.ANALYZING -> {
                 AnalyzingContent(
+                    phase = state.analyzePhase,
+                    current = state.analyzeCurrent,
+                    total = state.analyzeTotal,
                     modifier = Modifier.padding(paddingValues),
                 )
             }
@@ -699,11 +704,49 @@ private fun UploadingContent(
 // === Analyzing ===
 
 @Composable
-private fun AnalyzingContent(modifier: Modifier = Modifier) {
-    FullScreenLoadingIndicator(
-        modifier = modifier,
-        message = "Analyzing Backup...",
-    )
+private fun AnalyzingContent(
+    phase: String,
+    current: Int,
+    total: Int,
+    modifier: Modifier = Modifier,
+) {
+    val phaseText =
+        when (phase) {
+            "parsing" -> "Parsing backup..."
+            "matching_users" -> "Matching users..."
+            "matching_books" -> "Matching books..."
+            "matching_sessions" -> "Analyzing sessions..."
+            "matching_progress" -> "Analyzing progress..."
+            "done" -> "Finishing up..."
+            else -> "Analyzing..."
+        }
+
+    Column(
+        modifier = modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        CircularProgressIndicator()
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = phaseText,
+            style = MaterialTheme.typography.bodyLarge,
+        )
+        if (total > 0) {
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "$current / $total",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            @Suppress("MagicNumber")
+            LinearProgressIndicator(
+                progress = { current.toFloat() / total.toFloat() },
+                modifier = Modifier.fillMaxWidth(0.6f),
+            )
+        }
+    }
 }
 
 // === User Mapping ===

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/BackupApiContract.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/BackupApiContract.kt
@@ -1,8 +1,10 @@
 package com.calypsan.listenup.client.data.remote
 
 import com.calypsan.listenup.client.core.FileSource
+import com.calypsan.listenup.client.data.remote.model.AnalysisStatusResponse
 import com.calypsan.listenup.client.data.remote.model.AnalyzeABSRequest
 import com.calypsan.listenup.client.data.remote.model.AnalyzeABSResponse
+import com.calypsan.listenup.client.data.remote.model.AsyncAnalyzeResponse
 import com.calypsan.listenup.client.data.remote.model.BackupResponse
 import com.calypsan.listenup.client.data.remote.model.ImportABSRequest
 import com.calypsan.listenup.client.data.remote.model.ImportABSResponse
@@ -87,6 +89,16 @@ interface BackupApiContract {
      * Analyze an Audiobookshelf backup.
      */
     suspend fun analyzeABSBackup(request: AnalyzeABSRequest): AnalyzeABSResponse
+
+    /**
+     * Start an async analysis of an Audiobookshelf backup.
+     */
+    suspend fun analyzeABSBackupAsync(request: AnalyzeABSRequest): AsyncAnalyzeResponse
+
+    /**
+     * Poll the status of an async analysis.
+     */
+    suspend fun getAnalysisStatus(analysisId: String): AnalysisStatusResponse
 
     /**
      * Import from an Audiobookshelf backup.

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/model/BackupModels.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/model/BackupModels.kt
@@ -181,6 +181,27 @@ data class AnalyzeABSResponse(
 )
 
 /**
+ * Response from starting an async ABS analysis.
+ */
+@Serializable
+data class AsyncAnalyzeResponse(
+    @SerialName("analysis_id") val analysisId: String,
+)
+
+/**
+ * Response from polling async ABS analysis status.
+ */
+@Serializable
+data class AnalysisStatusResponse(
+    val status: String, // "running", "completed", "failed"
+    val phase: String, // "parsing", "matching_users", "matching_books", etc.
+    val current: Int = 0,
+    val total: Int = 0,
+    val result: AnalyzeABSResponse? = null,
+    val error: String? = null,
+)
+
+/**
  * Request to import from an ABS backup.
  */
 @Serializable


### PR DESCRIPTION
## Changes

Adds progress feedback during ABS backup analysis.

**Client:**
- Call new async analyze endpoint, poll for status every 1.5s
- Show current phase (parsing, matching users/books/sessions/progress)
- Linear progress bar with current/total counter during book matching
- New API models: AsyncAnalyzeResponse, AnalysisStatusResponse

**Requires:** ListenUpApp/server PR (feat/analyze-progress) for async endpoints

Closes #109