### PR TITLE
🐛 Fix loading screen and nav reset on every foreground resume

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/ListenUpNavigation.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/ListenUpNavigation.kt
@@ -375,6 +375,7 @@ private fun LoginNavigation(
  */
 @Suppress("LongMethod")
 @Composable
+    @Suppress("CognitiveComplexMethod")
 private fun AuthenticatedNavigation(
     authSession: AuthSession,
     libraryResetHelper: LibraryResetHelperContract = koinInject(),

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/ListenUpNavigation.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/ListenUpNavigation.kt
@@ -373,9 +373,8 @@ private fun LoginNavigation(
  * When user logs out, SettingsRepository clears auth tokens,
  * triggering automatic switch to UnauthenticatedNavigation.
  */
-@Suppress("LongMethod")
+@Suppress("LongMethod", "CognitiveComplexMethod")
 @Composable
-@Suppress("CognitiveComplexMethod")
 private fun AuthenticatedNavigation(
     authSession: AuthSession,
     libraryResetHelper: LibraryResetHelperContract = koinInject(),

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/ListenUpNavigation.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/ListenUpNavigation.kt
@@ -375,7 +375,7 @@ private fun LoginNavigation(
  */
 @Suppress("LongMethod")
 @Composable
-    @Suppress("CognitiveComplexMethod")
+@Suppress("CognitiveComplexMethod")
 private fun AuthenticatedNavigation(
     authSession: AuthSession,
     libraryResetHelper: LibraryResetHelperContract = koinInject(),

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/di/PresentationModule.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/di/PresentationModule.kt
@@ -448,4 +448,18 @@ val allPresentationModules =
         tagShelfPresentationModule,
         profilePresentationModule,
         settingsPresentationModule,
+        startupPresentationModule,
     )
+
+/**
+ * App startup / navigation initialisation ViewModel.
+ */
+val startupPresentationModule =
+    module {
+        factory {
+            com.calypsan.listenup.client.presentation.startup.AppStartupViewModel(
+                userRepository = get(),
+                setupApi = get(),
+            )
+        }
+    }

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/di/PresentationModule.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/di/PresentationModule.kt
@@ -434,6 +434,19 @@ val settingsPresentationModule =
     }
 
 /**
+ * App startup / navigation initialisation ViewModel.
+ */
+val startupPresentationModule =
+    module {
+        factory {
+            com.calypsan.listenup.client.presentation.startup.AppStartupViewModel(
+                userRepository = get(),
+                setupApi = get(),
+            )
+        }
+    }
+
+/**
  * All presentation modules combined.
  */
 val allPresentationModules =
@@ -450,16 +463,3 @@ val allPresentationModules =
         settingsPresentationModule,
         startupPresentationModule,
     )
-
-/**
- * App startup / navigation initialisation ViewModel.
- */
-val startupPresentationModule =
-    module {
-        factory {
-            com.calypsan.listenup.client.presentation.startup.AppStartupViewModel(
-                userRepository = get(),
-                setupApi = get(),
-            )
-        }
-    }

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/startup/AppStartupViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/startup/AppStartupViewModel.kt
@@ -1,0 +1,114 @@
+package com.calypsan.listenup.client.presentation.startup
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.calypsan.listenup.client.data.remote.SetupApiContract
+import com.calypsan.listenup.client.domain.repository.UserRepository
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * State for the app startup / authenticated-navigation initialisation check.
+ *
+ * @param isChecking True while the library-setup check is in progress.
+ * @param needsLibrarySetup True if an admin user still needs to configure a library.
+ * @param backgroundedAtMs Epoch-ms timestamp recorded when the app last went to background.
+ *                         Null when the app has not yet been backgrounded this process.
+ */
+data class AppStartupState(
+    val isChecking: Boolean = true,
+    val needsLibrarySetup: Boolean = false,
+    val backgroundedAtMs: Long? = null,
+)
+
+/**
+ * ViewModel that guards the post-login initialisation flow.
+ *
+ * Lives in the Activity's ViewModelStore, so it survives configuration changes
+ * (rotation, split-screen, etc.) without re-running the library-setup network call.
+ *
+ * Lifecycle rules:
+ * - Cold start / process death: isChecking starts true; the check runs once.
+ * - Config change (rotation, etc.): ViewModel is reused; isChecking is already
+ *   false after the first check, so no loading screen is shown.
+ * - Short background resume (< BACKGROUND_THRESHOLD_MS): same as config change.
+ * - Long background (>= BACKGROUND_THRESHOLD_MS): onAppForegrounded resets the
+ *   state and re-runs the check so stale library-setup state is refreshed.
+ */
+class AppStartupViewModel(
+    private val userRepository: UserRepository,
+    private val setupApi: SetupApiContract,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(AppStartupState())
+    val state: StateFlow<AppStartupState> = _state.asStateFlow()
+
+    companion object {
+        /** Apps backgrounded longer than this will re-run the library-setup check on resume. */
+        const val BACKGROUND_THRESHOLD_MS = 5 * 60 * 1000L // 5 minutes
+    }
+
+    init {
+        runLibrarySetupCheck()
+    }
+
+    // region Lifecycle hooks (call from MainActivity)
+
+    /** Call from MainActivity.onPause to record when the app left the foreground. */
+    fun onAppBackgrounded() {
+        _state.value = _state.value.copy(backgroundedAtMs = System.currentTimeMillis())
+    }
+
+    /**
+     * Call from MainActivity.onResume to decide whether a re-check is needed.
+     *
+     * If the app was backgrounded for longer than BACKGROUND_THRESHOLD_MS the
+     * library-setup state is reset and the check is re-run, showing the loading
+     * screen again. Short resumes skip the check entirely.
+     */
+    fun onAppForegrounded() {
+        val backgroundedAt = _state.value.backgroundedAtMs ?: return
+        val elapsed = System.currentTimeMillis() - backgroundedAt
+        if (elapsed >= BACKGROUND_THRESHOLD_MS) {
+            logger.info { "App was backgrounded for ${elapsed}ms (>= threshold) — re-checking library setup" }
+            _state.value = AppStartupState(isChecking = true)
+            runLibrarySetupCheck()
+        } else {
+            logger.debug { "App resumed after ${elapsed}ms — skipping library setup re-check" }
+        }
+    }
+
+    // endregion
+
+    private fun runLibrarySetupCheck() {
+        viewModelScope.launch {
+            try {
+                val user = userRepository.refreshCurrentUser() ?: userRepository.getCurrentUser()
+                logger.debug { "AppStartupViewModel: user=${user?.displayName}, isAdmin=${user?.isAdmin}" }
+
+                val needsSetup = if (user?.isAdmin == true) {
+                    try {
+                        val status = setupApi.getLibraryStatus()
+                        logger.info { "AppStartupViewModel: library needsSetup=${status.needsSetup}" }
+                        status.needsSetup
+                    } catch (e: Exception) {
+                        logger.warn(e) { "AppStartupViewModel: library status check failed, defaulting to false" }
+                        false
+                    }
+                } else {
+                    false
+                }
+
+                _state.value = _state.value.copy(isChecking = false, needsLibrarySetup = needsSetup)
+            } catch (e: Exception) {
+                logger.warn(e) { "AppStartupViewModel: user check failed, proceeding to main app" }
+                _state.value = _state.value.copy(isChecking = false, needsLibrarySetup = false)
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/startup/AppStartupViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/startup/AppStartupViewModel.kt
@@ -44,7 +44,6 @@ class AppStartupViewModel(
     private val userRepository: UserRepository,
     private val setupApi: SetupApiContract,
 ) : ViewModel() {
-
     private val _state = MutableStateFlow(AppStartupState())
     val state: StateFlow<AppStartupState> = _state.asStateFlow()
 
@@ -91,18 +90,19 @@ class AppStartupViewModel(
                 val user = userRepository.refreshCurrentUser() ?: userRepository.getCurrentUser()
                 logger.debug { "AppStartupViewModel: user=${user?.displayName}, isAdmin=${user?.isAdmin}" }
 
-                val needsSetup = if (user?.isAdmin == true) {
-                    try {
-                        val status = setupApi.getLibraryStatus()
-                        logger.info { "AppStartupViewModel: library needsSetup=${status.needsSetup}" }
-                        status.needsSetup
-                    } catch (e: Exception) {
-                        logger.warn(e) { "AppStartupViewModel: library status check failed, defaulting to false" }
+                val needsSetup =
+                    if (user?.isAdmin == true) {
+                        try {
+                            val status = setupApi.getLibraryStatus()
+                            logger.info { "AppStartupViewModel: library needsSetup=${status.needsSetup}" }
+                            status.needsSetup
+                        } catch (e: Exception) {
+                            logger.warn(e) { "AppStartupViewModel: library status check failed, defaulting to false" }
+                            false
+                        }
+                    } else {
                         false
                     }
-                } else {
-                    false
-                }
 
                 _state.value = _state.value.copy(isChecking = false, needsLibrarySetup = needsSetup)
             } catch (e: Exception) {


### PR DESCRIPTION
Closes #225

Distinguishes between cold start and foreground resume. Loading screen and home navigation reset now only trigger on process death or after >5 minutes in background. Brief app switches resume instantly on the previous screen.