### PR TITLE
🐛 Eliminate ~60s playback delay on downloaded books

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -23,6 +23,9 @@ kotlin {
         // Enable Android resources (opt-in required with new KMP plugin)
         androidResources { enable = true }
 
+        // Enable Android host tests (JVM-based unit tests)
+        withHostTest {}
+
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_17)
             freeCompilerArgs.addAll(
@@ -146,8 +149,12 @@ kotlin {
                 }
             }
         }
-        // Note: Android tests use androidHostTest/androidDeviceTest source sets
-        // with the new KMP plugin. Add test dependencies there when needed.
+        val androidHostTest by getting {
+            dependencies {
+                implementation(libs.kotlin.test)
+                implementation(libs.kotlinx.coroutines.test)
+            }
+        }
     }
 }
 

--- a/composeApp/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/AndroidAudioTokenProviderTest.kt
+++ b/composeApp/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/AndroidAudioTokenProviderTest.kt
@@ -1,0 +1,87 @@
+package com.calypsan.listenup.client.playback
+
+import com.calypsan.listenup.client.core.AccessToken
+import com.calypsan.listenup.client.core.RefreshToken
+import com.calypsan.listenup.client.data.remote.AuthApiContract
+import com.calypsan.listenup.client.data.remote.AuthResponse
+import com.calypsan.listenup.client.data.remote.RegisterResponse
+import com.calypsan.listenup.client.data.remote.RegistrationStatusResponse
+import com.calypsan.listenup.client.domain.repository.AuthSession
+import com.calypsan.listenup.client.domain.repository.AuthState
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.runBlocking
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class AndroidAudioTokenProviderTest {
+
+    @Test
+    fun `prepareForPlayback returns without calling refreshToken when cached token is valid`() {
+        val accessTokenCalls = AtomicInteger(0)
+
+        val session = object : AuthSession {
+            override val authState: StateFlow<AuthState> =
+                MutableStateFlow(AuthState.Authenticated(userId = "u1", sessionId = "s1"))
+
+            override suspend fun getAccessToken(): AccessToken? {
+                accessTokenCalls.incrementAndGet()
+                return AccessToken("valid-test-token")
+            }
+
+            override suspend fun getRefreshToken(): RefreshToken? = null
+            override suspend fun getSessionId(): String? = "s1"
+            override suspend fun getUserId(): String? = "u1"
+            override suspend fun saveAuthTokens(access: AccessToken, refresh: RefreshToken, sessionId: String, userId: String) {}
+            override suspend fun updateAccessToken(token: AccessToken) {}
+            override suspend fun clearAuthTokens() {}
+            override suspend fun isAuthenticated(): Boolean = true
+            override suspend fun initializeAuthState() {}
+            override suspend fun checkServerStatus(): AuthState = AuthState.Authenticated("u1", "s1")
+            override suspend fun refreshOpenRegistration() {}
+            override suspend fun savePendingRegistration(userId: String, email: String, password: String) {}
+            override suspend fun getPendingRegistration(): Triple<String, String, String>? = null
+            override suspend fun clearPendingRegistration() {}
+        }
+
+        val authApi = object : AuthApiContract {
+            override suspend fun setup(email: String, password: String, firstName: String, lastName: String): AuthResponse = TODO()
+            override suspend fun login(email: String, password: String): AuthResponse = TODO()
+            override suspend fun register(email: String, password: String, firstName: String, lastName: String): RegisterResponse = TODO()
+            override suspend fun refresh(refreshToken: RefreshToken): AuthResponse = TODO()
+            override suspend fun logout(sessionId: String) = TODO()
+            override suspend fun checkRegistrationStatus(userId: String): RegistrationStatusResponse = TODO()
+        }
+
+        val scope = CoroutineScope(Job())
+
+        try {
+            val provider = AndroidAudioTokenProvider(session, authApi, scope)
+
+            // Let init's refreshToken() complete
+            runBlocking { delay(200) }
+
+            val callsAfterInit = accessTokenCalls.get()
+            assertTrue(callsAfterInit >= 1, "Init should have called getAccessToken at least once")
+
+            // Act - prepareForPlayback should NOT call refreshToken again
+            // because the cached token is valid (set to expire in ~50 minutes)
+            runBlocking { provider.prepareForPlayback() }
+
+            // Assert - getAccessToken should not have been called again
+            assertEquals(
+                callsAfterInit,
+                accessTokenCalls.get(),
+                "prepareForPlayback should skip refreshToken when cached token is still valid",
+            )
+        } finally {
+            scope.cancel()
+        }
+    }
+}

