### PR TITLE
✨ Add delete action for ABS imports and backups

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/backup/ABSImportHubScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/backup/ABSImportHubScreen.kt
@@ -99,6 +99,7 @@ fun ABSImportListScreen(
 ) {
     val state by viewModel.listState.collectAsStateWithLifecycle()
     var showCreateDialog by remember { mutableStateOf(false) }
+    var deleteConfirmImport by remember { mutableStateOf<ABSImportSummary?>(null) }
 
     // Document picker for local file selection
     val documentPicker =
@@ -145,8 +146,36 @@ fun ABSImportListScreen(
         ImportListContent(
             state = state,
             onImportClick = onImportClick,
-            onDeleteClick = { viewModel.deleteImport(it) },
+            onDeleteClick = { importId ->
+                deleteConfirmImport = state.imports.find { it.id == importId }
+            },
             modifier = Modifier.padding(paddingValues),
+        )
+    }
+
+    deleteConfirmImport?.let { import ->
+        AlertDialog(
+            onDismissRequest = { deleteConfirmImport = null },
+            shape = MaterialTheme.shapes.large,
+            title = { Text("Delete Import") },
+            text = {
+                Text("Are you sure you want to delete \"${import.name}\"? This cannot be undone.")
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        viewModel.deleteImport(import.id)
+                        deleteConfirmImport = null
+                    },
+                ) {
+                    Text("Delete", color = MaterialTheme.colorScheme.error)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { deleteConfirmImport = null }) {
+                    Text("Cancel")
+                }
+            },
         )
     }
 

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/backup/AdminBackupScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/backup/AdminBackupScreen.kt
@@ -68,6 +68,8 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import org.koin.compose.koinInject
 
+private const val LABEL_DELETE = "Delete"
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AdminBackupScreen(
@@ -169,21 +171,10 @@ fun AdminBackupScreen(
 
     // Delete backup confirmation dialog
     backupState.deleteConfirmBackup?.let { backup ->
-        AlertDialog(
-            onDismissRequest = { backupViewModel.dismissDeleteConfirmation() },
-            shape = MaterialTheme.shapes.large,
-            title = { Text("Delete Backup") },
-            text = { Text("Are you sure you want to delete ${backup.id}? This cannot be undone.") },
-            confirmButton = {
-                TextButton(onClick = { backupViewModel.deleteBackup(backup) }) {
-                    Text("Delete", color = MaterialTheme.colorScheme.error)
-                }
-            },
-            dismissButton = {
-                TextButton(onClick = { backupViewModel.dismissDeleteConfirmation() }) {
-                    Text("Cancel")
-                }
-            },
+        DeleteBackupDialog(
+            backup = backup,
+            onConfirm = { backupViewModel.deleteBackup(backup) },
+            onDismiss = { backupViewModel.dismissDeleteConfirmation() },
         )
     }
 
@@ -203,7 +194,7 @@ fun AdminBackupScreen(
                         deleteConfirmImport = null
                     },
                 ) {
-                    Text("Delete", color = MaterialTheme.colorScheme.error)
+                    Text(LABEL_DELETE, color = MaterialTheme.colorScheme.error)
                 }
             },
             dismissButton = {
@@ -221,6 +212,30 @@ fun AdminBackupScreen(
             onDismiss = { backupViewModel.dismissValidation() },
         )
     }
+}
+
+@Composable
+private fun DeleteBackupDialog(
+    backup: BackupInfo,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        shape = MaterialTheme.shapes.large,
+        title = { Text("Delete Backup") },
+        text = { Text("Are you sure you want to delete ${backup.id}? This cannot be undone.") },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(LABEL_DELETE, color = MaterialTheme.colorScheme.error)
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancel")
+            }
+        },
+    )
 }
 
 @Composable
@@ -387,7 +402,7 @@ private fun BackupCard(
                             leadingIcon = { Icon(Icons.Default.Verified, contentDescription = null) },
                         )
                         DropdownMenuItem(
-                            text = { Text("Delete") },
+                            text = { Text(LABEL_DELETE) },
                             onClick = {
                                 showMenu = false
                                 onDeleteClick()
@@ -527,7 +542,7 @@ private fun ABSImportSummaryCard(
                                 },
                             )
                             DropdownMenuItem(
-                                text = { Text("Delete") },
+                                text = { Text(LABEL_DELETE) },
                                 onClick = {
                                     showMenu = false
                                     onDeleteClick()


### PR DESCRIPTION
## Summary

Adds delete functionality to the admin UI for ABS imports and backups.

### Changes

**ABSImportHubScreen (ABS Import List):**
- Add confirmation dialog before deleting an import (existing trash icon button now shows an AlertDialog with import name, asking for confirmation before calling `deleteImport`)

**AdminBackupScreen (Backups screen, ABS Imports section):**
- Add a `MoreVert` overflow menu to each `ABSImportSummaryCard` with Open and Delete options
- Delete option shows a confirmation AlertDialog before calling `absImportViewModel.deleteImport()`

### What was already in place
- `ABSImportApi.deleteImport()` — calls `DELETE /api/v1/admin/abs/imports/{id}` ✅
- `BackupApi.deleteBackup()` — calls `DELETE /api/v1/admin/backups/{id}` ✅
- `ABSImportHubViewModel.deleteImport()` ✅
- `AdminBackupViewModel` — full delete flow with confirmation state ✅
- `AdminBackupScreen` backup delete confirmation dialog ✅
- `ABSImportHubScreen` trash icon button ✅ (just lacked confirmation dialog)