### PR TITLE
🔗 Switch ReadingSessionPuller to /sync/reading-sessions

### DIFF
--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/SyncApi.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/SyncApi.kt
@@ -422,15 +422,16 @@ class SyncApi(
 
     /**
      * Get all reading sessions for offline-first book detail pages.
+     * Returns active, completed, and abandoned sessions for the Readers section.
      *
-     * Endpoint: GET /api/v1/sync/active-sessions
+     * Endpoint: GET /api/v1/sync/reading-sessions
      * Auth: Required
      */
     override suspend fun getReadingSessions(): Result<SyncReadingSessionsResponse> =
         suspendRunCatching {
             val client = clientFactory.getClient()
             val response: ApiResponse<ApiActiveSessions> =
-                client.get("/api/v1/sync/active-sessions").body()
+                client.get("/api/v1/sync/reading-sessions").body()
             val apiSessions = response.toResult().getOrThrow()
             SyncReadingSessionsResponse(
                 readers =


### PR DESCRIPTION
Companion to ListenUpApp/server#62.

ReadingSessionPuller was calling /sync/active-sessions which only returns sessions with finished_at IS NULL. Completed and abandoned sessions were excluded, leaving the Readers section empty.

Switch to /sync/reading-sessions which returns all session states. Single-line change in SyncApi.kt.