### PR TITLE
Fix: Pause playback when user swipes app away

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
@@ -311,14 +311,18 @@ class PlaybackService : MediaLibraryService() {
     override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaLibrarySession? = mediaLibrarySession
 
     override fun onTaskRemoved(rootIntent: Intent?) {
+        val player = mediaLibrarySession?.player
+
+        // Pause playback when user swipes app away — notification remains for resume
+        player?.playWhenReady = false
+
         // Always save position when the user swipes the app away — if the system
         // later kills the process, onDestroy may not get a chance to run
         saveCurrentPosition()
 
-        val player = mediaLibrarySession?.player
         // Don't stop immediately - keep the idle timer running
         // User can still resume from notification
-        if (player == null || (!player.playWhenReady && idleJob == null)) {
+        if (player == null || idleJob == null) {
             stopSelf()
         }
     }


### PR DESCRIPTION
Fixes #207

## Problem
`onTaskRemoved` intentionally kept playback running after swipe-away so users could resume from the notification. With `WAKE_MODE_LOCAL` keeping the CPU awake, this meant audio could play silently to completion (muted device, disconnected Bluetooth) without the user knowing — causing the position jump bug in #204.

## Fix
Set `player.playWhenReady = false` before saving position. The notification persists so users can still resume. The idle timer condition is simplified since `playWhenReady` is now always false at that point.