### PR TITLE
fix: throttle cover downloads to prevent server saturation

### DIFF
--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/CoverDownloadWorker.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/CoverDownloadWorker.kt
@@ -6,12 +6,15 @@ import com.calypsan.listenup.client.data.local.db.CoverDownloadDao
 import com.calypsan.listenup.client.data.local.db.CoverDownloadStatus
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
 private val logger = KotlinLogging.logger {}
+
+private const val COVER_DOWNLOAD_DELAY_MS = 500L
 
 /**
  * Processes the persistent cover download queue.
@@ -118,6 +121,8 @@ class CoverDownloadWorker(
                         coverDownloadDao.markFailed(task.bookId, e.message)
                         logger.warn(e) { "Cover download error: ${task.bookId.value}" }
                     }
+
+                    delay(COVER_DOWNLOAD_DELAY_MS)
                 }
             }
 

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/CoverDownloadWorkerTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/CoverDownloadWorkerTest.kt
@@ -1,0 +1,64 @@
+package com.calypsan.listenup.client.data.sync
+
+import com.calypsan.listenup.client.core.BookId
+import com.calypsan.listenup.client.core.Result
+import com.calypsan.listenup.client.core.Success
+import com.calypsan.listenup.client.core.Timestamp
+import com.calypsan.listenup.client.data.local.db.CoverDownloadDao
+import com.calypsan.listenup.client.data.local.db.CoverDownloadStatus
+import com.calypsan.listenup.client.data.local.db.CoverDownloadTaskEntity
+import dev.mokkery.answering.returns
+import dev.mokkery.answering.sequentiallyReturns
+import dev.mokkery.every
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.currentTime
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CoverDownloadWorkerTest {
+    private fun createTask(id: String) =
+        CoverDownloadTaskEntity(
+            bookId = BookId(id),
+            status = CoverDownloadStatus.PENDING,
+            attempts = 0,
+            createdAt = Timestamp.now(),
+        )
+
+    @Test
+    fun `processQueue delays between each download`() =
+        runTest {
+            val dao: CoverDownloadDao = mock()
+            val downloader: ImageDownloaderContract = mock()
+
+            val tasks = listOf(createTask("a"), createTask("b"), createTask("c"))
+
+            // First call returns tasks, second returns empty to stop loop
+            everySuspend { dao.getNextBatch(limit = any()) } sequentiallyReturns listOf(tasks, emptyList())
+            everySuspend { dao.markInProgress(any()) } returns Unit
+            everySuspend { dao.markCompleted(any()) } returns Unit
+            everySuspend { dao.observeRemainingCount() } returns flowOf(0)
+            everySuspend { dao.observeCompletedCount() } returns flowOf(0)
+            everySuspend { dao.observeTotalCount() } returns flowOf(0)
+            everySuspend { downloader.downloadCover(any()) } returns Success(true)
+
+            val worker = CoverDownloadWorker(dao, downloader)
+
+            val startTime = currentTime
+            worker.processQueue()
+            val elapsed = currentTime - startTime
+
+            // 3 tasks * 500ms delay = 1500ms minimum
+            val expectedMinimum = 3 * 500L
+            assertTrue(
+                elapsed >= expectedMinimum,
+                "Expected at least ${expectedMinimum}ms but took ${elapsed}ms",
+            )
+        }
+}


### PR DESCRIPTION
Adds a 500ms delay between each cover download in `CoverDownloadWorker.processQueue()` to prevent server saturation during initial sync with 1000+ books.

Covers already display via Coil's server URL fallback, so the download queue is just pre-caching for offline use — no rush needed.

## Changes
- Add `COVER_DOWNLOAD_DELAY_MS = 500L` constant
- Add `delay()` after each download attempt in the processing loop
- Add unit test verifying throttling behavior with `StandardTestDispatcher`