--- a/composeApp/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/AndroidAudioTokenProviderTest.kt
+++ b/composeApp/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/AndroidAudioTokenProviderTest.kt
@@ -21,43 +21,83 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class AndroidAudioTokenProviderTest {
-
     @Test
     fun `prepareForPlayback returns without calling refreshToken when cached token is valid`() {
         val accessTokenCalls = AtomicInteger(0)
 
-        val session = object : AuthSession {
-            override val authState: StateFlow<AuthState> =
-                MutableStateFlow(AuthState.Authenticated(userId = "u1", sessionId = "s1"))
+        val session =
+            object : AuthSession {
+                override val authState: StateFlow<AuthState> =
+                    MutableStateFlow(AuthState.Authenticated(userId = "u1", sessionId = "s1"))
 
-            override suspend fun getAccessToken(): AccessToken? {
-                accessTokenCalls.incrementAndGet()
-                return AccessToken("valid-test-token")
+                override suspend fun getAccessToken(): AccessToken? {
+                    accessTokenCalls.incrementAndGet()
+                    return AccessToken("valid-test-token")
+                }
+
+                override suspend fun getRefreshToken(): RefreshToken? = null
+
+                override suspend fun getSessionId(): String? = "s1"
+
+                override suspend fun getUserId(): String? = "u1"
+
+                override suspend fun saveAuthTokens(
+                    access: AccessToken,
+                    refresh: RefreshToken,
+                    sessionId: String,
+                    userId: String,
+                ) {}
+
+                override suspend fun updateAccessToken(token: AccessToken) {}
+
+                override suspend fun clearAuthTokens() {}
+
+                override suspend fun isAuthenticated(): Boolean = true
+
+                override suspend fun initializeAuthState() {}
+
+                override suspend fun checkServerStatus(): AuthState = AuthState.Authenticated("u1", "s1")
+
+                override suspend fun refreshOpenRegistration() {}
+
+                override suspend fun savePendingRegistration(
+                    userId: String,
+                    email: String,
+                    password: String,
+                ) {}
+
+                override suspend fun getPendingRegistration(): Triple<String, String, String>? = null
+
+                override suspend fun clearPendingRegistration() {}
             }
 
-            override suspend fun getRefreshToken(): RefreshToken? = null
-            override suspend fun getSessionId(): String? = "s1"
-            override suspend fun getUserId(): String? = "u1"
-            override suspend fun saveAuthTokens(access: AccessToken, refresh: RefreshToken, sessionId: String, userId: String) {}
-            override suspend fun updateAccessToken(token: AccessToken) {}
-            override suspend fun clearAuthTokens() {}
-            override suspend fun isAuthenticated(): Boolean = true
-            override suspend fun initializeAuthState() {}
-            override suspend fun checkServerStatus(): AuthState = AuthState.Authenticated("u1", "s1")
-            override suspend fun refreshOpenRegistration() {}
-            override suspend fun savePendingRegistration(userId: String, email: String, password: String) {}
-            override suspend fun getPendingRegistration(): Triple<String, String, String>? = null
-            override suspend fun clearPendingRegistration() {}
-        }
+        val authApi =
+            object : AuthApiContract {
+                override suspend fun setup(
+                    email: String,
+                    password: String,
+                    firstName: String,
+                    lastName: String,
+                ): AuthResponse = TODO()
 
-        val authApi = object : AuthApiContract {
-            override suspend fun setup(email: String, password: String, firstName: String, lastName: String): AuthResponse = TODO()
-            override suspend fun login(email: String, password: String): AuthResponse = TODO()
-            override suspend fun register(email: String, password: String, firstName: String, lastName: String): RegisterResponse = TODO()
-            override suspend fun refresh(refreshToken: RefreshToken): AuthResponse = TODO()
-            override suspend fun logout(sessionId: String) = TODO()
-            override suspend fun checkRegistrationStatus(userId: String): RegistrationStatusResponse = TODO()
-        }
+                override suspend fun login(
+                    email: String,
+                    password: String,
+                ): AuthResponse = TODO()
+
+                override suspend fun register(
+                    email: String,
+                    password: String,
+                    firstName: String,
+                    lastName: String,
+                ): RegisterResponse = TODO()
+
+                override suspend fun refresh(refreshToken: RefreshToken): AuthResponse = TODO()
+
+                override suspend fun logout(sessionId: String) = TODO()
+
+                override suspend fun checkRegistrationStatus(userId: String): RegistrationStatusResponse = TODO()
+            }
 
         val scope = CoroutineScope(Job())
 

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/domain/playback/PlaybackTimelineTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/domain/playback/PlaybackTimelineTest.kt
@@ -18,39 +18,42 @@ class PlaybackTimelineTest {
         codec: String = "mp3",
         duration: Long = 1_800_000L,
         size: Long = 30_000_000L,
-    ): AudioFile = AudioFile(
-        id = id,
-        filename = filename,
-        format = format,
-        codec = codec,
-        duration = duration,
-        size = size,
-    )
+    ): AudioFile =
+        AudioFile(
+            id = id,
+            filename = filename,
+            format = format,
+            codec = codec,
+            duration = duration,
+            size = size,
+        )
 
     @Test
     fun `buildWithTranscodeSupport never calls prepareStream and uses direct URLs for non-local files`() =
         runTest {
             // Given - two files: first is local, second is not
-            val files = listOf(
-                audioFile(id = "af-001", filename = "chapter1.mp3"),
-                audioFile(id = "af-002", filename = "chapter2.mp3"),
-            )
+            val files =
+                listOf(
+                    audioFile(id = "af-001", filename = "chapter1.mp3"),
+                    audioFile(id = "af-002", filename = "chapter2.mp3"),
+                )
 
             var prepareStreamCalled = false
 
             // When
-            val timeline = PlaybackTimeline.buildWithTranscodeSupport(
-                bookId = bookId,
-                audioFiles = files,
-                baseUrl = baseUrl,
-                resolveLocalPath = { fileId ->
-                    if (fileId == "af-001") "/downloads/chapter1.mp3" else null
-                },
-                prepareStream = { _, _ ->
-                    prepareStreamCalled = true
-                    StreamPrepareResult(streamUrl = "/api/v1/books/book-1/audio/af-002", ready = true)
-                },
-            )
+            val timeline =
+                PlaybackTimeline.buildWithTranscodeSupport(
+                    bookId = bookId,
+                    audioFiles = files,
+                    baseUrl = baseUrl,
+                    resolveLocalPath = { fileId ->
+                        if (fileId == "af-001") "/downloads/chapter1.mp3" else null
+                    },
+                    prepareStream = { _, _ ->
+                        prepareStreamCalled = true
+                        StreamPrepareResult(streamUrl = "/api/v1/books/book-1/audio/af-002", ready = true)
+                    },
+                )
 
             // Then - prepareStream should never be called
             assertFalse(prepareStreamCalled, "prepareStream should not be called at all")
@@ -67,25 +70,27 @@ class PlaybackTimelineTest {
     fun `buildWithTranscodeSupport uses direct URLs for all non-local files`() =
         runTest {
             // Given - three non-local files
-            val files = listOf(
-                audioFile(id = "af-001", filename = "chapter1.mp3"),
-                audioFile(id = "af-002", filename = "chapter2.mp3"),
-                audioFile(id = "af-003", filename = "chapter3.mp3"),
-            )
+            val files =
+                listOf(
+                    audioFile(id = "af-001", filename = "chapter1.mp3"),
+                    audioFile(id = "af-002", filename = "chapter2.mp3"),
+                    audioFile(id = "af-003", filename = "chapter3.mp3"),
+                )
 
             var prepareStreamCallCount = 0
 
             // When
-            val timeline = PlaybackTimeline.buildWithTranscodeSupport(
-                bookId = bookId,
-                audioFiles = files,
-                baseUrl = baseUrl,
-                resolveLocalPath = { null }, // none are local
-                prepareStream = { _, _ ->
-                    prepareStreamCallCount++
-                    StreamPrepareResult(streamUrl = "ignored", ready = true)
-                },
-            )
+            val timeline =
+                PlaybackTimeline.buildWithTranscodeSupport(
+                    bookId = bookId,
+                    audioFiles = files,
+                    baseUrl = baseUrl,
+                    resolveLocalPath = { null }, // none are local
+                    prepareStream = { _, _ ->
+                        prepareStreamCallCount++
+                        StreamPrepareResult(streamUrl = "ignored", ready = true)
+                    },
+                )
 
             // Then - prepareStream should never be called
             assertEquals(0, prepareStreamCallCount, "prepareStream should not be called")

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/domain/playback/PlaybackTimelineTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/domain/playback/PlaybackTimelineTest.kt
@@ -1,0 +1,101 @@
+package com.calypsan.listenup.client.domain.playback
+
+import com.calypsan.listenup.client.core.BookId
+import com.calypsan.listenup.client.domain.model.AudioFile
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class PlaybackTimelineTest {
+    private val bookId = BookId("book-1")
+    private val baseUrl = "https://server.example.com"
+
+    private fun audioFile(
+        id: String = "af-001",
+        filename: String = "chapter1.mp3",
+        format: String = "mp3",
+        codec: String = "mp3",
+        duration: Long = 1_800_000L,
+        size: Long = 30_000_000L,
+    ): AudioFile = AudioFile(
+        id = id,
+        filename = filename,
+        format = format,
+        codec = codec,
+        duration = duration,
+        size = size,
+    )
+
+    @Test
+    fun `buildWithTranscodeSupport never calls prepareStream and uses direct URLs for non-local files`() =
+        runTest {
+            // Given - two files: first is local, second is not
+            val files = listOf(
+                audioFile(id = "af-001", filename = "chapter1.mp3"),
+                audioFile(id = "af-002", filename = "chapter2.mp3"),
+            )
+
+            var prepareStreamCalled = false
+
+            // When
+            val timeline = PlaybackTimeline.buildWithTranscodeSupport(
+                bookId = bookId,
+                audioFiles = files,
+                baseUrl = baseUrl,
+                resolveLocalPath = { fileId ->
+                    if (fileId == "af-001") "/downloads/chapter1.mp3" else null
+                },
+                prepareStream = { _, _ ->
+                    prepareStreamCalled = true
+                    StreamPrepareResult(streamUrl = "/api/v1/books/book-1/audio/af-002", ready = true)
+                },
+            )
+
+            // Then - prepareStream should never be called
+            assertFalse(prepareStreamCalled, "prepareStream should not be called at all")
+
+            // Non-local file should get direct URL pattern
+            val nonLocalSegment = timeline.files[1]
+            assertEquals(
+                "$baseUrl/api/v1/books/${bookId.value}/audio/af-002",
+                nonLocalSegment.streamingUrl,
+            )
+        }
+
+    @Test
+    fun `buildWithTranscodeSupport uses direct URLs for all non-local files`() =
+        runTest {
+            // Given - three non-local files
+            val files = listOf(
+                audioFile(id = "af-001", filename = "chapter1.mp3"),
+                audioFile(id = "af-002", filename = "chapter2.mp3"),
+                audioFile(id = "af-003", filename = "chapter3.mp3"),
+            )
+
+            var prepareStreamCallCount = 0
+
+            // When
+            val timeline = PlaybackTimeline.buildWithTranscodeSupport(
+                bookId = bookId,
+                audioFiles = files,
+                baseUrl = baseUrl,
+                resolveLocalPath = { null }, // none are local
+                prepareStream = { _, _ ->
+                    prepareStreamCallCount++
+                    StreamPrepareResult(streamUrl = "ignored", ready = true)
+                },
+            )
+
+            // Then - prepareStream should never be called
+            assertEquals(0, prepareStreamCallCount, "prepareStream should not be called")
+
+            // All files should get the direct URL pattern (no ?variant=transcoded suffix)
+            for (segment in timeline.files) {
+                assertEquals(
+                    "$baseUrl/api/v1/books/${bookId.value}/audio/${segment.audioFileId}",
+                    segment.streamingUrl,
+                )
+            }
+        }
+}


### PR DESCRIPTION
Fixes #145

Two root causes eliminated:

**RC1 — Blocking prepareStream:** `buildWithTranscodeSupport` was blocking on a `prepareStream` server poll for the first non-local audio file, waiting up to 10 minutes for transcode readiness. Non-local files now use direct URLs immediately — ExoPlayer buffers naturally.

**RC2 — Auth mutex contention:** `prepareForPlayback()` was acquiring `refreshMutex` even when a valid cached token existed. If the background proactive refresh was making a slow network call, playback was blocked for 60+ seconds. Fast-path added: return immediately when cached token is valid and not near expiry.