### PR TITLE
🔧 Background ABS import UX — dismiss sheet immediately, notify on completion (#165)

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/backup/ABSUploadSheet.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/backup/ABSUploadSheet.kt
@@ -36,7 +36,6 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -52,15 +51,11 @@ import com.calypsan.listenup.client.design.components.ListenUpButton
 import com.calypsan.listenup.client.upload.ABSUploadWorker
 import com.calypsan.listenup.client.util.DocumentPickerResult
 import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import java.io.File
 import java.util.UUID
 
 private val logger = KotlinLogging.logger {}
-
-/** Delay before auto-navigating after successful upload. */
-private const val SUCCESS_ANIMATION_DELAY_MS = 1500L
 
 /**
  * State for the ABS upload flow.
@@ -129,16 +124,8 @@ fun ABSUploadSheet(
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
-    // Auto-navigate to import hub when upload completes
-    LaunchedEffect(state) {
-        if (state is ABSUploadState.Complete) {
-            delay(SUCCESS_ANIMATION_DELAY_MS)
-            onNavigateToImport(state.importId)
-        }
-    }
-
     ModalBottomSheet(
-        onDismissRequest = { if (state !is ABSUploadState.Uploading) onDismiss() },
+        onDismissRequest = onDismiss,
         sheetState = sheetState,
         shape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp),
         dragHandle = {

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/backup/AdminBackupScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/backup/AdminBackupScreen.kt
@@ -151,7 +151,13 @@ fun AdminBackupScreen(
             state = uploadSheetState.uploadState,
             onPickFile = { documentPicker.launch() },
             onUpload = {
-                uploadSheetState.enqueueUpload(context)
+                val workId = uploadSheetState.enqueueUpload(context)
+                if (workId != null) {
+                    // Dismiss sheet immediately — import list on this screen shows progress
+                    showUploadSheet = false
+                    uploadSheetState.reset()
+                    absImportViewModel.loadImports()
+                }
             },
             onNavigateToImport = { importId ->
                 showUploadSheet = false


### PR DESCRIPTION
## What

Fixes #165. The upload sheet no longer holds the user hostage while the backup is being processed.

## Changes

### ABSUploadSheet.kt
- Removed the `LaunchedEffect` that blocked navigation until the worker completed
- Removed the dismiss guard during `Uploading` state — user can leave freely at any time
- Sheet is dismissed immediately after `enqueueUpload()` succeeds

### AdminBackupScreen.kt
- After enqueue, immediately dismisses the sheet, resets state, and refreshes the import list
- User stays on AdminBackupScreen where in-progress imports are shown inline with progress indicators

### ABSUploadWorker.kt
- Added `showCompleteNotification()` on success: "Backup ready to review" / "Your Audiobookshelf backup has been analysed and is ready to map."
- Added `showFailureNotification()` on final failure: "Backup import failed"
- Both use a new `abs_import_complete` channel (IMPORTANCE_DEFAULT) with a PendingIntent to relaunch the app on tap
- Auto-cancels the in-progress notification when complete

### ABSImportHubScreen.kt
- No changes needed — already shows "Analyzing..." banners with progress indicators for in-progress imports