### PR TITLE
🐛 Restore playback speed on app relaunch

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
@@ -850,6 +850,11 @@ class PlaybackService : MediaLibraryService() {
                                                         .build(),
                                                 ).build()
                                         }
+                                    // Apply the restored playback speed to ExoPlayer
+                                    val resumeSpeed = prepareResult.resumeSpeed
+                                    if (resumeSpeed != 1.0f) {
+                                        this@PlaybackService.player?.setPlaybackSpeed(resumeSpeed)
+                                    }
                                     resolvedItems.addAll(bookItems)
                                 }
                             } else {
@@ -1012,6 +1017,11 @@ class PlaybackService : MediaLibraryService() {
                                     ).build()
                             }
 
+                        // Apply the restored playback speed to ExoPlayer
+                        val resumeSpeed = prepareResult.resumeSpeed
+                        if (resumeSpeed != 1.0f) {
+                            this@PlaybackService.player?.setPlaybackSpeed(resumeSpeed)
+                        }
                         // Resolve start position
                         val startPosition = prepareResult.timeline.resolve(prepareResult.resumePositionMs)
 

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
@@ -405,6 +405,16 @@ class PlaybackService : MediaLibraryService() {
     }
 
     /**
+     * Apply restored playback speed to ExoPlayer.
+     * Extracted to keep onAddMediaItems and onPlaybackResumption within complexity limits.
+     */
+    private fun applyResumeSpeed(speed: Float) {
+        if (speed != 1.0f) {
+            player?.setPlaybackSpeed(speed)
+        }
+    }
+
+    /**
      * Listens to player events for logging and progress tracking.
      */
     private inner class PlayerListener : Player.Listener {
@@ -851,10 +861,7 @@ class PlaybackService : MediaLibraryService() {
                                                 ).build()
                                         }
                                     // Apply the restored playback speed to ExoPlayer
-                                    val resumeSpeed = prepareResult.resumeSpeed
-                                    if (resumeSpeed != 1.0f) {
-                                        this@PlaybackService.player?.setPlaybackSpeed(resumeSpeed)
-                                    }
+                                    applyResumeSpeed(prepareResult.resumeSpeed)
                                     resolvedItems.addAll(bookItems)
                                 }
                             } else {
@@ -1018,10 +1025,7 @@ class PlaybackService : MediaLibraryService() {
                             }
 
                         // Apply the restored playback speed to ExoPlayer
-                        val resumeSpeed = prepareResult.resumeSpeed
-                        if (resumeSpeed != 1.0f) {
-                            this@PlaybackService.player?.setPlaybackSpeed(resumeSpeed)
-                        }
+                        applyResumeSpeed(prepareResult.resumeSpeed)
                         // Resolve start position
                         val startPosition = prepareResult.timeline.resolve(prepareResult.resumePositionMs)
 


### PR DESCRIPTION
Fixes #190: Playback speed was not being applied to ExoPlayer when resuming playback after app relaunch. The PlaybackManager correctly computed the resume speed from saved position or default preferences, but the Android PlaybackService never set it on the ExoPlayer instance in onPlaybackResumption or onAddMediaItems.