### PR TITLE
🐛 Pull-to-refresh triggers sync to update listening sessions

### DIFF
--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/home/HomeViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/home/HomeViewModel.kt
@@ -183,14 +183,15 @@ class HomeViewModel(
     /**
      * Refresh home screen data.
      *
-     * Since continue listening is observed from local Room data, this is a no-op.
-     * The Flow automatically updates when playback positions change.
-     * Pull-to-refresh triggers sync elsewhere, which updates Room,
-     * causing the Flow to emit new data.
+     * Triggers a full sync with the server, which pulls updated playback progress
+     * (including isFinished state) into local Room. The continue listening and
+     * shelves Flows then emit automatically with the new data.
      */
     fun refresh() {
-        // No-op - data auto-updates from Room Flow
-        logger.debug { "Refresh requested - data will update automatically from Room" }
+        viewModelScope.launch {
+            logger.debug { "Refresh: triggering sync to pull latest progress" }
+            syncRepository.sync()
+        }
     }
 
     /**

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/home/HomeViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/home/HomeViewModelTest.kt
@@ -300,7 +300,9 @@ class HomeViewModelTest {
         runTest {
             // Given
             val fixture = createFixture()
-            everySuspend { fixture.syncRepository.sync() } returns com.calypsan.listenup.client.core.Success(Unit)
+            everySuspend { fixture.syncRepository.sync() } returns
+                com.calypsan.listenup.client.core
+                    .Success(Unit)
             val viewModel = fixture.build()
             advanceUntilIdle()
 

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/home/HomeViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/home/HomeViewModelTest.kt
@@ -7,9 +7,12 @@ import com.calypsan.listenup.client.domain.repository.ShelfRepository
 import com.calypsan.listenup.client.domain.repository.SyncRepository
 import com.calypsan.listenup.client.domain.repository.UserRepository
 import dev.mokkery.answering.returns
+import dev.mokkery.answering.throws
 import dev.mokkery.every
+import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
+import dev.mokkery.verifySuspend
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -293,21 +296,42 @@ class HomeViewModelTest {
     // ========== Refresh Tests ==========
 
     @Test
-    fun `refresh is no-op since data is observed reactively`() =
+    fun `refresh triggers a full server sync`() =
         runTest {
-            // Given - ViewModel with reactive observation
+            // Given
             val fixture = createFixture()
-            fixture.continueListeningFlow.value = listOf(createContinueListeningBook())
+            everySuspend { fixture.syncRepository.sync() } returns com.calypsan.listenup.client.core.Success(Unit)
             val viewModel = fixture.build()
             advanceUntilIdle()
-            val initialState = viewModel.state.value
 
-            // When - refresh is called
+            // When
             viewModel.refresh()
             advanceUntilIdle()
 
-            // Then - state is unchanged (refresh is a no-op)
-            assertEquals(initialState.continueListening, viewModel.state.value.continueListening)
+            // Then
+            verifySuspend { fixture.syncRepository.sync() }
+        }
+
+    @Test
+    fun `refresh handles sync failure gracefully`() =
+        runTest {
+            // Given - sync returns a failure Result (not an exception)
+            val fixture = createFixture()
+            everySuspend { fixture.syncRepository.sync() } returns
+                com.calypsan.listenup.client.core.Failure(
+                    exception = RuntimeException("Network error"),
+                    message = "Network error",
+                )
+            val viewModel = fixture.build()
+            advanceUntilIdle()
+
+            // When
+            viewModel.refresh()
+            advanceUntilIdle()
+
+            // Then - ViewModel is still functional, sync was attempted
+            verifySuspend { fixture.syncRepository.sync() }
+            assertFalse(viewModel.state.value.isDataLoading)
         }
 
     // ========== State Derived Properties Tests ==========


### PR DESCRIPTION
HomeViewModel.refresh() was a no-op — it logged a debug message and returned, so pull-to-refresh on the home screen never actually fetched updated progress from the server.

Fixed to call syncRepository.sync(), which runs the full pull/push pipeline including ProgressPuller. The isSyncing flag is already observed from syncRepository.syncState so the loading indicator works automatically.

One-line change in HomeViewModel.refresh().