### PR TITLE
🐛 Self-heal entity count mismatch after delta sync

### DIFF
--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/Daos.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/Daos.kt
@@ -140,6 +140,9 @@ interface SeriesDao {
     @Query("SELECT * FROM series WHERE id = :id")
     fun observeByIdWithBooks(id: String): Flow<SeriesWithBooks?>
 
+    @Query("SELECT COUNT(*) FROM series")
+    suspend fun count(): Int
+
     @Query("DELETE FROM series")
     suspend fun deleteAll()
 }
@@ -298,6 +301,9 @@ interface ContributorDao {
         contributorId: String,
         imagePath: String?,
     )
+
+    @Query("SELECT COUNT(*) FROM contributors")
+    suspend fun count(): Int
 
     @Query("DELETE FROM contributors")
     suspend fun deleteAll()

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/pull/PullSyncOrchestrator.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/pull/PullSyncOrchestrator.kt
@@ -52,7 +52,7 @@ class PullSyncOrchestrator(
      *
      * @param onProgress Callback for progress updates
      */
-    @Suppress("CognitiveComplexMethod")
+    @Suppress("CognitiveComplexMethod", "LongMethod", "CyclomaticComplexMethod")
     suspend fun pull(onProgress: (SyncStatus) -> Unit) =
         coroutineScope {
             logger.debug { "Pulling changes from server" }
@@ -197,21 +197,26 @@ class PullSyncOrchestrator(
             // Self-healing: if local count < manifest count, the delta sync filtered out entities
             // whose updated_at predates the client checkpoint. Re-pull those entity types in full.
             if (manifest != null) {
-                if (totalBooks > 0 && bookDao.count() < totalBooks) {
+                val localBookCount = bookDao.count()
+                if (totalBooks > 0 && localBookCount < totalBooks) {
                     logger.warn {
-                        "Book count mismatch: local=${bookDao.count()}, server=$totalBooks — re-pulling books in full"
+                        "Book count mismatch: local=$localBookCount, server=$totalBooks — re-pulling books in full"
                     }
                     bookPuller.pull(null) {}
                 }
-                if (totalSeries > 0 && seriesDao.count() < totalSeries) {
+                val localSeriesCount = seriesDao.count()
+                if (totalSeries > 0 && localSeriesCount < totalSeries) {
                     logger.warn {
-                        "Series count mismatch: local=${seriesDao.count()}, server=$totalSeries — re-pulling series in full"
+                        "Series count mismatch: local=$localSeriesCount, " +
+                            "server=$totalSeries — re-pulling series in full"
                     }
                     seriesPuller.pull(null) {}
                 }
-                if (totalContributors > 0 && contributorDao.count() < totalContributors) {
+                val localContributorCount = contributorDao.count()
+                if (totalContributors > 0 && localContributorCount < totalContributors) {
                     logger.warn {
-                        "Contributor count mismatch: local=${contributorDao.count()}, server=$totalContributors — re-pulling contributors in full"
+                        "Contributor count mismatch: local=$localContributorCount, " +
+                            "server=$totalContributors — re-pulling contributors in full"
                     }
                     contributorPuller.pull(null) {}
                 }

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/pull/PullSyncOrchestrator.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/pull/PullSyncOrchestrator.kt
@@ -198,15 +198,21 @@ class PullSyncOrchestrator(
             // whose updated_at predates the client checkpoint. Re-pull those entity types in full.
             if (manifest != null) {
                 if (totalBooks > 0 && bookDao.count() < totalBooks) {
-                    logger.warn { "Book count mismatch: local=${bookDao.count()}, server=$totalBooks — re-pulling books in full" }
+                    logger.warn {
+                        "Book count mismatch: local=${bookDao.count()}, server=$totalBooks — re-pulling books in full"
+                    }
                     bookPuller.pull(null) {}
                 }
                 if (totalSeries > 0 && seriesDao.count() < totalSeries) {
-                    logger.warn { "Series count mismatch: local=${seriesDao.count()}, server=$totalSeries — re-pulling series in full" }
+                    logger.warn {
+                        "Series count mismatch: local=${seriesDao.count()}, server=$totalSeries — re-pulling series in full"
+                    }
                     seriesPuller.pull(null) {}
                 }
                 if (totalContributors > 0 && contributorDao.count() < totalContributors) {
-                    logger.warn { "Contributor count mismatch: local=${contributorDao.count()}, server=$totalContributors — re-pulling contributors in full" }
+                    logger.warn {
+                        "Contributor count mismatch: local=${contributorDao.count()}, server=$totalContributors — re-pulling contributors in full"
+                    }
                     contributorPuller.pull(null) {}
                 }
             }

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/di/Koin.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/di/Koin.kt
@@ -1084,6 +1084,9 @@ val syncModule =
                 coordinator = get(),
                 syncApi = get<SyncApiContract>(),
                 syncDao = get(),
+                bookDao = get(),
+                seriesDao = get(),
+                contributorDao = get(),
             )
         }
 

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/pull/PullSyncOrchestratorTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/pull/PullSyncOrchestratorTest.kt
@@ -1,6 +1,9 @@
 package com.calypsan.listenup.client.data.sync.pull
 
 import com.calypsan.listenup.client.core.Timestamp
+import com.calypsan.listenup.client.data.local.db.BookDao
+import com.calypsan.listenup.client.data.local.db.ContributorDao
+import com.calypsan.listenup.client.data.local.db.SeriesDao
 import com.calypsan.listenup.client.data.local.db.SyncDao
 import com.calypsan.listenup.client.data.sync.SyncCoordinator
 import com.calypsan.listenup.client.data.sync.model.SyncPhase
@@ -44,6 +47,9 @@ class PullSyncOrchestratorTest {
         val readingSessionsPuller: Puller = mock()
         val syncDao: SyncDao = mock()
         val syncApi: com.calypsan.listenup.client.data.remote.SyncApiContract = mock()
+        val bookDao: BookDao = mock()
+        val seriesDao: SeriesDao = mock()
+        val contributorDao: ContributorDao = mock()
 
         // Use real coordinator for simpler testing
         val coordinator = SyncCoordinator()
@@ -64,6 +70,9 @@ class PullSyncOrchestratorTest {
             everySuspend { syncApi.getManifest() } returns
                 com.calypsan.listenup.client.core.Result
                     .Failure(message = "no manifest")
+            everySuspend { bookDao.count() } returns 0
+            everySuspend { seriesDao.count() } returns 0
+            everySuspend { contributorDao.count() } returns 0
         }
 
         fun build(): PullSyncOrchestrator =
@@ -81,6 +90,9 @@ class PullSyncOrchestratorTest {
                 coordinator = coordinator,
                 syncApi = syncApi,
                 syncDao = syncDao,
+                bookDao = bookDao,
+                seriesDao = seriesDao,
+                contributorDao = contributorDao,
             )
     }
 


### PR DESCRIPTION
Fixes #162

After sync completes, compare local entity counts against manifest counts. If any entity type has fewer local records than the server reports, re-pull that type with `updatedAfter = null` (full pull). This handles the case where the client checkpoint is newer than the server entities'  updated_at timestamps, causing delta sync to silently return nothing.