### PR TITLE
Fix slow playback start — use local file URI for downloaded books

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlayerViewModel.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlayerViewModel.kt
@@ -142,12 +142,12 @@ class PlayerViewModel(
                         logger.debug {
                             "MediaItem[$index]: id=${file.audioFileId}, " +
                                 "duration=${file.durationMs}ms, " +
-                                "url=${file.streamingUrl.takeLast(30)}"
+                                "uri=${file.playbackUri.takeLast(40)} (local=${file.isDownloaded})"
                         }
                         MediaItem
                             .Builder()
                             .setMediaId(file.audioFileId)
-                            .setUri(file.streamingUrl)
+                            .setUri(file.playbackUri)
                             .setMediaMetadata(
                                 MediaMetadata
                                     .Builder()


### PR DESCRIPTION
Fixes #189

**Root cause:** `PlayerViewModel.connectAndPlay()` always passed `file.streamingUrl` to ExoPlayer when building `MediaItem`s — even when the book was fully downloaded locally. `FileSegment.playbackUri` (which prefers `file://` local path when downloaded) existed but was never used. Downloaded books were streaming over the network unnecessarily.

**Fix:** Changed `file.streamingUrl` → `file.playbackUri` when building `MediaItem`s. For downloaded books, ExoPlayer now reads from the local file system instead of making network requests over Tailscale.

**Note:** For non-downloaded books streaming over a slow connection (Tailscale), further improvement is possible via `DefaultLoadControl` buffer tuning — tracked in #189.