### PR TITLE
🛡️ Restore in-flight ABS upload after app restart (#165 follow-up)

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/backup/ABSUploadSheet.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/backup/ABSUploadSheet.kt
@@ -57,6 +57,8 @@ import java.util.UUID
 
 private val logger = KotlinLogging.logger {}
 
+private const val DEFAULT_FILENAME = "backup"
+
 /**
  * State for the ABS upload flow.
  */
@@ -667,7 +669,7 @@ class ABSUploadSheetState {
      */
     fun observeWorkInfo(workInfo: WorkInfo?) {
         if (workInfo == null) return
-        val filename = pendingFilename ?: "backup"
+        val filename = pendingFilename ?: DEFAULT_FILENAME
 
         when (workInfo.state) {
             WorkInfo.State.ENQUEUED,
@@ -730,8 +732,8 @@ class ABSUploadSheetState {
             }
         if (running != null) {
             activeWorkId = running.id
-            if (pendingFilename == null) pendingFilename = "backup"
-            uploadState = ABSUploadState.Uploading(pendingFilename ?: "backup", UploadPhase.UPLOADING)
+            if (pendingFilename == null) pendingFilename = DEFAULT_FILENAME
+            uploadState = ABSUploadState.Uploading(pendingFilename ?: DEFAULT_FILENAME, UploadPhase.UPLOADING)
         }
     }
 

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/backup/ABSUploadSheet.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/backup/ABSUploadSheet.kt
@@ -719,12 +719,15 @@ class ABSUploadSheetState {
      */
     fun restoreActiveWorkIfRunning(context: Context) {
         if (activeWorkId != null) return
-        val infos = WorkManager.getInstance(context)
-            .getWorkInfosByTag(ABSUploadWorker.WORK_TAG)
-            .get()
-        val running = infos.firstOrNull { info ->
-            info.state == WorkInfo.State.RUNNING || info.state == WorkInfo.State.ENQUEUED
-        }
+        val infos =
+            WorkManager
+                .getInstance(context)
+                .getWorkInfosByTag(ABSUploadWorker.WORK_TAG)
+                .get()
+        val running =
+            infos.firstOrNull { info ->
+                info.state == WorkInfo.State.RUNNING || info.state == WorkInfo.State.ENQUEUED
+            }
         if (running != null) {
             activeWorkId = running.id
             if (pendingFilename == null) pendingFilename = "backup"

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/backup/AdminBackupScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/backup/AdminBackupScreen.kt
@@ -98,6 +98,11 @@ fun AdminBackupScreen(
             uploadSheetState.onDocumentSelected(result)
         }
 
+    // Restore any in-flight upload job after app restart
+    LaunchedEffect(Unit) {
+        uploadSheetState.restoreActiveWorkIfRunning(context)
+    }
+
     // Observe WorkManager work info when an upload is active
     LaunchedEffect(uploadSheetState.activeWorkId) {
         val flow = uploadSheetState.getWorkInfoFlow(context) ?: return@LaunchedEffect

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/upload/ABSUploadWorker.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/upload/ABSUploadWorker.kt
@@ -65,6 +65,7 @@ class ABSUploadWorker(
         const val KEY_FILE_SIZE = "file_size"
         const val KEY_IMPORT_ID = "import_id"
         const val KEY_ERROR = "error"
+        const val WORK_TAG = "abs_upload_worker"
 
         /**
          * Enqueue an upload work request.
@@ -92,6 +93,7 @@ class ABSUploadWorker(
                 OneTimeWorkRequestBuilder<ABSUploadWorker>()
                     .setInputData(data)
                     .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+                    .addTag(WORK_TAG)
                     .build()
 
             WorkManager.getInstance(context).enqueue(request)


### PR DESCRIPTION
## What

Follow-up to #174. Adds crash resilience: if the app is killed and relaunched while an upload is in progress, the in-flight job is automatically re-observed on screen startup.

## Changes

### ABSUploadWorker.kt
Added `WORK_TAG` constant and `.addTag(WORK_TAG)` to the work request so jobs are queryable by tag.

### ABSUploadSheet.kt
Added `restoreActiveWorkIfRunning()` to `ABSUploadSheetState`: queries WorkManager by tag for any RUNNING/ENQUEUED job and restores `activeWorkId` + upload state.

### AdminBackupScreen.kt
Added `LaunchedEffect(Unit)` on screen startup that calls `restoreActiveWorkIfRunning(context)`.

## Result
- App killed mid-upload → relaunch → AdminBackupScreen re-attaches to the running worker
- Worker completes → auto-navigates to import detail (existing LaunchedEffect)
- If not on AdminBackupScreen when it completes → completion notification still fires (existing)