### PR TITLE
✨ Handle analyzing status: polling + UI

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/backup/ABSImportHubScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/backup/ABSImportHubScreen.kt
@@ -1,7 +1,6 @@
 @file:Suppress("LongMethod", "LongParameterList", "CognitiveComplexMethod")
 
 package com.calypsan.listenup.client.features.admin.backup
-
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -85,6 +84,7 @@ import com.calypsan.listenup.client.presentation.admin.ImportHubTab
 import com.calypsan.listenup.client.util.DocumentPickerResult
 import com.calypsan.listenup.client.util.rememberABSBackupPicker
 import org.koin.compose.koinInject
+private const val IMPORT_STATUS_ANALYZING = "analyzing"
 
 // ============================================================
 // Import List Screen
@@ -336,7 +336,7 @@ private fun ImportSummaryCard(
                 )
             }
 
-            if (import.status == "analyzing") {
+            if (import.status == IMPORT_STATUS_ANALYZING) {
                 Spacer(modifier = Modifier.height(12.dp))
                 LinearProgressIndicator(
                     modifier = Modifier.fillMaxWidth(),
@@ -434,7 +434,7 @@ private fun StatusBadge(
                 )
             }
 
-            "analyzing" -> {
+            IMPORT_STATUS_ANALYZING -> {
                 Triple(
                     MaterialTheme.colorScheme.secondaryContainer,
                     MaterialTheme.colorScheme.onSecondaryContainer,
@@ -638,7 +638,7 @@ private fun ImportHubContent(
 ) {
     Column(modifier = modifier.fillMaxSize()) {
         // Analyzing banner
-        if (state.import?.status == "analyzing") {
+        if (state.import?.status == IMPORT_STATUS_ANALYZING) {
             Surface(
                 modifier = Modifier.fillMaxWidth(),
                 color = MaterialTheme.colorScheme.secondaryContainer,
@@ -659,7 +659,7 @@ private fun ImportHubContent(
         }
 
         // Tab row
-        val tabsEnabled = state.import?.status != "analyzing"
+        val tabsEnabled = state.import?.status != IMPORT_STATUS_ANALYZING
         PrimaryTabRow(selectedTabIndex = state.activeTab.ordinal) {
             ImportHubTab.entries.forEach { tab ->
                 Tab(

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/backup/ABSImportHubScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/backup/ABSImportHubScreen.kt
@@ -47,6 +47,7 @@ import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.PrimaryTabRow
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
@@ -335,7 +336,18 @@ private fun ImportSummaryCard(
                 )
             }
 
-            if (import.totalSessions > 0) {
+            if (import.status == "analyzing") {
+                Spacer(modifier = Modifier.height(12.dp))
+                LinearProgressIndicator(
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = "Analyzing backup…",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            } else if (import.totalSessions > 0) {
                 Spacer(modifier = Modifier.height(12.dp))
                 LinearProgressIndicator(
                     progress = { progress },
@@ -419,6 +431,22 @@ private fun StatusBadge(
                     MaterialTheme.colorScheme.surfaceContainerHighest,
                     MaterialTheme.colorScheme.onSurfaceVariant,
                     "Archived",
+                )
+            }
+
+            "analyzing" -> {
+                Triple(
+                    MaterialTheme.colorScheme.secondaryContainer,
+                    MaterialTheme.colorScheme.onSecondaryContainer,
+                    "Analyzing…",
+                )
+            }
+
+            "failed" -> {
+                Triple(
+                    MaterialTheme.colorScheme.errorContainer,
+                    MaterialTheme.colorScheme.onErrorContainer,
+                    "Failed",
                 )
             }
 
@@ -609,12 +637,35 @@ private fun ImportHubContent(
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier.fillMaxSize()) {
+        // Analyzing banner
+        if (state.import?.status == "analyzing") {
+            Surface(
+                modifier = Modifier.fillMaxWidth(),
+                color = MaterialTheme.colorScheme.secondaryContainer,
+            ) {
+                Column(
+                    modifier = Modifier.padding(16.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Text(
+                        text = "Analysis in progress…",
+                        style = MaterialTheme.typography.titleSmall,
+                        color = MaterialTheme.colorScheme.onSecondaryContainer,
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                }
+            }
+        }
+
         // Tab row
+        val tabsEnabled = state.import?.status != "analyzing"
         PrimaryTabRow(selectedTabIndex = state.activeTab.ordinal) {
             ImportHubTab.entries.forEach { tab ->
                 Tab(
                     selected = state.activeTab == tab,
-                    onClick = { onTabChange(tab) },
+                    onClick = { if (tabsEnabled || tab == ImportHubTab.OVERVIEW) onTabChange(tab) },
+                    enabled = tabsEnabled || tab == ImportHubTab.OVERVIEW,
                     text = { Text(tab.name.lowercase().replaceFirstChar { it.uppercase() }) },
                 )
             }

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ABSImportApi.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ABSImportApi.kt
@@ -724,8 +724,8 @@ class ABSImportApi(
             val response: ApiResponse<ImportSessionsResult> =
                 client.post("/api/v1/admin/abs/imports/$importId/sessions/import") {
                     timeout {
-                        requestTimeoutMillis = 30 * 1000
-                        socketTimeoutMillis = 30 * 1000
+                        requestTimeoutMillis = 5 * 60 * 1000
+                        socketTimeoutMillis = 5 * 60 * 1000
                     }
                 }.body()
 

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ABSImportApi.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ABSImportApi.kt
@@ -480,8 +480,8 @@ class ABSImportApi(
                 client.post("/api/v1/admin/abs/imports") {
                     setBody(CreateImportRequest(backupPath = backupPath, name = name))
                     timeout {
-                        requestTimeoutMillis = 5 * 60 * 1000
-                        socketTimeoutMillis = 5 * 60 * 1000
+                        requestTimeoutMillis = 30 * 1000
+                        socketTimeoutMillis = 30 * 1000
                     }
                 }.body()
 
@@ -724,8 +724,8 @@ class ABSImportApi(
             val response: ApiResponse<ImportSessionsResult> =
                 client.post("/api/v1/admin/abs/imports/$importId/sessions/import") {
                     timeout {
-                        requestTimeoutMillis = 5 * 60 * 1000
-                        socketTimeoutMillis = 5 * 60 * 1000
+                        requestTimeoutMillis = 30 * 1000
+                        socketTimeoutMillis = 30 * 1000
                     }
                 }.body()
 

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/admin/ABSImportHubViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/admin/ABSImportHubViewModel.kt
@@ -30,6 +30,9 @@ import kotlinx.coroutines.launch
 
 private val logger = KotlinLogging.logger {}
 
+private const val IMPORT_STATUS_ANALYZING = "analyzing"
+private const val ANALYSIS_POLL_INTERVAL_MS = 3_000L
+
 /**
  * Tab in the import hub detail view.
  */
@@ -142,7 +145,7 @@ class ABSImportHubViewModel(
                 is Success -> {
                     listState.update { it.copy(isCreating = false) }
                     loadImports() // Refresh list
-                    if (result.data.status == "analyzing") {
+                    if (result.data.status == IMPORT_STATUS_ANALYZING) {
                         startAnalysisPolling(result.data.id)
                     }
                 }
@@ -171,7 +174,7 @@ class ABSImportHubViewModel(
         when (val result = absImportApi.createImport(fileSource, name)) {
             is Success -> {
                 loadImports() // Refresh list in background
-                if (result.data.status == "analyzing") {
+                if (result.data.status == IMPORT_STATUS_ANALYZING) {
                     startAnalysisPolling(result.data.id)
                 }
                 Success(result.data.id)
@@ -197,7 +200,7 @@ class ABSImportHubViewModel(
                 is Success -> {
                     listState.update { it.copy(isCreating = false) }
                     loadImports() // Refresh list
-                    if (result.data.status == "analyzing") {
+                    if (result.data.status == IMPORT_STATUS_ANALYZING) {
                         startAnalysisPolling(result.data.id)
                     }
                 }
@@ -653,7 +656,7 @@ class ABSImportHubViewModel(
         analysisPollingJob =
             viewModelScope.launch {
                 while (true) {
-                    delay(3000)
+                    delay(ANALYSIS_POLL_INTERVAL_MS)
                     when (val result = absImportApi.getImport(importId)) {
                         is Success -> {
                             val imp = result.data
@@ -686,7 +689,7 @@ class ABSImportHubViewModel(
                                         },
                                 )
                             }
-                            if (imp.status != "analyzing") {
+                            if (imp.status != IMPORT_STATUS_ANALYZING) {
                                 logger.info { "Import $importId analysis complete: ${imp.status}" }
                                 break
                             }


### PR DESCRIPTION
## Changes

Companion to ListenUpApp/server#43 which makes import creation async.

### Timeout reduction
- `createImportFromPath`: 5min → 30s (server now returns immediately)
- `importReadySessions`: kept at 30s (unchanged, already fast)

### Polling for analysis completion
- After creating an import that returns `status: "analyzing"`, ViewModel polls `getImport()` every 3s
- Updates both list and hub states on each poll
- Stops when status changes to `active` or `failed`
- Cancelled in `onCleared()`

### UI changes
- **Import list**: analyzing imports show indeterminate `LinearProgressIndicator` with "Analyzing backup…" text
- **Hub screen**: analyzing imports show a banner ("Analysis in progress…") with progress bar; Users/Books/Sessions tabs disabled until analysis completes
- **StatusBadge**: added `analyzing` (secondary color) and `failed` (error color) states