### PR TITLE
🐛 Restore isSearchActive param removed incorrectly by detekt fix

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/backup/ABSImportHubScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/backup/ABSImportHubScreen.kt
@@ -1051,6 +1051,7 @@ private fun UsersTabContent(
 @Composable
 private fun HubUserMappingCard(
     user: ABSImportUser,
+    isSearchActive: Boolean,
     searchQuery: String,
     searchResults: List<UserSearchResult>,
     isSearching: Boolean,
@@ -1361,6 +1362,7 @@ private fun BooksTabContent(
 @Composable
 private fun HubBookMappingCard(
     book: ABSImportBook,
+    isSearchActive: Boolean,
     searchQuery: String,
     searchResults: List<SearchHitResponse>,
     isSearching: Boolean,


### PR DESCRIPTION
Our param removal regex was too broad and removed isSearchActive from the outer HubUserMappingCard and HubBookMappingCard functions, breaking compilation. This restores the param to those functions only (not the extracted State composables where detekt correctly flagged it as unused).