### PR TITLE
🐛 Only clear auth session on 401/403, preserve tokens on transient errors

### DIFF
--- a/shared/src/androidMain/kotlin/com/calypsan/listenup/client/data/remote/ApiClientFactory.android.kt
+++ b/shared/src/androidMain/kotlin/com/calypsan/listenup/client/data/remote/ApiClientFactory.android.kt
@@ -75,29 +75,7 @@ internal actual suspend fun createStreamingHttpClient(
                 }
 
                 refreshTokens {
-                    val currentRefreshToken =
-                        authSession.getRefreshToken()
-                            ?: error("No refresh token available")
-
-                    try {
-                        val response = authApi.refresh(currentRefreshToken)
-
-                        authSession.saveAuthTokens(
-                            access = AccessToken(response.accessToken),
-                            refresh = RefreshToken(response.refreshToken),
-                            sessionId = response.sessionId,
-                            userId = response.userId,
-                        )
-
-                        BearerTokens(
-                            accessToken = response.accessToken,
-                            refreshToken = response.refreshToken,
-                        )
-                    } catch (e: Exception) {
-                        logger.warn(e) { "Token refresh failed, clearing auth state" }
-                        authSession.clearAuthTokens()
-                        null
-                    }
+                    refreshAuthTokens(authSession, authApi)
                 }
 
                 sendWithoutRequest { request ->

--- a/shared/src/androidMain/kotlin/com/calypsan/listenup/client/data/remote/ApiClientFactory.android.kt
+++ b/shared/src/androidMain/kotlin/com/calypsan/listenup/client/data/remote/ApiClientFactory.android.kt
@@ -1,7 +1,5 @@
 package com.calypsan.listenup.client.data.remote
 
-import com.calypsan.listenup.client.core.AccessToken
-import com.calypsan.listenup.client.core.RefreshToken
 import com.calypsan.listenup.client.core.ServerUrl
 import com.calypsan.listenup.client.domain.repository.AuthSession
 import io.github.oshai.kotlinlogging.KotlinLogging

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ApiClientFactory.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ApiClientFactory.kt
@@ -27,6 +27,8 @@ import io.ktor.client.plugins.plugin
 import kotlinx.serialization.json.Json
 
 private const val SERVER_URL_NOT_CONFIGURED_MESSAGE = "Server URL not configured"
+private const val HTTP_UNAUTHORIZED = 401
+private const val HTTP_FORBIDDEN = 403
 private val logger = KotlinLogging.logger {}
 
 /**
@@ -334,7 +336,7 @@ internal suspend fun refreshAuthTokens(
         )
     } catch (e: ResponseException) {
         val status = e.response.status.value
-        if (status == 401 || status == 403) {
+        if (status == HTTP_UNAUTHORIZED || status == HTTP_FORBIDDEN) {
             logger.warn(e) { "Token refresh rejected ($status), clearing auth state" }
             authSession.clearAuthTokens()
         } else {

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ApiClientFactory.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ApiClientFactory.kt
@@ -20,6 +20,7 @@ import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import io.ktor.client.plugins.HttpRequestTimeoutException
+import io.ktor.client.plugins.ResponseException
 import io.ktor.client.plugins.HttpSend
 import kotlinx.io.IOException
 import io.ktor.client.plugins.plugin
@@ -301,3 +302,47 @@ internal expect suspend fun createStreamingHttpClient(
  * @return HttpClient with streaming configuration, no auth
  */
 internal expect fun createUnauthenticatedStreamingHttpClient(serverUrl: ServerUrl): HttpClient
+
+/**
+ * Refreshes auth tokens using the provided refresh token.
+ *
+ * On success, saves the new tokens and returns them as [BearerTokens].
+ * On failure, returns null. Only clears the auth session for definitive
+ * auth rejections (HTTP 401/403).
+ */
+internal suspend fun refreshAuthTokens(
+    authSession: AuthSession,
+    authApi: AuthApiContract,
+): BearerTokens? {
+    val currentRefreshToken =
+        authSession.getRefreshToken()
+            ?: error("No refresh token available")
+
+    return try {
+        val response = authApi.refresh(currentRefreshToken)
+
+        authSession.saveAuthTokens(
+            access = AccessToken(response.accessToken),
+            refresh = RefreshToken(response.refreshToken),
+            sessionId = response.sessionId,
+            userId = response.userId,
+        )
+
+        BearerTokens(
+            accessToken = response.accessToken,
+            refreshToken = response.refreshToken,
+        )
+    } catch (e: ResponseException) {
+        val status = e.response.status.value
+        if (status == 401 || status == 403) {
+            logger.warn(e) { "Token refresh rejected ($status), clearing auth state" }
+            authSession.clearAuthTokens()
+        } else {
+            logger.warn(e) { "Token refresh failed with HTTP $status, preserving auth state" }
+        }
+        null
+    } catch (e: Exception) {
+        logger.warn(e) { "Token refresh failed due to network error, preserving auth state" }
+        null
+    }
+}

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/remote/RefreshAuthTokensTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/remote/RefreshAuthTokensTest.kt
@@ -1,0 +1,121 @@
+package com.calypsan.listenup.client.data.remote
+
+import com.calypsan.listenup.client.core.RefreshToken
+import com.calypsan.listenup.client.domain.repository.AuthSession
+import dev.mokkery.answering.returns
+import dev.mokkery.answering.throws
+import dev.mokkery.every
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verifySuspend
+import io.ktor.client.plugins.ResponseException
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.test.runTest
+import kotlinx.io.IOException
+import kotlin.test.Test
+import kotlin.test.assertNull
+
+/**
+ * Tests for [refreshAuthTokens] token refresh error handling.
+ *
+ * Verifies that auth tokens are only cleared on definitive auth rejections
+ * (401/403), NOT on transient errors like network failures or server errors.
+ */
+class RefreshAuthTokensTest {
+    // ========== Test Fixtures ==========
+
+    private class TestFixture {
+        val authSession: AuthSession = mock()
+        val authApi: AuthApiContract = mock()
+        val refreshToken = RefreshToken("test-refresh-token")
+    }
+
+    private fun createFixture(): TestFixture {
+        val fixture = TestFixture()
+        everySuspend { fixture.authSession.getRefreshToken() } returns fixture.refreshToken
+        return fixture
+    }
+
+    /**
+     * Creates a [ResponseException] with a mock response carrying the given HTTP status code.
+     * Uses [ResponseException] (the parent of [io.ktor.client.plugins.ClientRequestException]
+     * and [io.ktor.client.plugins.ServerResponseException]) because Ktor's concrete exception
+     * constructors access `response.call.request.url` which requires mocking final classes.
+     */
+    private fun httpException(statusCode: Int): ResponseException {
+        val mockResponse: HttpResponse = mock()
+        every { mockResponse.status } returns HttpStatusCode.fromValue(statusCode)
+        return ResponseException(mockResponse, "HTTP $statusCode")
+    }
+
+    // ========== Tokens NOT Cleared Tests ==========
+
+    @Test
+    fun `does not clear tokens on network error`() =
+        runTest {
+            // Given
+            val fixture = createFixture()
+            everySuspend { fixture.authApi.refresh(any()) } throws IOException("Connection refused")
+            // clearAuthTokens throws AssertionError if called - Error is not caught by catch(Exception)
+            everySuspend { fixture.authSession.clearAuthTokens() } throws
+                AssertionError("clearAuthTokens() must not be called for network errors")
+
+            // When
+            val result = refreshAuthTokens(fixture.authSession, fixture.authApi)
+
+            // Then
+            assertNull(result)
+        }
+
+    @Test
+    fun `does not clear tokens on 503 Service Unavailable`() =
+        runTest {
+            // Given
+            val fixture = createFixture()
+            everySuspend { fixture.authApi.refresh(any()) } throws httpException(503)
+            everySuspend { fixture.authSession.clearAuthTokens() } throws
+                AssertionError("clearAuthTokens() must not be called for 503 errors")
+
+            // When
+            val result = refreshAuthTokens(fixture.authSession, fixture.authApi)
+
+            // Then
+            assertNull(result)
+        }
+
+    // ========== Tokens ARE Cleared Tests ==========
+
+    @Test
+    fun `clears tokens on 401 Unauthorized`() =
+        runTest {
+            // Given
+            val fixture = createFixture()
+            everySuspend { fixture.authApi.refresh(any()) } throws httpException(401)
+            everySuspend { fixture.authSession.clearAuthTokens() } returns Unit
+
+            // When
+            val result = refreshAuthTokens(fixture.authSession, fixture.authApi)
+
+            // Then
+            assertNull(result)
+            verifySuspend { fixture.authSession.clearAuthTokens() }
+        }
+
+    @Test
+    fun `clears tokens on 403 Forbidden`() =
+        runTest {
+            // Given
+            val fixture = createFixture()
+            everySuspend { fixture.authApi.refresh(any()) } throws httpException(403)
+            everySuspend { fixture.authSession.clearAuthTokens() } returns Unit
+
+            // When
+            val result = refreshAuthTokens(fixture.authSession, fixture.authApi)
+
+            // Then
+            assertNull(result)
+            verifySuspend { fixture.authSession.clearAuthTokens() }
+        }
+}


### PR DESCRIPTION
Fixes #142

Users were being kicked to the login screen on any network hiccup. The Ktor bearer auth plugin was clearing auth tokens on ALL exceptions — including timeouts and server errors — not just actual auth rejections.

**Root cause:** `refreshTokens` catch block called `authSession.clearAuthTokens()` unconditionally.

**Fix:** Only clear tokens on `ClientRequestException` with status 401 or 403. All other failures (network errors, 5xx, timeouts) preserve tokens and return null without logging out.