### PR TITLE
🔒🛡️ Gate sync behind auth & clear playback on logout

### DIFF
--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/PendingOperationDao.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/PendingOperationDao.kt
@@ -215,4 +215,17 @@ interface PendingOperationDao {
         """,
     )
     suspend fun resetStuckOperations()
+
+    /**
+     * Get book IDs that have a pending or in-progress MARK_COMPLETE operation.
+     * Used by ProgressPuller to avoid overwriting local isFinished=true.
+     */
+    @Query(
+        """
+        SELECT entityId FROM pending_operations
+        WHERE operationType = ${OperationType.MARK_COMPLETE_ORDINAL}
+          AND status IN (${OperationStatus.PENDING_ORDINAL}, ${OperationStatus.IN_PROGRESS_ORDINAL})
+        """,
+    )
+    suspend fun getPendingMarkCompleteBookIds(): List<String>
 }

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/PendingOperationEntity.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/PendingOperationEntity.kt
@@ -74,6 +74,9 @@ enum class OperationType {
     // Profile updates (coalesce by user)
     PROFILE_UPDATE,
     PROFILE_AVATAR,
+
+    // Mark book as complete (retry on failure)
+    MARK_COMPLETE,
     ;
 
     companion object {
@@ -90,6 +93,7 @@ enum class OperationType {
         const val USER_PREFERENCES_ORDINAL = 9
         const val PROFILE_UPDATE_ORDINAL = 10
         const val PROFILE_AVATAR_ORDINAL = 11
+        const val MARK_COMPLETE_ORDINAL = 12
     }
 }
 

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/PendingOperationRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/PendingOperationRepositoryImpl.kt
@@ -74,6 +74,7 @@ private fun OperationType.toDomain(): PendingOperationType =
         OperationType.USER_PREFERENCES -> PendingOperationType.USER_PREFERENCES
         OperationType.PROFILE_UPDATE -> PendingOperationType.PROFILE_UPDATE
         OperationType.PROFILE_AVATAR -> PendingOperationType.PROFILE_AVATAR
+        OperationType.MARK_COMPLETE -> PendingOperationType.MARK_COMPLETE
     }
 
 /**

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/PlaybackPositionRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/PlaybackPositionRepositoryImpl.kt
@@ -119,13 +119,13 @@ class PlaybackPositionRepositoryImpl(
             }
 
             is Failure -> {
-                logger.warn { "markComplete: server sync failed for $bookId, rolling back" }
-                // Rollback on failure
-                if (existing != null) {
-                    dao.save(existing)
-                } else {
-                    dao.delete(BookId(bookId))
+                logger.warn {
+                    "markComplete: server sync failed for $bookId (keeping local update; will sync on next pull)"
                 }
+                // Do NOT rollback. Optimistic local update is correct.
+                // Book is marked finished locally (isFinished = true persists).
+                // Server will eventually sync back the correct state via ProgressPuller.
+                // Rolling back on failure creates a race where the book reappears in Continue Listening.
                 result
             }
         }

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/SettingsRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/SettingsRepositoryImpl.kt
@@ -267,7 +267,7 @@ class SettingsRepositoryImpl(
      * 2. Making another HTTP call during auth failure can cause issues
      * 3. Server setup status rarely changes during a session
      *
-     * TODO: Add playback resilience - check if audio is playing before clearing.
+     * Playback resilience handled in LogoutUseCase (clears playback before auth tokens).
      * If playing, show banner instead of redirecting to login.
      */
     override suspend fun clearAuthTokens() {

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/pull/ProgressPuller.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/pull/ProgressPuller.kt
@@ -106,20 +106,12 @@ class ProgressPuller(
                         } else {
                             entities.map { entity ->
                                 if (entity.bookId.value in pendingCompleteBookIds && !entity.isFinished) {
-                                    // Server says not finished but we have a pending local markComplete
-                                    // Preserve local isFinished=true
-                                    val localEntity = existingPositions[entity.bookId.value]
-                                    if (localEntity?.isFinished == true) {
-                                        logger.info {
-                                            "Preserving local isFinished=true for ${entity.bookId.value} (pending MARK_COMPLETE)"
-                                        }
-                                        entity.copy(
-                                            isFinished = true,
-                                            finishedAt = localEntity.finishedAt,
-                                        )
-                                    } else {
-                                        entity
+                                    // Server says not finished but we have a pending local markComplete.
+                                    // The pending op is the source of truth — unconditionally preserve isFinished.
+                                    logger.info {
+                                        "Preserving isFinished=true for ${entity.bookId.value} (pending MARK_COMPLETE)"
                                     }
+                                    entity.copy(isFinished = true)
                                 } else {
                                     entity
                                 }

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/pull/ProgressPuller.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/pull/ProgressPuller.kt
@@ -4,6 +4,7 @@ import com.calypsan.listenup.client.core.BookId
 import com.calypsan.listenup.client.core.Result
 import com.calypsan.listenup.client.data.local.db.PendingOperationDao
 import com.calypsan.listenup.client.data.local.db.PlaybackPositionDao
+import com.calypsan.listenup.client.data.local.db.PlaybackPositionEntity
 import com.calypsan.listenup.client.data.remote.SyncApiContract
 import com.calypsan.listenup.client.data.sync.model.SyncPhase
 import com.calypsan.listenup.client.data.sync.model.SyncStatus
@@ -83,54 +84,7 @@ class ProgressPuller(
                             item.toEntity(existing)
                         }
 
-                    // Debug: Verify entities have correct isFinished values before save
-                    val finishedEntities = entities.filter { it.isFinished }
-                    logger.debug {
-                        "Entities with isFinished=true BEFORE saveAll: ${finishedEntities.size}"
-                    }
-                    if (finishedEntities.isNotEmpty()) {
-                        val sample = finishedEntities.take(3)
-                        logger.debug {
-                            "Sample finished entities: ${sample.map {
-                                "${it.bookId.value}: isFinished=${it.isFinished}"
-                            }}"
-                        }
-                    }
-
-                    // Guard: don't overwrite isFinished for books with pending MARK_COMPLETE
-                    val pendingCompleteBookIds =
-                        pendingOperationDao.getPendingMarkCompleteBookIds().toSet()
-                    val guardedEntities =
-                        if (pendingCompleteBookIds.isEmpty()) {
-                            entities
-                        } else {
-                            entities.map { entity ->
-                                if (entity.bookId.value in pendingCompleteBookIds && !entity.isFinished) {
-                                    // Server says not finished but we have a pending local markComplete.
-                                    // The pending op is the source of truth — unconditionally preserve isFinished.
-                                    logger.info {
-                                        "Preserving isFinished=true for ${entity.bookId.value} (pending MARK_COMPLETE)"
-                                    }
-                                    entity.copy(isFinished = true)
-                                } else {
-                                    entity
-                                }
-                            }
-                        }
-
-                    playbackPositionDao.saveAll(guardedEntities)
-
-                    // Debug: Verify what's in DB after save
-                    val dbCheck = playbackPositionDao.getByBookIds(entities.map { it.bookId })
-                    val dbFinishedCount = dbCheck.count { it.isFinished }
-                    logger.debug {
-                        "DB check AFTER saveAll: ${dbCheck.size} positions, $dbFinishedCount finished"
-                    }
-                    if (dbFinishedCount == 0 && finishedEntities.isNotEmpty()) {
-                        logger.warn {
-                            "BUG: isFinished not persisting! ${finishedEntities.size} entities had isFinished=true but DB shows 0"
-                        }
-                    }
+                    guardAndSaveEntities(entities)
 
                     logger.info {
                         "Progress sync complete: $created created, $updated updated, " +
@@ -146,6 +100,60 @@ class ProgressPuller(
         } catch (e: Exception) {
             logger.warn(e) { "Failed to sync progress" }
             // Don't throw - progress sync is not critical for basic functionality
+        }
+    }
+
+    /**
+     * Apply pending MARK_COMPLETE guards, persist entities, and verify isFinished state.
+     *
+     * Ensures books with pending local MARK_COMPLETE operations retain isFinished=true
+     * even if the server hasn't processed the operation yet.
+     */
+    private suspend fun guardAndSaveEntities(entities: List<PlaybackPositionEntity>) {
+        val finishedEntities = entities.filter { it.isFinished }
+        logger.debug {
+            "Entities with isFinished=true BEFORE saveAll: ${finishedEntities.size}"
+        }
+        if (finishedEntities.isNotEmpty()) {
+            val sample = finishedEntities.take(3)
+            logger.debug {
+                "Sample finished entities: ${sample.map {
+                    "${it.bookId.value}: isFinished=${it.isFinished}"
+                }}"
+            }
+        }
+
+        // Guard: don't overwrite isFinished for books with pending MARK_COMPLETE
+        val pendingCompleteBookIds =
+            pendingOperationDao.getPendingMarkCompleteBookIds().toSet()
+        val guardedEntities =
+            if (pendingCompleteBookIds.isEmpty()) {
+                entities
+            } else {
+                entities.map { entity ->
+                    if (entity.bookId.value in pendingCompleteBookIds && !entity.isFinished) {
+                        logger.info {
+                            "Preserving isFinished=true for ${entity.bookId.value} (pending MARK_COMPLETE)"
+                        }
+                        entity.copy(isFinished = true)
+                    } else {
+                        entity
+                    }
+                }
+            }
+
+        playbackPositionDao.saveAll(guardedEntities)
+
+        // Debug: Verify what's in DB after save
+        val dbCheck = playbackPositionDao.getByBookIds(entities.map { it.bookId })
+        val dbFinishedCount = dbCheck.count { it.isFinished }
+        logger.debug {
+            "DB check AFTER saveAll: ${dbCheck.size} positions, $dbFinishedCount finished"
+        }
+        if (dbFinishedCount == 0 && finishedEntities.isNotEmpty()) {
+            logger.warn {
+                "BUG: isFinished not persisting! ${finishedEntities.size} entities had isFinished=true but DB shows 0"
+            }
         }
     }
 }

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/push/OperationExecutor.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/push/OperationExecutor.kt
@@ -107,6 +107,7 @@ class OperationExecutor(
             userPreferencesHandler: UserPreferencesHandler,
             profileUpdateHandler: ProfileUpdateHandler,
             profileAvatarHandler: ProfileAvatarHandler,
+            markCompleteHandler: MarkCompleteHandler,
         ): OperationExecutor =
             OperationExecutor(
                 mapOf(
@@ -122,6 +123,7 @@ class OperationExecutor(
                     OperationType.USER_PREFERENCES to userPreferencesHandler,
                     OperationType.PROFILE_UPDATE to profileUpdateHandler,
                     OperationType.PROFILE_AVATAR to profileAvatarHandler,
+                    OperationType.MARK_COMPLETE to markCompleteHandler,
                 ),
             )
     }

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/push/OperationPayloads.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/push/OperationPayloads.kt
@@ -182,3 +182,17 @@ data class ProfileAvatarPayload(
     @SerialName("content_type")
     val contentType: String,
 )
+
+/**
+ * Payload for MARK_COMPLETE operations.
+ * Coalesces by book - only the latest timestamps matter.
+ */
+@Serializable
+data class MarkCompletePayload(
+    @SerialName("book_id")
+    val bookId: String,
+    @SerialName("started_at")
+    val startedAt: String? = null,
+    @SerialName("finished_at")
+    val finishedAt: String? = null,
+)

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/push/PendingOperationRepository.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/push/PendingOperationRepository.kt
@@ -27,6 +27,7 @@ private val SILENT_TYPES =
         OperationType.LISTENING_EVENT,
         OperationType.PLAYBACK_POSITION,
         OperationType.USER_PREFERENCES,
+        OperationType.MARK_COMPLETE,
     )
 
 /**

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/di/Koin.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/di/Koin.kt
@@ -427,6 +427,7 @@ val useCaseModule =
                 authRepository = get(),
                 authSession = get(),
                 userRepository = get(),
+                playbackStateProvider = get<PlaybackManager>(),
             )
         }
 

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/domain/model/PendingOperation.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/domain/model/PendingOperation.kt
@@ -40,6 +40,7 @@ enum class PendingOperationType {
     USER_PREFERENCES,
     PROFILE_UPDATE,
     PROFILE_AVATAR,
+    MARK_COMPLETE,
 }
 
 /**

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/sync/SyncIndicatorViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/sync/SyncIndicatorViewModel.kt
@@ -211,6 +211,7 @@ class SyncIndicatorViewModel(
             PendingOperationType.USER_PREFERENCES -> "Syncing preferences"
             PendingOperationType.PROFILE_UPDATE -> "Updating profile"
             PendingOperationType.PROFILE_AVATAR -> "Uploading avatar"
+            PendingOperationType.MARK_COMPLETE -> "Marking book complete"
         }
     }
 }

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/PlaybackPositionRepositoryImplTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/PlaybackPositionRepositoryImplTest.kt
@@ -10,6 +10,8 @@ import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
+import com.calypsan.listenup.client.data.sync.push.MarkCompleteHandler
+import com.calypsan.listenup.client.data.sync.push.PendingOperationRepositoryContract
 import dev.mokkery.mock
 import dev.mokkery.verifySuspend
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -76,7 +78,7 @@ class PlaybackPositionRepositoryImplTest {
             val dao = createMockDao()
             val entity = createPlaybackPositionEntity(bookId = "book-123", positionMs = 45000L)
             everySuspend { dao.get(BookId("book-123")) } returns entity
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi())
+            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
 
             // When
             val result = repository.get("book-123")
@@ -93,7 +95,7 @@ class PlaybackPositionRepositoryImplTest {
             // Given
             val dao = createMockDao()
             everySuspend { dao.get(any()) } returns null
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi())
+            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
 
             // When
             val result = repository.get("nonexistent-book")
@@ -108,7 +110,7 @@ class PlaybackPositionRepositoryImplTest {
             // Given
             val dao = createMockDao()
             everySuspend { dao.get(any()) } returns null
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi())
+            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
 
             // When
             repository.get("test-book-id")
@@ -126,7 +128,7 @@ class PlaybackPositionRepositoryImplTest {
             val dao = createMockDao()
             val entity = createPlaybackPositionEntity(bookId = "book-1", positionMs = 30000L)
             every { dao.observe(BookId("book-1")) } returns flowOf(entity)
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi())
+            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
 
             // When
             val result = repository.observe("book-1").first()
@@ -143,7 +145,7 @@ class PlaybackPositionRepositoryImplTest {
             // Given
             val dao = createMockDao()
             every { dao.observe(any()) } returns flowOf(null)
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi())
+            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
 
             // When
             val result = repository.observe("missing-book").first()
@@ -160,7 +162,7 @@ class PlaybackPositionRepositoryImplTest {
             val entity1 = createPlaybackPositionEntity(bookId = "book-1", positionMs = 1000L)
             val entity2 = createPlaybackPositionEntity(bookId = "book-1", positionMs = 2000L)
             every { dao.observe(BookId("book-1")) } returns flowOf(null, entity1, entity2)
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi())
+            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
 
             // When
             val emissions = repository.observe("book-1").take(3).toList()
@@ -186,7 +188,7 @@ class PlaybackPositionRepositoryImplTest {
                     createPlaybackPositionEntity(bookId = "book-3", positionMs = 3000L),
                 )
             every { dao.observeAll() } returns flowOf(entities)
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi())
+            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
 
             // When
             val result = repository.observeAll().first()
@@ -204,7 +206,7 @@ class PlaybackPositionRepositoryImplTest {
             // Given
             val dao = createMockDao()
             every { dao.observeAll() } returns flowOf(emptyList())
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi())
+            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
 
             // When
             val result = repository.observeAll().first()
@@ -226,7 +228,7 @@ class PlaybackPositionRepositoryImplTest {
                     createPlaybackPositionEntity(bookId = "book-2"),
                 )
             every { dao.observeAll() } returns flowOf(list0, list1, list2)
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi())
+            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
 
             // When
             val emissions = repository.observeAll().take(3).toList()
@@ -245,7 +247,7 @@ class PlaybackPositionRepositoryImplTest {
             val dao = createMockDao()
             val entity = createPlaybackPositionEntity(bookId = "unique-book-id-123")
             every { dao.observeAll() } returns flowOf(listOf(entity))
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi())
+            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
 
             // When
             val result = repository.observeAll().first()
@@ -268,7 +270,7 @@ class PlaybackPositionRepositoryImplTest {
                     createPlaybackPositionEntity(bookId = "book-2", positionMs = 2000L),
                 )
             everySuspend { dao.getRecentPositions(10) } returns entities
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi())
+            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
 
             // When
             val result = repository.getRecentPositions(10)
@@ -285,7 +287,7 @@ class PlaybackPositionRepositoryImplTest {
             // Given
             val dao = createMockDao()
             everySuspend { dao.getRecentPositions(5) } returns emptyList()
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi())
+            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
 
             // When
             repository.getRecentPositions(5)
@@ -300,7 +302,7 @@ class PlaybackPositionRepositoryImplTest {
             // Given
             val dao = createMockDao()
             everySuspend { dao.getRecentPositions(any()) } returns emptyList()
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi())
+            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
 
             // When
             val result = repository.getRecentPositions(10)
@@ -330,7 +332,7 @@ class PlaybackPositionRepositoryImplTest {
                     ),
                 )
             everySuspend { dao.getRecentPositions(10) } returns entities
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi())
+            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
 
             // When
             val result = repository.getRecentPositions(10)
@@ -350,7 +352,7 @@ class PlaybackPositionRepositoryImplTest {
             // Given
             val dao = createMockDao()
             everySuspend { dao.get(BookId("new-book")) } returns null
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi())
+            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
 
             // When
             repository.save(
@@ -380,7 +382,7 @@ class PlaybackPositionRepositoryImplTest {
                     syncedAt = 1704067200000L, // Previously synced
                 )
             everySuspend { dao.get(BookId("book-1")) } returns existingEntity
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi())
+            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
 
             // When
             repository.save(
@@ -402,7 +404,7 @@ class PlaybackPositionRepositoryImplTest {
             // Given
             val dao = createMockDao()
             everySuspend { dao.get(BookId("new-book")) } returns null
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi())
+            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
 
             // When
             repository.save(
@@ -423,7 +425,7 @@ class PlaybackPositionRepositoryImplTest {
             // Given
             val dao = createMockDao()
             everySuspend { dao.get(any()) } returns null
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi())
+            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
 
             // When
             repository.save(
@@ -444,7 +446,7 @@ class PlaybackPositionRepositoryImplTest {
         runTest {
             // Given
             val dao = createMockDao()
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi())
+            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
 
             // When
             repository.delete("book-to-delete")
@@ -458,7 +460,7 @@ class PlaybackPositionRepositoryImplTest {
         runTest {
             // Given
             val dao = createMockDao()
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi())
+            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
 
             // When/Then - should not throw
             repository.delete("nonexistent-book")
@@ -476,7 +478,7 @@ class PlaybackPositionRepositoryImplTest {
             val dao = createMockDao()
             val entity = createPlaybackPositionEntity(bookId = "unique-book-123")
             everySuspend { dao.get(BookId("unique-book-123")) } returns entity
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi())
+            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
 
             // When
             val result = repository.get("unique-book-123")
@@ -493,7 +495,7 @@ class PlaybackPositionRepositoryImplTest {
             val dao = createMockDao()
             val entity = createPlaybackPositionEntity(positionMs = 123456789L)
             everySuspend { dao.get(any()) } returns entity
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi())
+            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
 
             // When
             val result = repository.get("book-1")
@@ -510,7 +512,7 @@ class PlaybackPositionRepositoryImplTest {
             val dao = createMockDao()
             val entity = createPlaybackPositionEntity(playbackSpeed = 2.5f)
             everySuspend { dao.get(any()) } returns entity
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi())
+            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
 
             // When
             val result = repository.get("book-1")
@@ -527,7 +529,7 @@ class PlaybackPositionRepositoryImplTest {
             val dao = createMockDao()
             val entity = createPlaybackPositionEntity(hasCustomSpeed = true)
             everySuspend { dao.get(any()) } returns entity
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi())
+            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
 
             // When
             val result = repository.get("book-1")
@@ -544,7 +546,7 @@ class PlaybackPositionRepositoryImplTest {
             val dao = createMockDao()
             val entity = createPlaybackPositionEntity(hasCustomSpeed = false)
             everySuspend { dao.get(any()) } returns entity
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi())
+            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
 
             // When
             val result = repository.get("book-1")
@@ -561,7 +563,7 @@ class PlaybackPositionRepositoryImplTest {
             val dao = createMockDao()
             val entity = createPlaybackPositionEntity(updatedAt = 1704110400000L)
             everySuspend { dao.get(any()) } returns entity
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi())
+            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
 
             // When
             val result = repository.get("book-1")
@@ -578,7 +580,7 @@ class PlaybackPositionRepositoryImplTest {
             val dao = createMockDao()
             val entity = createPlaybackPositionEntity(syncedAt = 1704200000000L)
             everySuspend { dao.get(any()) } returns entity
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi())
+            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
 
             // When
             val result = repository.get("book-1")
@@ -595,7 +597,7 @@ class PlaybackPositionRepositoryImplTest {
             val dao = createMockDao()
             val entity = createPlaybackPositionEntity(syncedAt = null)
             everySuspend { dao.get(any()) } returns entity
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi())
+            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
 
             // When
             val result = repository.get("book-1")
@@ -612,7 +614,7 @@ class PlaybackPositionRepositoryImplTest {
             val dao = createMockDao()
             val entity = createPlaybackPositionEntity(lastPlayedAt = 1704300000000L)
             everySuspend { dao.get(any()) } returns entity
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi())
+            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
 
             // When
             val result = repository.get("book-1")
@@ -629,7 +631,7 @@ class PlaybackPositionRepositoryImplTest {
             val dao = createMockDao()
             val entity = createPlaybackPositionEntity(lastPlayedAt = null)
             everySuspend { dao.get(any()) } returns entity
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi())
+            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
 
             // When
             val result = repository.get("book-1")
@@ -655,7 +657,7 @@ class PlaybackPositionRepositoryImplTest {
                     lastPlayedAt = 1704200000000L,
                 )
             everySuspend { dao.get(BookId("complete-book-123")) } returns entity
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi())
+            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
 
             // When
             val result = repository.get("complete-book-123")
@@ -680,7 +682,7 @@ class PlaybackPositionRepositoryImplTest {
             val dao = createMockDao()
             val entity = createPlaybackPositionEntity(positionMs = 0L)
             everySuspend { dao.get(any()) } returns entity
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi())
+            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
 
             // When
             val result = repository.get("book-1")
@@ -697,7 +699,7 @@ class PlaybackPositionRepositoryImplTest {
             val dao = createMockDao()
             val entity = createPlaybackPositionEntity(playbackSpeed = 1.0f)
             everySuspend { dao.get(any()) } returns entity
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi())
+            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
 
             // When
             val result = repository.get("book-1")
@@ -718,7 +720,7 @@ class PlaybackPositionRepositoryImplTest {
                     createPlaybackPositionEntity(bookId = "book-1", positionMs = 2000L), // duplicate
                 )
             every { dao.observeAll() } returns flowOf(entities)
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi())
+            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
 
             // When
             val result = repository.observeAll().first()


### PR DESCRIPTION
## Fixes

### #209 — Gate sync scheduling behind auth
Background sync was being scheduled in `ListenUp.onCreate()` before the user authenticated. Now observes `authState` and only schedules sync after `Authenticated` state is reached.

### #214 — Clear playback before clearing auth tokens  
Logout now calls `clearPlayback()` via `PlaybackStateProvider` before clearing auth tokens, preventing orphaned playback state during logout.

Closes #209, closes #214