### PR TITLE
🐛 Fix ABS import: status polling + list refresh after background upload (#181)

### DIFF
--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/admin/ABSImportHubViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/admin/ABSImportHubViewModel.kt
@@ -246,6 +246,15 @@ class ABSImportHubViewModel(
                     hubState.update { it.copy(import = result.data, isLoading = false) }
                     // Load initial data for the active tab
                     loadTabData(ImportHubTab.OVERVIEW)
+                    // Start polling if analysis is still in progress (covers WorkManager upload flow)
+                    if (result.data.status == IMPORT_STATUS_ANALYZING) {
+                        startAnalysisPolling(importId)
+                    }
+                    // If this import isn't in the list yet (newly created via background upload),
+                    // reload the list so the user sees it when they navigate back
+                    if (listState.value.imports.none { it.id == importId }) {
+                        loadImports()
+                    }
                 }
 
                 is Failure -> {


### PR DESCRIPTION
## Root Cause

Two gaps left after the WorkManager background upload fix (#165):

**1. Status stuck at 'analyzing'**
`openImport()` fetched the import once but never started the polling loop. `startAnalysisPolling()` was only called from `createImport()` / `createImportFromPath()`. Since WorkManager bypasses those VM functions entirely, landing on the import detail via deep-link or notification left the status frozen.

**2. List doesn't show the new import**
`loadImports()` ran once at VM init (before the upload finished). The new import didn't exist yet, so it was never in the list. The polling loop in `startAnalysisPolling()` updates existing list entries by ID — it can't add entries that weren't there.

## Fix

Both gaps fixed in `openImport()`:

```kotlin
// Start polling if analysis is still in progress (covers WorkManager upload flow)
if (result.data.status == IMPORT_STATUS_ANALYZING) {
    startAnalysisPolling(importId)
}
// If this import isn't in the list yet (newly created via background upload),
// reload the list so the user sees it when they navigate back
if (listState.value.imports.none { it.id == importId }) {
    loadImports()
}
```

- Polling updates both `hubState` (detail screen) and `listState` (list screen) every 3s until status != analyzing — so both screens stay live
- List reload only fires when the import is genuinely missing (not on every open)

Closes #181