### PR TITLE
🐛 Fix series detail crash on navigation (#167)

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/BookCoverImage.kt
+++ b/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/BookCoverImage.kt
@@ -76,8 +76,8 @@ fun BookCoverImage(
         key1 = bookId,
         key2 = coverPath,
     ) {
-        // Skip async if we already have a sync request
-        if (coverPath != null) return@produceState
+        // Skip async if we already have a sync request, or if bookId is blank (no valid ID to look up)
+        if (coverPath != null || bookId.isBlank()) return@produceState
 
         val imageRepository: ImageRepository =
             org.koin.core.context.GlobalContext

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/SearchRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/SearchRepositoryImpl.kt
@@ -211,7 +211,7 @@ private fun SearchHitResponse.toDomain(imageStorage: ImageStorage): SearchHit {
 
     // Resolve cover path for books (convert String to BookId)
     val coverPath =
-        if (hitType == SearchHitType.BOOK) {
+        if (hitType == SearchHitType.BOOK && id.isNotBlank()) {
             val bookId = BookId(id)
             if (imageStorage.exists(bookId)) imageStorage.getCoverPath(bookId) else null
         } else {

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/seriesdetail/SeriesDetailViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/seriesdetail/SeriesDetailViewModel.kt
@@ -99,7 +99,7 @@ class SeriesDetailViewModel(
  * UI state for the Series Detail screen.
  */
 data class SeriesDetailUiState(
-    val isLoading: Boolean = false,
+    val isLoading: Boolean = true,
     val seriesId: String = "",
     val seriesName: String = "",
     val seriesDescription: String? = null,

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/seriesdetail/SeriesDetailViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/seriesdetail/SeriesDetailViewModelTest.kt
@@ -131,7 +131,7 @@ class SeriesDetailViewModelTest {
     // ========== Initial State Tests ==========
 
     @Test
-    fun `initial state has isLoading false and empty data`() =
+    fun `initial state has isLoading true and empty data`() =
         runTest {
             // Given
             val fixture = createFixture()
@@ -139,7 +139,7 @@ class SeriesDetailViewModelTest {
 
             // Then
             val state = viewModel.state.value
-            assertFalse(state.isLoading)
+            assertTrue(state.isLoading)
             assertEquals("", state.seriesName)
             assertTrue(state.books.isEmpty())
             assertNull(state.error)


### PR DESCRIPTION
## Root Cause

`SeriesDetailUiState` defaults to `isLoading = false`, so the first composition frame renders the content branch before `LaunchedEffect` fires `loadSeries()`. The hero section passes `bookId = featuredBookId ?: ""` to `BookCoverImage` — with no data loaded yet, `featuredBookId` is null, so `bookId = ""`. The async path calls `BookId("")` which throws `IllegalArgumentException` from the value class `require(isNotBlank)` guard inside `produceState` — instant fatal crash.

The same blank-ID pattern also silently breaks search (#178): `SearchHitResponse.toDomain()` calls `BookId(id)` without a blank check, so any server result with a blank `id` throws and falls back to empty local FTS.

## Changes

- **`SeriesDetailUiState.isLoading` default → `true`** — shows loading spinner on first frame instead of crashing on blank `featuredBookId`
- **`BookCoverImage` blank-ID guard** — bail out of async path when `bookId.isBlank()`, defensive against any screen passing empty string
- **`SearchHitResponse.toDomain()` blank-ID guard** — only call `BookId(id)` when `id.isNotBlank()`, prevents silent server search fallback (#178)
- **`SeriesDetailViewModelTest`** — updated initial-state assertion to match corrected default

Closes #167
Closes #178