### PR TITLE
✨ Background ABS import with notification deep-link (#165)

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/MainActivity.kt
@@ -154,6 +154,16 @@ class MainActivity : ComponentActivity() {
                 println("MainActivity: Received SLEEP_TIMER shortcut action - minutes=$timerMinutes")
                 shortcutActionManager.setPendingAction(ShortcutAction.SleepTimer(timerMinutes))
             }
+
+            ShortcutActions.NAVIGATE_TO_ABS_IMPORT -> {
+                val importId = intent.getStringExtra(ShortcutActions.EXTRA_IMPORT_ID)
+                if (importId != null) {
+                    println("MainActivity: Received NAVIGATE_TO_ABS_IMPORT action - importId=$importId")
+                    shortcutActionManager.setPendingAction(ShortcutAction.NavigateToAbsImport(importId))
+                } else {
+                    println("MainActivity: NAVIGATE_TO_ABS_IMPORT action missing import_id extra")
+                }
+            }
         }
     }
 

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/backup/ABSUploadSheet.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/backup/ABSUploadSheet.kt
@@ -36,7 +36,6 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -52,15 +51,11 @@ import com.calypsan.listenup.client.design.components.ListenUpButton
 import com.calypsan.listenup.client.upload.ABSUploadWorker
 import com.calypsan.listenup.client.util.DocumentPickerResult
 import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import java.io.File
 import java.util.UUID
 
 private val logger = KotlinLogging.logger {}
-
-/** Delay before auto-navigating after successful upload. */
-private const val SUCCESS_ANIMATION_DELAY_MS = 1500L
 
 /**
  * State for the ABS upload flow.
@@ -129,16 +124,8 @@ fun ABSUploadSheet(
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
-    // Auto-navigate to import hub when upload completes
-    LaunchedEffect(state) {
-        if (state is ABSUploadState.Complete) {
-            delay(SUCCESS_ANIMATION_DELAY_MS)
-            onNavigateToImport(state.importId)
-        }
-    }
-
     ModalBottomSheet(
-        onDismissRequest = { if (state !is ABSUploadState.Uploading) onDismiss() },
+        onDismissRequest = onDismiss,
         sheetState = sheetState,
         shape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp),
         dragHandle = {

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/backup/AdminBackupScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/backup/AdminBackupScreen.kt
@@ -105,6 +105,15 @@ fun AdminBackupScreen(
         }
     }
 
+    // Auto-navigate to import detail when background upload completes while on this screen
+    LaunchedEffect(uploadSheetState.uploadState) {
+        val currentState = uploadSheetState.uploadState
+        if (currentState is ABSUploadState.Complete && currentState.importId.isNotEmpty()) {
+            uploadSheetState.reset()
+            onABSImportHubClick(currentState.importId)
+        }
+    }
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -151,7 +160,10 @@ fun AdminBackupScreen(
             state = uploadSheetState.uploadState,
             onPickFile = { documentPicker.launch() },
             onUpload = {
-                uploadSheetState.enqueueUpload(context)
+                val workId = uploadSheetState.enqueueUpload(context)
+                if (workId != null) {
+                    showUploadSheet = false
+                }
             },
             onNavigateToImport = { importId ->
                 showUploadSheet = false

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/backup/AdminBackupScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/backup/AdminBackupScreen.kt
@@ -72,6 +72,7 @@ private const val LABEL_DELETE = "Delete"
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
+@Suppress("LongMethod")
 fun AdminBackupScreen(
     backupViewModel: AdminBackupViewModel = koinInject(),
     absImportViewModel: ABSImportHubViewModel = koinInject(),

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/ListenUpNavigation.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/ListenUpNavigation.kt
@@ -507,6 +507,16 @@ private fun AuthenticatedNavigation(
                     // Let the user interact with sleep timer in the player
                 }
             }
+
+            is ShortcutAction.NavigateToAbsImport -> {
+                logger.info { "Navigating to ABS import: ${action.importId}" }
+                if (backStack.lastOrNull() != Shell) {
+                    backStack.clear()
+                    backStack.add(Shell)
+                }
+                backStack.add(AdminBackups)
+                backStack.add(ABSImportDetail(action.importId))
+            }
         }
 
         // Consume the action after processing

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/shortcuts/ShortcutActions.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/shortcuts/ShortcutActions.kt
@@ -60,6 +60,14 @@ object ShortcutActions {
      */
     const val SLEEP_TIMER = "com.calypsan.listenup.action.SLEEP_TIMER"
 
