### PR TITLE
🐛 Background-safe ABS backup upload via WorkManager (#110)

### DIFF
--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
 

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
@@ -17,7 +17,7 @@ import com.calypsan.listenup.client.download.DownloadManager
 import com.calypsan.listenup.client.features.bookdetail.AndroidBookDetailPlatformActions
 import com.calypsan.listenup.client.features.bookdetail.BookDetailPlatformActions
 import com.calypsan.listenup.client.download.DownloadService
-import com.calypsan.listenup.client.download.DownloadWorkerFactory
+import com.calypsan.listenup.client.download.ListenUpWorkerFactory
 import com.calypsan.listenup.client.automotive.BrowseTreeProvider
 import com.calypsan.listenup.client.shortcuts.ListenUpShortcutManager
 import com.calypsan.listenup.client.playback.AndroidAudioCapabilityDetector
@@ -257,7 +257,7 @@ class ListenUp :
         // Configure WorkManager with custom factory for dependency injection.
         // Must be done before verifyCriticalKoinBindings() because DownloadManager needs WorkManager.
         val workerFactory =
-            DownloadWorkerFactory(
+            ListenUpWorkerFactory(
                 downloadDao = get(),
                 fileManager = get(),
                 tokenProvider = get<AndroidAudioTokenProvider>(),
@@ -265,6 +265,8 @@ class ListenUp :
                 playbackPreferences = get(),
                 playbackApi = get(),
                 capabilityDetector = get(),
+                backupApi = get(),
+                absImportApi = get(),
             )
 
         val workManagerConfig =

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/download/ListenUpWorkerFactory.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/download/ListenUpWorkerFactory.kt
@@ -38,23 +38,31 @@ class ListenUpWorkerFactory(
         workerParameters: WorkerParameters,
     ): ListenableWorker? =
         when (workerClassName) {
-            DownloadWorker::class.java.name -> DownloadWorker(
-                appContext,
-                workerParameters,
-                downloadDao,
-                fileManager,
-                tokenProvider,
-                serverConfig,
-                playbackPreferences,
-                playbackApi,
-                capabilityDetector,
-            )
-            ABSUploadWorker::class.java.name -> ABSUploadWorker(
-                appContext,
-                workerParameters,
-                backupApi,
-                absImportApi,
-            )
-            else -> null
+            DownloadWorker::class.java.name -> {
+                DownloadWorker(
+                    appContext,
+                    workerParameters,
+                    downloadDao,
+                    fileManager,
+                    tokenProvider,
+                    serverConfig,
+                    playbackPreferences,
+                    playbackApi,
+                    capabilityDetector,
+                )
+            }
+
+            ABSUploadWorker::class.java.name -> {
+                ABSUploadWorker(
+                    appContext,
+                    workerParameters,
+                    backupApi,
+                    absImportApi,
+                )
+            }
+
+            else -> {
+                null
+            }
         }
 }

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/download/ListenUpWorkerFactory.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/download/ListenUpWorkerFactory.kt
@@ -5,16 +5,23 @@ import androidx.work.ListenableWorker
 import androidx.work.WorkerFactory
 import androidx.work.WorkerParameters
 import com.calypsan.listenup.client.data.local.db.DownloadDao
+import com.calypsan.listenup.client.data.remote.ABSImportApiContract
+import com.calypsan.listenup.client.data.remote.BackupApiContract
 import com.calypsan.listenup.client.data.remote.PlaybackApi
 import com.calypsan.listenup.client.domain.repository.PlaybackPreferences
 import com.calypsan.listenup.client.domain.repository.ServerConfig
 import com.calypsan.listenup.client.playback.AudioCapabilityDetector
 import com.calypsan.listenup.client.playback.AudioTokenProvider
+import com.calypsan.listenup.client.upload.ABSUploadWorker
 
 /**
- * WorkerFactory for injecting dependencies into DownloadWorker.
+ * WorkerFactory for injecting dependencies into all ListenUp workers.
+ *
+ * Handles creation of:
+ * - [DownloadWorker] — offline audiobook downloads
+ * - [ABSUploadWorker] — Audiobookshelf backup upload and import
  */
-class DownloadWorkerFactory(
+class ListenUpWorkerFactory(
     private val downloadDao: DownloadDao,
     private val fileManager: DownloadFileManager,
     private val tokenProvider: AudioTokenProvider,
@@ -22,14 +29,16 @@ class DownloadWorkerFactory(
     private val playbackPreferences: PlaybackPreferences,
     private val playbackApi: PlaybackApi,
     private val capabilityDetector: AudioCapabilityDetector,
+    private val backupApi: BackupApiContract,
+    private val absImportApi: ABSImportApiContract,
 ) : WorkerFactory() {
     override fun createWorker(
         appContext: Context,
         workerClassName: String,
         workerParameters: WorkerParameters,
     ): ListenableWorker? =
-        if (workerClassName == DownloadWorker::class.java.name) {
-            DownloadWorker(
+        when (workerClassName) {
+            DownloadWorker::class.java.name -> DownloadWorker(
                 appContext,
                 workerParameters,
                 downloadDao,
@@ -40,7 +49,12 @@ class DownloadWorkerFactory(
                 playbackApi,
                 capabilityDetector,
             )
-        } else {
-            null
+            ABSUploadWorker::class.java.name -> ABSUploadWorker(
+                appContext,
+                workerParameters,
+                backupApi,
+                absImportApi,
+            )
+            else -> null
         }
 }

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/backup/ABSUploadSheet.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/backup/ABSUploadSheet.kt
@@ -651,22 +651,24 @@ class ABSUploadSheetState {
             val cacheFile = copyToCache(context, uri, filename)
 
             // Enqueue background worker
-            val workId = ABSUploadWorker.enqueue(
-                context = context,
-                cacheFilePath = cacheFile.absolutePath,
-                filename = filename,
-                fileSize = cacheFile.length(),
-            )
+            val workId =
+                ABSUploadWorker.enqueue(
+                    context = context,
+                    cacheFilePath = cacheFile.absolutePath,
+                    filename = filename,
+                    fileSize = cacheFile.length(),
+                )
 
             activeWorkId = workId
             logger.info { "Enqueued ABS upload worker: workId=$workId, file=${cacheFile.absolutePath}" }
             workId
         } catch (e: Exception) {
             logger.error(e) { "Failed to enqueue upload" }
-            uploadState = ABSUploadState.Error(
-                message = e.message ?: "Failed to prepare upload",
-                filename = filename,
-            )
+            uploadState =
+                ABSUploadState.Error(
+                    message = e.message ?: "Failed to prepare upload",
+                    filename = filename,
+                )
             null
         }
     }
@@ -715,7 +717,8 @@ class ABSUploadSheetState {
      */
     fun getWorkInfoFlow(context: Context): Flow<WorkInfo?>? {
         val workId = activeWorkId ?: return null
-        return WorkManager.getInstance(context)
+        return WorkManager
+            .getInstance(context)
             .getWorkInfoByIdFlow(workId)
     }
 
@@ -747,7 +750,11 @@ class ABSUploadSheetState {
      * This must be called in the foreground because SAF URIs may not persist
      * after the app is backgrounded.
      */
-    private fun copyToCache(context: Context, uri: Uri, filename: String): File {
+    private fun copyToCache(
+        context: Context,
+        uri: Uri,
+        filename: String,
+    ): File {
         val cacheDir = File(context.cacheDir, "abs_uploads")
         cacheDir.mkdirs()
 

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/backup/ABSUploadSheet.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/backup/ABSUploadSheet.kt
@@ -700,7 +700,7 @@ class ABSUploadSheetState {
             }
 
             WorkInfo.State.FAILED -> {
-                val error = workInfo.outputData.getString("error") ?: "Upload failed"
+                val error = workInfo.outputData.getString(ABSUploadWorker.KEY_ERROR) ?: "Upload failed"
                 uploadState = ABSUploadState.Error(message = error, filename = filename)
                 activeWorkId = null
             }

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/backup/AdminBackupScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/backup/AdminBackupScreen.kt
@@ -44,7 +44,6 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/upload/ABSUploadWorker.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/upload/ABSUploadWorker.kt
@@ -47,7 +47,6 @@ class ABSUploadWorker(
     private val backupApi: BackupApiContract,
     private val absImportApi: ABSImportApiContract,
 ) : CoroutineWorker(context, params) {
-
     companion object {
         const val KEY_CACHE_FILE_PATH = "cache_file_path"
         const val KEY_FILENAME = "filename"
@@ -69,15 +68,17 @@ class ABSUploadWorker(
             filename: String,
             fileSize: Long,
         ): UUID {
-            val data = workDataOf(
-                KEY_CACHE_FILE_PATH to cacheFilePath,
-                KEY_FILENAME to filename,
-                KEY_FILE_SIZE to fileSize,
-            )
+            val data =
+                workDataOf(
+                    KEY_CACHE_FILE_PATH to cacheFilePath,
+                    KEY_FILENAME to filename,
+                    KEY_FILE_SIZE to fileSize,
+                )
 
-            val request = OneTimeWorkRequestBuilder<ABSUploadWorker>()
-                .setInputData(data)
-                .build()
+            val request =
+                OneTimeWorkRequestBuilder<ABSUploadWorker>()
+                    .setInputData(data)
+                    .build()
 
             WorkManager.getInstance(context).enqueue(request)
             return request.id
@@ -85,10 +86,12 @@ class ABSUploadWorker(
     }
 
     override suspend fun doWork(): Result {
-        val cacheFilePath = inputData.getString(KEY_CACHE_FILE_PATH)
-            ?: return Result.failure(workDataOf("error" to "Missing cache file path"))
-        val filename = inputData.getString(KEY_FILENAME)
-            ?: return Result.failure(workDataOf("error" to "Missing filename"))
+        val cacheFilePath =
+            inputData.getString(KEY_CACHE_FILE_PATH)
+                ?: return Result.failure(workDataOf("error" to "Missing cache file path"))
+        val filename =
+            inputData.getString(KEY_FILENAME)
+                ?: return Result.failure(workDataOf("error" to "Missing filename"))
 
         val cacheFile = File(cacheFilePath)
 
@@ -114,6 +117,7 @@ class ABSUploadWorker(
                     logger.info { "Import created: id=$importId" }
                     Result.success(workDataOf(KEY_IMPORT_ID to importId))
                 }
+
                 is Failure -> {
                     val error = importResult.exception?.message ?: "Failed to create import"
                     logger.error { "Import creation failed: $error" }
@@ -146,21 +150,24 @@ class ABSUploadWorker(
 
         // Create notification channel (required for Android 8+)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val channel = NotificationChannel(
-                CHANNEL_ID,
-                CHANNEL_NAME,
-                NotificationManager.IMPORTANCE_LOW,
-            )
+            val channel =
+                NotificationChannel(
+                    CHANNEL_ID,
+                    CHANNEL_NAME,
+                    NotificationManager.IMPORTANCE_LOW,
+                )
             notificationManager.createNotificationChannel(channel)
         }
 
-        val notification = NotificationCompat.Builder(applicationContext, CHANNEL_ID)
-            .setContentTitle("Uploading ABS Backup")
-            .setContentText("Importing Audiobookshelf backup…")
-            .setSmallIcon(android.R.drawable.stat_sys_upload)
-            .setProgress(0, 0, true)
-            .setOngoing(true)
-            .build()
+        val notification =
+            NotificationCompat
+                .Builder(applicationContext, CHANNEL_ID)
+                .setContentTitle("Uploading ABS Backup")
+                .setContentText("Importing Audiobookshelf backup…")
+                .setSmallIcon(android.R.drawable.stat_sys_upload)
+                .setProgress(0, 0, true)
+                .setOngoing(true)
+                .build()
 
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             ForegroundInfo(

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/upload/ABSUploadWorker.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/upload/ABSUploadWorker.kt
@@ -52,6 +52,7 @@ class ABSUploadWorker(
         const val KEY_FILENAME = "filename"
         const val KEY_FILE_SIZE = "file_size"
         const val KEY_IMPORT_ID = "import_id"
+        const val KEY_ERROR = "error"
 
         /**
          * Enqueue an upload work request.
@@ -88,10 +89,10 @@ class ABSUploadWorker(
     override suspend fun doWork(): Result {
         val cacheFilePath =
             inputData.getString(KEY_CACHE_FILE_PATH)
-                ?: return Result.failure(workDataOf("error" to "Missing cache file path"))
+                ?: return Result.failure(workDataOf(KEY_ERROR to "Missing cache file path"))
         val filename =
             inputData.getString(KEY_FILENAME)
-                ?: return Result.failure(workDataOf("error" to "Missing filename"))
+                ?: return Result.failure(workDataOf(KEY_ERROR to "Missing filename"))
 
         val cacheFile = File(cacheFilePath)
 
@@ -100,7 +101,7 @@ class ABSUploadWorker(
 
             if (!cacheFile.exists()) {
                 logger.error { "Cache file does not exist: $cacheFilePath" }
-                return Result.failure(workDataOf("error" to "Cache file not found"))
+                return Result.failure(workDataOf(KEY_ERROR to "Cache file not found"))
             }
 
             logger.info { "Starting ABS upload: filename=$filename, size=${cacheFile.length()}" }
@@ -141,7 +142,7 @@ class ABSUploadWorker(
             logger.info { "Retrying upload (attempt ${runAttemptCount + 1}/$MAX_RUN_ATTEMPTS)" }
             Result.retry()
         } else {
-            Result.failure(workDataOf("error" to errorMessage))
+            Result.failure(workDataOf(KEY_ERROR to errorMessage))
         }
 
     private fun createForegroundInfo(): ForegroundInfo {

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/upload/ABSUploadWorker.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/upload/ABSUploadWorker.kt
@@ -1,0 +1,175 @@
+package com.calypsan.listenup.client.upload
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.content.pm.ServiceInfo
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.work.CoroutineWorker
+import androidx.work.ForegroundInfo
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import androidx.work.workDataOf
+import com.calypsan.listenup.client.core.Failure
+import com.calypsan.listenup.client.core.Success
+import com.calypsan.listenup.client.data.remote.ABSImportApiContract
+import com.calypsan.listenup.client.data.remote.BackupApiContract
+import io.github.oshai.kotlinlogging.KotlinLogging
+import java.io.File
+import java.util.UUID
+
+private val logger = KotlinLogging.logger {}
+
+private const val CHANNEL_ID = "abs_upload"
+private const val CHANNEL_NAME = "ABS Import Upload"
+private const val NOTIFICATION_ID = 9001
+private const val MAX_RUN_ATTEMPTS = 3
+
+/**
+ * Background worker that uploads an Audiobookshelf backup and creates an import.
+ *
+ * Runs as a foreground service with [FOREGROUND_SERVICE_TYPE_DATA_SYNC][ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC]
+ * so the upload survives app backgrounding.
+ *
+ * Input data:
+ * - [KEY_CACHE_FILE_PATH] — absolute path to the cached backup file
+ * - [KEY_FILENAME] — original display filename
+ * - [KEY_FILE_SIZE] — file size in bytes
+ *
+ * Output data:
+ * - [KEY_IMPORT_ID] — the created import ID on success
+ */
+class ABSUploadWorker(
+    context: Context,
+    params: WorkerParameters,
+    private val backupApi: BackupApiContract,
+    private val absImportApi: ABSImportApiContract,
+) : CoroutineWorker(context, params) {
+
+    companion object {
+        const val KEY_CACHE_FILE_PATH = "cache_file_path"
+        const val KEY_FILENAME = "filename"
+        const val KEY_FILE_SIZE = "file_size"
+        const val KEY_IMPORT_ID = "import_id"
+
+        /**
+         * Enqueue an upload work request.
+         *
+         * @param context Android context
+         * @param cacheFilePath Absolute path to the cached backup file
+         * @param filename Original display filename
+         * @param fileSize File size in bytes
+         * @return The work request UUID for observation
+         */
+        fun enqueue(
+            context: Context,
+            cacheFilePath: String,
+            filename: String,
+            fileSize: Long,
+        ): UUID {
+            val data = workDataOf(
+                KEY_CACHE_FILE_PATH to cacheFilePath,
+                KEY_FILENAME to filename,
+                KEY_FILE_SIZE to fileSize,
+            )
+
+            val request = OneTimeWorkRequestBuilder<ABSUploadWorker>()
+                .setInputData(data)
+                .build()
+
+            WorkManager.getInstance(context).enqueue(request)
+            return request.id
+        }
+    }
+
+    override suspend fun doWork(): Result {
+        val cacheFilePath = inputData.getString(KEY_CACHE_FILE_PATH)
+            ?: return Result.failure(workDataOf("error" to "Missing cache file path"))
+        val filename = inputData.getString(KEY_FILENAME)
+            ?: return Result.failure(workDataOf("error" to "Missing filename"))
+
+        val cacheFile = File(cacheFilePath)
+
+        return try {
+            setForeground(createForegroundInfo())
+
+            if (!cacheFile.exists()) {
+                logger.error { "Cache file does not exist: $cacheFilePath" }
+                return Result.failure(workDataOf("error" to "Cache file not found"))
+            }
+
+            logger.info { "Starting ABS upload: filename=$filename, size=${cacheFile.length()}" }
+
+            // Upload the backup file
+            val fileSource = CachedFileSource(cacheFile, filename)
+            val uploadResponse = backupApi.uploadABSBackup(fileSource)
+            logger.info { "Upload complete, server path: ${uploadResponse.path}" }
+
+            // Create the import from the uploaded file
+            when (val importResult = absImportApi.createImportFromPath(uploadResponse.path, filename)) {
+                is Success -> {
+                    val importId = importResult.data.id
+                    logger.info { "Import created: id=$importId" }
+                    Result.success(workDataOf(KEY_IMPORT_ID to importId))
+                }
+                is Failure -> {
+                    val error = importResult.exception?.message ?: "Failed to create import"
+                    logger.error { "Import creation failed: $error" }
+                    retryOrFail(error)
+                }
+            }
+        } catch (e: Exception) {
+            logger.error(e) { "ABS upload failed" }
+            retryOrFail(e.message ?: "Upload failed")
+        } finally {
+            // Clean up cache file
+            if (cacheFile.exists()) {
+                val deleted = cacheFile.delete()
+                logger.debug { "Cache file cleanup: deleted=$deleted, path=$cacheFilePath" }
+            }
+        }
+    }
+
+    private fun retryOrFail(errorMessage: String): Result =
+        if (runAttemptCount < MAX_RUN_ATTEMPTS) {
+            logger.info { "Retrying upload (attempt ${runAttemptCount + 1}/$MAX_RUN_ATTEMPTS)" }
+            Result.retry()
+        } else {
+            Result.failure(workDataOf("error" to errorMessage))
+        }
+
+    private fun createForegroundInfo(): ForegroundInfo {
+        val notificationManager =
+            applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+        // Create notification channel (required for Android 8+)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                CHANNEL_NAME,
+                NotificationManager.IMPORTANCE_LOW,
+            )
+            notificationManager.createNotificationChannel(channel)
+        }
+
+        val notification = NotificationCompat.Builder(applicationContext, CHANNEL_ID)
+            .setContentTitle("Uploading ABS Backup")
+            .setContentText("Importing Audiobookshelf backup…")
+            .setSmallIcon(android.R.drawable.stat_sys_upload)
+            .setProgress(0, 0, true)
+            .setOngoing(true)
+            .build()
+
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            ForegroundInfo(
+                NOTIFICATION_ID,
+                notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
+            )
+        } else {
+            ForegroundInfo(NOTIFICATION_ID, notification)
+        }
+    }
+}

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/upload/CachedFileSource.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/upload/CachedFileSource.kt
@@ -1,0 +1,27 @@
+package com.calypsan.listenup.client.upload
+
+import com.calypsan.listenup.client.core.FileSource
+import io.ktor.utils.io.ByteReadChannel
+import io.ktor.utils.io.jvm.javaio.toByteReadChannel
+import java.io.File
+import java.io.FileInputStream
+
+/**
+ * [FileSource] implementation backed by a [java.io.File] in the app cache directory.
+ *
+ * Used by [ABSUploadWorker] to stream a previously-cached file during background upload.
+ * The file must already exist on disk (copied from the content URI while in the foreground).
+ *
+ * @param file The cached file on disk
+ * @param name The original display filename
+ */
+class CachedFileSource(
+    private val file: File,
+    private val name: String,
+) : FileSource {
+    override val filename: String get() = name
+    override val size: Long? get() = file.length()
+
+    override fun openChannel(): ByteReadChannel =
+        FileInputStream(file).toByteReadChannel()
+}

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/upload/CachedFileSource.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/upload/CachedFileSource.kt
@@ -22,6 +22,5 @@ class CachedFileSource(
     override val filename: String get() = name
     override val size: Long? get() = file.length()
 
-    override fun openChannel(): ByteReadChannel =
-        FileInputStream(file).toByteReadChannel()
+    override fun openChannel(): ByteReadChannel = FileInputStream(file).toByteReadChannel()
 }

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/util/DocumentPickerState.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/util/DocumentPickerState.kt
@@ -33,6 +33,7 @@ sealed interface DocumentPickerResult {
         val filename: String,
         val mimeType: String,
         val size: Long,
+        val uri: Uri,
     ) : DocumentPickerResult
 
     /** User cancelled the picker. */
@@ -131,6 +132,7 @@ class DocumentPickerState(
             filename = filename,
             mimeType = mimeType,
             size = size ?: 0L,
+            uri = uri,
         )
     }
 }


### PR DESCRIPTION
## Changes

Moves ABS backup upload to a WorkManager `CoroutineWorker` with a foreground notification, so the upload survives app backgrounding.

**New files:**
- `ABSUploadWorker` — `CoroutineWorker` with `FOREGROUND_SERVICE_TYPE_DATA_SYNC`, handles upload + import creation, retries up to 3x, cleans up cache file
- `CachedFileSource` — `FileSource` backed by `java.io.File` for worker access
- `ListenUpWorkerFactory` — replaces `DownloadWorkerFactory`, handles both `DownloadWorker` and `ABSUploadWorker`

**Modified:**
- `ABSUploadSheetState` — copies file to cache in foreground, enqueues WorkManager job, observes `WorkInfo` for reactive state updates
- `DocumentPickerResult.Success` — now includes raw `Uri` for cache copying
- `AdminBackupScreen` — wires WorkManager observation via `LaunchedEffect`
- `AndroidManifest` — adds `FOREGROUND_SERVICE_DATA_SYNC` permission

**How it works:**
1. User picks file → SAF returns content URI
2. File copied to app cache dir (foreground, before WorkManager)
3. `ABSUploadWorker` enqueued — uploads from cache file, creates import, returns import ID
4. UI observes `WorkInfo` flow for state transitions
5. Cache file cleaned up in `finally` block

Closes #110