### PR TITLE
🐛 Fix reading sessions sync — wrong deserialization model (#179)

### DIFF
--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/SyncApi.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/SyncApi.kt
@@ -430,25 +430,25 @@ class SyncApi(
     override suspend fun getReadingSessions(): Result<SyncReadingSessionsResponse> =
         suspendRunCatching {
             val client = clientFactory.getClient()
-            val response: ApiResponse<ApiReadingSessions> =
+            val response: ApiResponse<ApiActiveSessions> =
                 client.get("/api/v1/sync/active-sessions").body()
             val apiSessions = response.toResult().getOrThrow()
             SyncReadingSessionsResponse(
                 readers =
-                    apiSessions.readers.map { reader ->
+                    apiSessions.sessions.map { session ->
                         SyncReadingSessionReaderResponse(
-                            bookId = reader.bookId,
-                            userId = reader.userId,
-                            displayName = reader.displayName,
-                            avatarType = reader.avatarType,
-                            avatarValue = reader.avatarValue,
-                            avatarColor = reader.avatarColor,
-                            isCurrentlyReading = reader.isCurrentlyReading,
-                            currentProgress = reader.currentProgress,
-                            startedAt = reader.startedAt,
-                            finishedAt = reader.finishedAt,
-                            lastActivityAt = reader.lastActivityAt,
-                            completionCount = reader.completionCount,
+                            bookId = session.bookId,
+                            userId = session.userId,
+                            displayName = session.displayName,
+                            avatarType = session.avatarType,
+                            avatarValue = session.avatarValue,
+                            avatarColor = session.avatarColor,
+                            isCurrentlyReading = false,
+                            currentProgress = 0.0,
+                            startedAt = session.startedAt,
+                            finishedAt = null,
+                            lastActivityAt = session.startedAt,
+                            completionCount = 0,
                         )
                     },
             )

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/SyncApi.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/SyncApi.kt
@@ -8,7 +8,6 @@ import com.calypsan.listenup.client.core.getOrThrow
 import com.calypsan.listenup.client.core.suspendRunCatching
 import com.calypsan.listenup.client.data.remote.model.AllProgressResponse
 import com.calypsan.listenup.client.data.remote.model.ApiActiveSessions
-import com.calypsan.listenup.client.data.remote.model.ApiReadingSessions
 import com.calypsan.listenup.client.data.remote.model.ApiResponse
 import com.calypsan.listenup.client.data.remote.model.ContinueListeningItemResponse
 import com.calypsan.listenup.client.data.remote.model.ContinueListeningResponse


### PR DESCRIPTION
## Root Cause

`getReadingSessions()` in `SyncApi.kt` calls `GET /api/v1/sync/active-sessions` but deserializes into `ApiReadingSessions` which expects `{ "readers": [...] }`. The server returns `{ "sessions": [...] }`, causing a `MissingFieldException` on every sync.

The correct model — `ApiActiveSessions` / `ApiActiveSessionResponse` — already exists in `SyncModels.kt` and exactly matches the server's `SyncActiveSessionsResponse` shape. The function was just using the wrong type.

## Change

- `ApiResponse<ApiReadingSessions>` → `ApiResponse<ApiActiveSessions>`
- `apiSessions.readers.map { reader ->` → `apiSessions.sessions.map { session ->`
- Field mapping updated; server-absent fields (`isCurrentlyReading`, `currentProgress`, `finishedAt`, `lastActivityAt`, `completionCount`) use sane defaults until the server API is enriched

## Notes

- `ApiReadingSessions` is now unused (dead code — can be removed in a follow-up)
- Server-side: enrich `SyncActiveSessionsResponse` to include the missing fields for full feature support

Closes #179