+    /**
+     * Navigate to a specific ABS import detail screen.
+     *
+     * Used by completion notifications from ABSUploadWorker.
+     * Requires EXTRA_IMPORT_ID to identify which import to view.
+     */
+    const val NAVIGATE_TO_ABS_IMPORT = "com.calypsan.listenup.action.NAVIGATE_TO_ABS_IMPORT"
+
     // ═══════════════════════════════════════════════════════════════════════════
     // INTENT EXTRAS
     // ═══════════════════════════════════════════════════════════════════════════
@@ -78,6 +86,13 @@ object ShortcutActions {
      * If not provided, uses default duration.
      */
     const val EXTRA_TIMER_MINUTES = "timer_minutes"
+
+    /**
+     * Import ID extra for NAVIGATE_TO_ABS_IMPORT action.
+     *
+     * Value type: String
+     */
+    const val EXTRA_IMPORT_ID = "import_id"
 
     // ═══════════════════════════════════════════════════════════════════════════
     // SHORTCUT IDS

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/upload/ABSUploadWorker.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/upload/ABSUploadWorker.kt
@@ -2,7 +2,9 @@ package com.calypsan.listenup.client.upload
 
 import android.app.NotificationChannel
 import android.app.NotificationManager
+import android.app.PendingIntent
 import android.content.Context
+import android.content.Intent
 import android.content.pm.ServiceInfo
 import android.os.Build
 import android.os.PowerManager
@@ -14,10 +16,12 @@ import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import androidx.work.workDataOf
+import com.calypsan.listenup.client.MainActivity
 import com.calypsan.listenup.client.core.Failure
 import com.calypsan.listenup.client.core.Success
 import com.calypsan.listenup.client.data.remote.ABSImportApiContract
 import com.calypsan.listenup.client.data.remote.BackupApiContract
+import com.calypsan.listenup.client.shortcuts.ShortcutActions
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.io.File
 import java.util.UUID
@@ -27,7 +31,13 @@ private val logger = KotlinLogging.logger {}
 private const val CHANNEL_ID = "abs_upload"
 private const val CHANNEL_NAME = "ABS Import Upload"
 private const val NOTIFICATION_ID = 9001
+private const val RESULT_CHANNEL_ID = "abs_import_complete"
+private const val RESULT_CHANNEL_NAME = "ABS Import Results"
+private const val RESULT_NOTIFICATION_ID = 9002
 private const val MAX_RUN_ATTEMPTS = 3
+private const val NOTIFICATION_TITLE_FAILURE = "Backup import failed"
+private const val NOTIFICATION_TEXT_FAILURE =
+    "The Audiobookshelf backup could not be processed. Please try again."
 
 /**
  * Background worker that uploads an Audiobookshelf backup and creates an import.
@@ -131,18 +141,32 @@ class ABSUploadWorker(
                 is Success -> {
                     val importId = importResult.data.id
                     logger.info { "Import created: id=$importId" }
+                    showResultNotification(
+                        title = "Backup ready to review",
+                        text = "Your Audiobookshelf backup has been analysed and is ready to map.",
+                        iconRes = android.R.drawable.stat_sys_upload_done,
+                        importId = importId,
+                    )
                     Result.success(workDataOf(KEY_IMPORT_ID to importId))
                 }
 
                 is Failure -> {
                     val error = importResult.exception?.message ?: "Failed to create import"
                     logger.error { "Import creation failed: $error" }
-                    retryOrFail(error)
+                    val result = retryOrFail(error)
+                    if (result is Result.Failure) {
+                        showFailureNotification()
+                    }
+                    result
                 }
             }
         } catch (e: Exception) {
             logger.error(e) { "ABS upload failed" }
-            retryOrFail(e.message ?: "Upload failed")
+            val result = retryOrFail(e.message ?: "Upload failed")
+            if (result is Result.Failure) {
+                showFailureNotification()
+            }
+            result
         } finally {
             if (wakeLock.isHeld) wakeLock.release()
             // Clean up cache file
@@ -160,6 +184,71 @@ class ABSUploadWorker(
         } else {
             Result.failure(workDataOf(KEY_ERROR to errorMessage))
         }
+
+    private fun showFailureNotification() {
+        showResultNotification(
+            title = NOTIFICATION_TITLE_FAILURE,
+            text = NOTIFICATION_TEXT_FAILURE,
+            iconRes = android.R.drawable.stat_notify_error,
+        )
+    }
+
+    @Suppress("LongMethod")
+    private fun showResultNotification(
+        title: String,
+        text: String,
+        iconRes: Int,
+        importId: String? = null,
+    ) {
+        val notificationManager =
+            applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel =
+                NotificationChannel(
+                    RESULT_CHANNEL_ID,
+                    RESULT_CHANNEL_NAME,
+                    NotificationManager.IMPORTANCE_DEFAULT,
+                )
+            notificationManager.createNotificationChannel(channel)
+        }
+
+        val intent =
+            if (importId != null) {
+                Intent(applicationContext, MainActivity::class.java).apply {
+                    action = ShortcutActions.NAVIGATE_TO_ABS_IMPORT
+                    putExtra(ShortcutActions.EXTRA_IMPORT_ID, importId)
+                    flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+                }
+            } else {
+                Intent(applicationContext, MainActivity::class.java).apply {
+                    flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+                }
+            }
+
+        val pendingIntent =
+            PendingIntent.getActivity(
+                applicationContext,
+                0,
+                intent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+            )
+
+        // Cancel the ongoing upload notification
+        notificationManager.cancel(NOTIFICATION_ID)
+
+        val notification =
+            NotificationCompat
+                .Builder(applicationContext, RESULT_CHANNEL_ID)
+                .setContentTitle(title)
+                .setContentText(text)
+                .setSmallIcon(iconRes)
+                .setAutoCancel(true)
+                .setContentIntent(pendingIntent)
+                .build()
+
+        notificationManager.notify(RESULT_NOTIFICATION_ID, notification)
+    }
 
     private fun createForegroundInfo(): ForegroundInfo {
         val notificationManager =

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/ShortcutActionManager.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/ShortcutActionManager.kt
@@ -45,6 +45,15 @@ sealed interface ShortcutAction {
     data class NavigateToBook(
         val bookId: String,
     ) : ShortcutAction
+
+    /**
+     * Navigate to a specific ABS import detail screen (from notification deep link).
+     *
+     * @property importId The ID of the import to view
+     */
+    data class NavigateToAbsImport(
+        val importId: String,
+    ) : ShortcutAction
 }
 
 /**


### PR DESCRIPTION
## What

Fixes #165. The upload sheet no longer holds the user while the backup processes. Upload continues in the background, and a notification deep-links directly to the import detail screen when analysis completes.

## Changes

### ShortcutActionManager.kt (shared)
Added `NavigateToAbsImport(importId: String)` to the `ShortcutAction` sealed interface.

### ShortcutActions.kt
Added `NAVIGATE_TO_ABS_IMPORT` action constant and `EXTRA_IMPORT_ID` extra key.

### MainActivity.kt
Handles `NAVIGATE_TO_ABS_IMPORT` intent → `ShortcutAction.NavigateToAbsImport`.

### ListenUpNavigation.kt
Handles `NavigateToAbsImport`: pushes Shell → AdminBackups → ABSImportDetail(importId).

### ABSUploadSheet.kt
Removed the blocking `LaunchedEffect`, the `Uploading` dismiss guard, and `SUCCESS_ANIMATION_DELAY_MS`. Sheet dismisses freely.

### AdminBackupScreen.kt
Dismisses sheet immediately on enqueue. New `LaunchedEffect(uploadSheetState.uploadState)` auto-navigates to `ABSImportDetail(importId)` when the worker completes.

### ABSUploadWorker.kt
Added `showResultNotification()` helper (single implementation, no duplication). Success fires a deep-link notification to the import detail screen; failure relaunches the app.