### PR TITLE
Fix: Scale skip duration by playback speed

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/playback/NowPlayingViewModel.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/playback/NowPlayingViewModel.kt
@@ -367,7 +367,7 @@ class NowPlayingViewModel(
         }
 
         val currentBookPos = playbackManager.currentPositionMs.value
-        val newBookPos = (currentBookPos - seconds * 1000).coerceAtLeast(0)
+        val newBookPos = (currentBookPos - (seconds * state.value.playbackSpeed * 1000).toLong()).coerceAtLeast(0)
         logger.debug { "skipBack: currentPos=$currentBookPos, newPos=$newBookPos" }
 
         val position = timeline.resolve(newBookPos)
@@ -396,7 +396,7 @@ class NowPlayingViewModel(
 
         val currentBookPos = playbackManager.currentPositionMs.value
         val totalDuration = playbackManager.totalDurationMs.value
-        val newBookPos = (currentBookPos + seconds * 1000).coerceAtMost(totalDuration)
+        val newBookPos = (currentBookPos + (seconds * state.value.playbackSpeed * 1000).toLong()).coerceAtMost(totalDuration)
         logger.debug { "skipForward: currentPos=$currentBookPos, newPos=$newBookPos, totalDuration=$totalDuration" }
 
         val position = timeline.resolve(newBookPos)

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/playback/NowPlayingViewModel.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/playback/NowPlayingViewModel.kt
@@ -396,7 +396,10 @@ class NowPlayingViewModel(
 
         val currentBookPos = playbackManager.currentPositionMs.value
         val totalDuration = playbackManager.totalDurationMs.value
-        val newBookPos = (currentBookPos + (seconds * state.value.playbackSpeed * 1000).toLong()).coerceAtMost(totalDuration)
+        val newBookPos =
+            (currentBookPos + (seconds * state.value.playbackSpeed * 1000).toLong()).coerceAtMost(
+                totalDuration,
+            )
         logger.debug { "skipForward: currentPos=$currentBookPos, newPos=$newBookPos, totalDuration=$totalDuration" }
 
         val position = timeline.resolve(newBookPos)

--- a/composeApp/src/desktopMain/kotlin/com/calypsan/listenup/client/playback/DesktopPlayerViewModel.kt
+++ b/composeApp/src/desktopMain/kotlin/com/calypsan/listenup/client/playback/DesktopPlayerViewModel.kt
@@ -184,14 +184,14 @@ class DesktopPlayerViewModel(
 
     fun skipBack(seconds: Int = 10) {
         val currentPos = playbackManager.currentPositionMs.value
-        val newPos = (currentPos - seconds * 1000L).coerceAtLeast(0)
+        val newPos = (currentPos - (seconds * state.value.playbackSpeed * 1000).toLong()).coerceAtLeast(0)
         audioPlayer.seekTo(newPos)
     }
 
     fun skipForward(seconds: Int = 30) {
         val currentPos = playbackManager.currentPositionMs.value
         val totalDuration = playbackManager.totalDurationMs.value
-        val newPos = (currentPos + seconds * 1000L).coerceAtMost(totalDuration)
+        val newPos = (currentPos + (seconds * state.value.playbackSpeed * 1000).toLong()).coerceAtMost(totalDuration)
         audioPlayer.seekTo(newPos)
     }
 


### PR DESCRIPTION
Fixes #200

## Problem
The skip forward/back buttons used a hardcoded duration in real seconds, ignoring playback speed. At 2x speed, tapping "back 10s" only moved 10 real seconds (5 seconds of listening time) instead of the expected 20 real seconds (10 seconds of listening time).

## Solution
Multiply the skip duration by the current playback speed so the skip always represents the same amount of *listening time* regardless of speed.

## Changes
- **`NowPlayingViewModel.kt`** (Android) — `skipBack` and `skipForward` now multiply by `state.value.playbackSpeed`
- **`DesktopPlayerViewModel.kt`** (Desktop) — same fix applied to the desktop player