### PR TITLE
🐛 Import/sync reliability: stuck imports + missing books (#166 #169 #170)

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/backup/ABSImportHubScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/backup/ABSImportHubScreen.kt
@@ -89,6 +89,9 @@ import org.koin.compose.koinInject
 
 private const val IMPORT_STATUS_ANALYZING = "analyzing"
 private const val IMPORT_STATUS_ACTIVE = "active"
+private const val LABEL_DELETE = "Delete"
+private const val LABEL_CANCEL = "Cancel"
+private const val LABEL_CANCEL_IMPORT = "Cancel Import"
 
 // ============================================================
 // Import List Screen
@@ -173,12 +176,12 @@ fun ABSImportListScreen(
                         deleteConfirmImport = null
                     },
                 ) {
-                    Text("Delete", color = MaterialTheme.colorScheme.error)
+                    Text(LABEL_DELETE, color = MaterialTheme.colorScheme.error)
                 }
             },
             dismissButton = {
                 TextButton(onClick = { deleteConfirmImport = null }) {
-                    Text("Cancel")
+                    Text(LABEL_CANCEL)
                 }
             },
         )
@@ -390,7 +393,7 @@ private fun ImportSummaryCard(
                 IconButton(onClick = onDelete) {
                     Icon(
                         Icons.Default.Delete,
-                        contentDescription = "Delete",
+                        contentDescription = LABEL_DELETE,
                         tint = MaterialTheme.colorScheme.error,
                     )
                 }
@@ -436,7 +439,7 @@ private fun StatusBadge(
 ) {
     val (containerColor, contentColor, label) =
         when (status.lowercase()) {
-            "active" -> {
+            IMPORT_STATUS_ACTIVE -> {
                 Triple(
                     MaterialTheme.colorScheme.primaryContainer,
                     MaterialTheme.colorScheme.onPrimaryContainer,
@@ -576,7 +579,7 @@ private fun CreateImportDialog(
         confirmButton = {},
         dismissButton = {
             TextButton(onClick = onDismiss) {
-                Text("Cancel")
+                Text(LABEL_CANCEL)
             }
         },
     )
@@ -646,7 +649,7 @@ fun ABSImportHubDetailScreen(
         AlertDialog(
             onDismissRequest = { showCancelConfirm = false },
             shape = MaterialTheme.shapes.large,
-            title = { Text("Cancel Import") },
+            title = { Text(LABEL_CANCEL_IMPORT) },
             text = {
                 Text("This will delete the stuck import. You can create a new one afterwards.")
             },
@@ -658,7 +661,7 @@ fun ABSImportHubDetailScreen(
                         onBackClick()
                     },
                 ) {
-                    Text("Delete", color = MaterialTheme.colorScheme.error)
+                    Text(LABEL_DELETE, color = MaterialTheme.colorScheme.error)
                 }
             },
             dismissButton = {
@@ -755,7 +758,7 @@ private fun ImportHubContent(
                         )
                     }
                     OutlinedButton(onClick = onCancelImport) {
-                        Text("Cancel Import")
+                        Text(LABEL_CANCEL_IMPORT)
                     }
                 }
             }

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/backup/ABSImportHubScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/backup/ABSImportHubScreen.kt
@@ -340,8 +340,9 @@ private fun ImportSummaryCard(
                 )
             }
 
-            val isStuck = import.status.lowercase() == IMPORT_STATUS_ACTIVE &&
-                import.totalUsers == 0 && import.totalBooks == 0 && import.totalSessions == 0
+            val isStuck =
+                import.status.lowercase() == IMPORT_STATUS_ACTIVE &&
+                    import.totalUsers == 0 && import.totalBooks == 0 && import.totalSessions == 0
 
             if (isStuck) {
                 Spacer(modifier = Modifier.height(12.dp))
@@ -692,11 +693,12 @@ private fun ImportHubContent(
     modifier: Modifier = Modifier,
 ) {
     // Stuck import: status is "active" but analysis never populated any data
-    val isStuckImport = state.import?.let { imp ->
-        imp.status.lowercase() == IMPORT_STATUS_ACTIVE &&
-            imp.completedAt == null &&
-            imp.totalUsers == 0 && imp.totalBooks == 0 && imp.totalSessions == 0
-    } == true
+    val isStuckImport =
+        state.import?.let { imp ->
+            imp.status.lowercase() == IMPORT_STATUS_ACTIVE &&
+                imp.completedAt == null &&
+                imp.totalUsers == 0 && imp.totalBooks == 0 && imp.totalSessions == 0
+        } == true
 
     Column(modifier = modifier.fillMaxSize()) {
         // Analyzing banner
@@ -724,9 +726,10 @@ private fun ImportHubContent(
         if (isStuckImport) {
             Card(
                 modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
-                colors = CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.errorContainer,
-                ),
+                colors =
+                    CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.errorContainer,
+                    ),
             ) {
                 Row(
                     modifier = Modifier.fillMaxWidth().padding(16.dp),


### PR DESCRIPTION
## What

Fixes #166, #169, and #170 — three related data-integrity bugs where interrupted operations leave the app in a broken state.

---

### #166 — Stuck ABS import no longer causes infinite spinner

A stuck import (, ) now shows a recoverable error UI instead of spinning forever.

**Changes in `ABSImportHubScreen.kt`:**
- **Detail screen** — Detects stuck imports (status=`active`, completedAt null, all counts zero). Shows an error card with a "Cancel Import" button that deletes the import via the existing endpoint and navigates back.
- **List screen** — Stuck import cards show a "Import appears stuck" warning label with error coloring, visible before opening the detail view.
- **ScanningOverlay** — Not involved (`isServerScanning` is driven by the library book scanner, independent of ABS import status). No change needed.

---

### #169 — Book sync cursor advances after persistence, not before

**Root cause:** In `BookPuller.kt`, `cursor` and `hasMore` were updated at the top of the success branch, before `processServerBooks()` was called. An interrupted sync would advance the checkpoint without saving the books — subsequent delta syncs skip the missing page entirely.

**Fix:** Move cursor/hasMore advancement to after `processServerBooks()` completes.

---

### #170 — Post-sync book completeness check

Already implemented by PR #164 (`PullSyncOrchestrator.kt` lines 200–206). No additional changes needed.