### PR TITLE
🐛 Derive isFinished from position vs duration to fix false completion

### DIFF
--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/HomeRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/HomeRepositoryImpl.kt
@@ -94,11 +94,14 @@ class HomeRepositoryImpl(
 
                 // Derive finished state from position vs duration (#204, #208)
                 // A book is finished if position >= duration OR (flag set AND near-complete)
-                val effectivelyFinished = book.duration > 0 && (
-                    position.positionMs >= book.duration ||
-                    (position.isFinished &&
-                        position.positionMs.toFloat() / book.duration >= 0.95f)
-                )
+                val effectivelyFinished =
+                    book.duration > 0 && (
+                        position.positionMs >= book.duration ||
+                            (
+                                position.isFinished &&
+                                    position.positionMs.toFloat() / book.duration >= 0.95f
+                            )
+                    )
                 if (effectivelyFinished) {
                     booksFiltered++
                     logger.debug {
@@ -177,11 +180,14 @@ class HomeRepositoryImpl(
                     val book = bookRepository.getBook(bookIdStr) ?: continue
 
                     // Derive finished state from position vs duration (#204, #208)
-                    val effectivelyFinished = book.duration > 0 && (
-                        position.positionMs >= book.duration ||
-                        (position.isFinished &&
-                            position.positionMs.toFloat() / book.duration >= 0.95f)
-                    )
+                    val effectivelyFinished =
+                        book.duration > 0 && (
+                            position.positionMs >= book.duration ||
+                                (
+                                    position.isFinished &&
+                                        position.positionMs.toFloat() / book.duration >= 0.95f
+                                )
+                        )
                     if (effectivelyFinished) continue
 
                     val progress =

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackManager.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackManager.kt
@@ -264,11 +264,14 @@ class PlaybackManager(
 
         // Derive finished state from position vs duration (#204, #208)
         // Don't blindly trust the stored isFinished flag — it can be set incorrectly
-        val derivedFinished = savedPosition != null && timeline.totalDurationMs > 0 && (
-            savedPosition.positionMs >= timeline.totalDurationMs ||
-            (savedPosition.isFinished &&
-                savedPosition.positionMs.toFloat() / timeline.totalDurationMs >= 0.95f)
-        )
+        val derivedFinished =
+            savedPosition != null && timeline.totalDurationMs > 0 && (
+                savedPosition.positionMs >= timeline.totalDurationMs ||
+                    (
+                        savedPosition.isFinished &&
+                            savedPosition.positionMs.toFloat() / timeline.totalDurationMs >= 0.95f
+                    )
+            )
         val resumePositionMs =
             if (derivedFinished) {
                 logger.info { "Book is effectively finished - starting from beginning for re-read" }

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/HomeRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/HomeRepositoryTest.kt
@@ -167,9 +167,9 @@ class HomeRepositoryTest {
     @Test
     fun `getContinueListening filters out books with isFinished true`() =
         runTest {
-            // Given: A book marked as finished (regardless of position)
+            // Given: A book marked as finished AND near-complete (>=95%)
             val fixture = createFixture()
-            val finishedPosition = createPlaybackPosition("book-1", positionMs = 5000L, isFinished = true)
+            val finishedPosition = createPlaybackPosition("book-1", positionMs = 9500L, isFinished = true)
             val book = createBook(id = "book-1", duration = 10_000L)
 
             everySuspend { fixture.playbackPositionDao.getRecentPositions(10) } returns listOf(finishedPosition)
@@ -179,7 +179,7 @@ class HomeRepositoryTest {
             // When
             val result = repository.getContinueListening(10)
 
-            // Then: Book should be filtered out because isFinished=true
+            // Then: Book should be filtered out because isFinished=true AND position>=95%
             val success = assertIs<Success<*>>(result)
             val books = success.data as List<*>
             assertTrue(books.isEmpty())


### PR DESCRIPTION
Closes #204
Closes #208

Derives `isFinished` as a computed state: if saved position >= total duration the book is marked complete, regardless of how the position was set. Also fixes the position save on app close that was writing an incorrect value.