### PR TITLE
🔥 Remove dead mock chapters and unused queueUpdate stub

### DIFF
--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncManager.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncManager.kt
@@ -10,7 +10,6 @@ import com.calypsan.listenup.client.core.getOrNull
 import com.calypsan.listenup.client.data.local.db.BookDao
 import com.calypsan.listenup.client.data.local.db.PendingOperationDao
 import com.calypsan.listenup.client.data.local.db.SyncDao
-import com.calypsan.listenup.client.data.local.db.Syncable
 import com.calypsan.listenup.client.data.local.db.clearLastSyncTime
 import com.calypsan.listenup.client.data.local.db.setLastSyncTime
 import com.calypsan.listenup.client.data.remote.SetupApiContract
@@ -486,14 +485,6 @@ class SyncManager(
             _syncState.value = SyncStatus.Error(exception = e)
             Failure(exception = e, message = "Failed to resync: ${e.message}")
         }
-    }
-
-    /**
-     * Queue an entity for synchronization with server.
-     */
-    suspend fun queueUpdate(entity: Syncable) {
-        // TODO: Implement via PendingOperationRepository
-        logger.debug { "Queued update for entity: $entity" }
     }
 
     /**

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/BookRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/BookRepositoryTest.kt
@@ -557,40 +557,6 @@ class BookRepositoryTest {
         }
 
     @Test
-    fun `getChapters generates mock chapters when database empty`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            everySuspend { fixture.chapterDao.getChaptersForBook(BookId("book-1")) } returns emptyList()
-            everySuspend { fixture.chapterDao.upsertAll(any()) } returns Unit
-            val repository = fixture.build()
-
-            // When
-            val result = repository.getChapters("book-1")
-
-            // Then
-            assertEquals(15, result.size) // Mock generates 15 chapters
-            assertEquals("Chapter 1", result[0].title)
-            assertEquals("Chapter 15", result[14].title)
-        }
-
-    @Test
-    fun `getChapters persists mock chapters to database`() =
-        runTest {
-            // Given
-            val fixture = createFixture()
-            everySuspend { fixture.chapterDao.getChaptersForBook(BookId("book-1")) } returns emptyList()
-            everySuspend { fixture.chapterDao.upsertAll(any()) } returns Unit
-            val repository = fixture.build()
-
-            // When
-            repository.getChapters("book-1")
-
-            // Then
-            verifySuspend { fixture.chapterDao.upsertAll(any()) }
-        }
-
-    @Test
     fun `getChapters transforms chapter entities to domain models`() =
         runTest {
             // Given


### PR DESCRIPTION
Fixes #213 and #215

- Remove client-side mock chapter generation fallback (server now syncs chapters via BookPuller)
- Remove unused queueUpdate() no-op stub from SyncManager