### PR TITLE
🐛 Fix autocomplete tap and book title display in ABS import

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/ListenUpAutocompleteField.kt
+++ b/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/ListenUpAutocompleteField.kt
@@ -21,6 +21,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.stringResource
@@ -114,11 +115,12 @@ fun AutocompleteResultItem(
         )
     },
 ) {
+    val keyboardController = LocalSoftwareKeyboardController.current
     Row(
         modifier =
             modifier
                 .fillMaxWidth()
-                .clickable(onClick = onClick)
+                .clickable { keyboardController?.hide(); onClick() }
                 .padding(horizontal = 16.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {

--- a/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/ListenUpAutocompleteField.kt
+++ b/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/ListenUpAutocompleteField.kt
@@ -120,8 +120,10 @@ fun AutocompleteResultItem(
         modifier =
             modifier
                 .fillMaxWidth()
-                .clickable { keyboardController?.hide(); onClick() }
-                .padding(horizontal = 16.dp, vertical = 12.dp),
+                .clickable {
+                    keyboardController?.hide()
+                    onClick()
+                }.padding(horizontal = 16.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         leadingIcon()

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/admin/ABSImportViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/admin/ABSImportViewModel.kt
@@ -461,12 +461,11 @@ class ABSImportViewModel(
                                         durationMs = suggestion.durationMs,
                                     )
                                 } else {
-                                    // Last resort: create display with match reason as subtitle
-                                    // This ensures the book shows as matched even without full details
+                                    // No suggestions available — use ABS metadata for display
                                     SelectedBookDisplay(
                                         bookId = listenupId,
-                                        title = "Matched book",
-                                        author = match.matchReason,
+                                        title = match.absTitle,
+                                        author = match.absAuthor,
                                         durationMs = null,
                                     )
                                 }


### PR DESCRIPTION
Fixes #131 and #132

## Changes
- **Keyboard dismiss on result tap**: `AutocompleteResultItem` now calls `LocalSoftwareKeyboardController.hide()` before firing `onClick()`. On Android, the first tap outside a focused TextField is normally consumed by the keyboard dismiss — this ensures the click registers on the first tap.
- **Book titles on All tab**: Fixed book mapping All tab to display actual title and author instead of raw IDs/placeholder text.