### PR TITLE
🐛 Keep upload sheet visible during upload — dismiss freely (#165 fix)

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/backup/AdminBackupScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/admin/backup/AdminBackupScreen.kt
@@ -166,10 +166,9 @@ fun AdminBackupScreen(
             state = uploadSheetState.uploadState,
             onPickFile = { documentPicker.launch() },
             onUpload = {
-                val workId = uploadSheetState.enqueueUpload(context)
-                if (workId != null) {
-                    showUploadSheet = false
-                }
+                // Sheet stays visible during upload — shows existing progress UI.
+                // Upload runs via foreground service so user can dismiss freely.
+                uploadSheetState.enqueueUpload(context)
             },
             onNavigateToImport = { importId ->
                 showUploadSheet = false


### PR DESCRIPTION
## Problem

After #175, the sheet was dismissed immediately on enqueue leaving the user with zero in-app feedback during the upload (the import does not exist yet while the file is uploading, so the AdminBackupScreen import list has nothing to show).

## Fix

Remove the automatic `showUploadSheet = false` on enqueue. The sheet stays open and shows the existing upload progress UI (spinner + phase text). The user can now:
- **Stay on the sheet** to see upload progress  
- **Dismiss freely** at any time (the dismiss guard was already removed) — the foreground service keeps uploading
- **Get a notification** when analysis completes regardless of whether they dismissed or not
- **Auto-navigate** to the import detail screen when the worker completes (if still on AdminBackupScreen)