### PR TITLE
🔐 Silent token refresh on 401 — no more login redirects (#168)

### DIFF
--- a/shared/src/appleMain/kotlin/com/calypsan/listenup/client/data/remote/ApiClientFactory.apple.kt
+++ b/shared/src/appleMain/kotlin/com/calypsan/listenup/client/data/remote/ApiClientFactory.apple.kt
@@ -1,10 +1,7 @@
 package com.calypsan.listenup.client.data.remote
 
-import com.calypsan.listenup.client.core.AccessToken
-import com.calypsan.listenup.client.core.RefreshToken
 import com.calypsan.listenup.client.core.ServerUrl
 import com.calypsan.listenup.client.domain.repository.AuthSession
-import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.darwin.Darwin
 import io.ktor.client.plugins.auth.Auth
@@ -16,8 +13,6 @@ import io.ktor.http.ContentType
 import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
-
-private val logger = KotlinLogging.logger {}
 
 /**
  * iOS implementation of streaming HTTP client factory.
@@ -75,29 +70,7 @@ internal actual suspend fun createStreamingHttpClient(
                 }
 
                 refreshTokens {
-                    val currentRefreshToken =
-                        authSession.getRefreshToken()
-                            ?: error("No refresh token available")
-
-                    try {
-                        val response = authApi.refresh(currentRefreshToken)
-
-                        authSession.saveAuthTokens(
-                            access = AccessToken(response.accessToken),
-                            refresh = RefreshToken(response.refreshToken),
-                            sessionId = response.sessionId,
-                            userId = response.userId,
-                        )
-
-                        BearerTokens(
-                            accessToken = response.accessToken,
-                            refreshToken = response.refreshToken,
-                        )
-                    } catch (e: Exception) {
-                        logger.warn(e) { "Token refresh failed, clearing auth state" }
-                        authSession.clearAuthTokens()
-                        null
-                    }
+                    refreshAuthTokens(authSession, authApi)
                 }
 
                 sendWithoutRequest { request ->

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ApiClientFactory.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ApiClientFactory.kt
@@ -158,31 +158,7 @@ class ApiClientFactory(
 
                         // Refresh tokens when receiving 401 Unauthorized
                         refreshTokens {
-                            val currentRefreshToken =
-                                authSession.getRefreshToken()
-                                    ?: error("No refresh token available")
-
-                            try {
-                                val response = authApi.refresh(currentRefreshToken)
-
-                                // Save new tokens to storage
-                                authSession.saveAuthTokens(
-                                    access = AccessToken(response.accessToken),
-                                    refresh = RefreshToken(response.refreshToken),
-                                    sessionId = response.sessionId,
-                                    userId = response.userId,
-                                )
-
-                                BearerTokens(
-                                    accessToken = response.accessToken,
-                                    refreshToken = response.refreshToken,
-                                )
-                            } catch (e: Exception) {
-                                // Refresh failed - clear auth state and force re-login
-                                logger.warn(e) { "Token refresh failed, clearing auth state" }
-                                authSession.clearAuthTokens()
-                                null
-                            }
+                            refreshAuthTokens(authSession, authApi)
                         }
 
                         // Control when to send bearer token

--- a/shared/src/jvmMain/kotlin/com/calypsan/listenup/client/data/remote/ApiClientFactory.jvm.kt
+++ b/shared/src/jvmMain/kotlin/com/calypsan/listenup/client/data/remote/ApiClientFactory.jvm.kt
@@ -1,10 +1,7 @@
 package com.calypsan.listenup.client.data.remote
 
-import com.calypsan.listenup.client.core.AccessToken
-import com.calypsan.listenup.client.core.RefreshToken
 import com.calypsan.listenup.client.core.ServerUrl
 import com.calypsan.listenup.client.domain.repository.AuthSession
-import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.plugins.auth.Auth
@@ -17,8 +14,6 @@ import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
 import kotlin.time.Duration.Companion.seconds
-
-private val logger = KotlinLogging.logger {}
 
 /**
  * JVM desktop implementation of streaming HTTP client factory.
@@ -75,29 +70,7 @@ internal actual suspend fun createStreamingHttpClient(
                 }
 
                 refreshTokens {
-                    val currentRefreshToken =
-                        authSession.getRefreshToken()
-                            ?: error("No refresh token available")
-
-                    try {
-                        val response = authApi.refresh(currentRefreshToken)
-
-                        authSession.saveAuthTokens(
-                            access = AccessToken(response.accessToken),
-                            refresh = RefreshToken(response.refreshToken),
-                            sessionId = response.sessionId,
-                            userId = response.userId,
-                        )
-
-                        BearerTokens(
-                            accessToken = response.accessToken,
-                            refreshToken = response.refreshToken,
-                        )
-                    } catch (e: Exception) {
-                        logger.warn(e) { "Token refresh failed, clearing auth state" }
-                        authSession.clearAuthTokens()
-                        null
-                    }
+                    refreshAuthTokens(authSession, authApi)
                 }
 
                 sendWithoutRequest { request ->


### PR DESCRIPTION
## What

Fixes #168. Replaces the buggy inline `refreshTokens` callback in the Ktor Auth plugin with the correct `refreshAuthTokens()` function that was already in the codebase (with tests).

## Why it was broken

The old `catch (e: Exception)` catch-all cleared auth tokens on **every** failure — network timeouts, 5xx errors, etc. Users got kicked to login even for transient issues.

## How it works now

`refreshAuthTokens()` correctly differentiates:
- **401/403 on refresh** → clear tokens, redirect to login (refresh token definitively rejected)
- **5xx / network errors** → preserve auth state, return null (transient — retry later)

## Files changed
- `ApiClientFactory.kt` (commonMain)
- `ApiClientFactory.jvm.kt` (JVM streaming client)
- `ApiClientFactory.apple.kt` (iOS streaming client)
- `ApiClientFactory.android.kt` was already correct — no change needed