### PR TITLE
🐛 Fix downloaded audiobooks not playing via local file URIs

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
@@ -15,6 +15,7 @@ import androidx.media3.common.Player
 import androidx.media3.common.TrackSelectionParameters
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DataSource
+import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.datasource.okhttp.OkHttpDataSource
 import androidx.media3.exoplayer.DefaultRenderersFactory
 import androidx.media3.exoplayer.ExoPlayer
@@ -149,8 +150,10 @@ class PlaybackService : MediaLibraryService() {
                 .writeTimeout(30.seconds.toJavaDuration())
                 .build()
 
-        // Create DataSource factory that uses OkHttp
-        val dataSourceFactory: DataSource.Factory = OkHttpDataSource.Factory(okHttpClient)
+        // Create DataSource factory: OkHttp for HTTP(S) streaming, DefaultDataSource
+        // wrapper to also handle file:// URIs for downloaded audiobooks
+        val httpDataSourceFactory: DataSource.Factory = OkHttpDataSource.Factory(okHttpClient)
+        val dataSourceFactory: DataSource.Factory = DefaultDataSource.Factory(this, httpDataSourceFactory)
 
         // Create media source factory
         val mediaSourceFactory =
@@ -853,7 +856,7 @@ class PlaybackService : MediaLibraryService() {
                                             MediaItem
                                                 .Builder()
                                                 .setMediaId(file.audioFileId)
-                                                .setUri(file.streamingUrl)
+                                                .setUri(file.playbackUri)
                                                 .setMediaMetadata(
                                                     MediaMetadata
                                                         .Builder()
@@ -957,7 +960,7 @@ class PlaybackService : MediaLibraryService() {
                 MediaItem
                     .Builder()
                     .setMediaId(file.audioFileId)
-                    .setUri(file.streamingUrl)
+                    .setUri(file.playbackUri)
                     .setMediaMetadata(
                         MediaMetadata
                             .Builder()
@@ -1016,7 +1019,7 @@ class PlaybackService : MediaLibraryService() {
                                 MediaItem
                                     .Builder()
                                     .setMediaId(file.audioFileId)
-                                    .setUri(file.streamingUrl)
+                                    .setUri(file.playbackUri)
                                     .setMediaMetadata(
                                         MediaMetadata
                                             .Builder()


### PR DESCRIPTION
## Problem
Downloaded audiobooks silently fail to play — player UI shows but audio never starts, seekbar doesn't advance, play/pause unresponsive.

Books that were never downloaded (streaming-only) play fine. Deleting a download and trying to play also fails.

## Root Cause
Two issues introduced by #193 (`d35f7e2`):

1. **`OkHttpDataSource` can't handle `file://` URIs.** When #193 changed `PlayerViewModel` to use `file.playbackUri` (which returns `file:///data/.../audiobooks/...` for downloaded files), ExoPlayer's data source factory was still `OkHttpDataSource.Factory` — an HTTP-only client. It silently fails on file URIs.

2. **Three other code paths still used `file.streamingUrl` instead of `file.playbackUri`.** The Android Auto, voice search, and browse tree playback paths in `PlaybackService.kt` were not updated by #193, so they always streamed even for downloaded books.

## Fix
- Wrap `OkHttpDataSource.Factory` in `DefaultDataSource.Factory`, which handles `file://` URIs natively and falls through to OkHttp for HTTP(S) streaming
- Update the three remaining `.setUri(file.streamingUrl)` calls to `.setUri(file.playbackUri)`

## Edge Cases Verified
- ✅ Streaming (non-downloaded) books — `playbackUri` returns `streamingUrl` when `localPath` is null, OkHttp handles with auth
- ✅ Partially downloaded books — per-file `localPath` resolution, mixed local/streaming works
- ✅ Deleted downloads — DB sets `localPath = NULL` on deletion, `playbackUri` falls back to streaming
- ✅ No other `DataSource.Factory` instances in the codebase