### PR TITLE
🐛 Fix readers section not showing for books

### DIFF
--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/SyncApi.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/SyncApi.kt
@@ -8,6 +8,7 @@ import com.calypsan.listenup.client.core.getOrThrow
 import com.calypsan.listenup.client.core.suspendRunCatching
 import com.calypsan.listenup.client.data.remote.model.AllProgressResponse
 import com.calypsan.listenup.client.data.remote.model.ApiActiveSessions
+import com.calypsan.listenup.client.data.remote.model.ApiReadingSessions
 import com.calypsan.listenup.client.data.remote.model.ApiResponse
 import com.calypsan.listenup.client.data.remote.model.ContinueListeningItemResponse
 import com.calypsan.listenup.client.data.remote.model.ContinueListeningResponse
@@ -430,25 +431,25 @@ class SyncApi(
     override suspend fun getReadingSessions(): Result<SyncReadingSessionsResponse> =
         suspendRunCatching {
             val client = clientFactory.getClient()
-            val response: ApiResponse<ApiActiveSessions> =
+            val response: ApiResponse<ApiReadingSessions> =
                 client.get("/api/v1/sync/reading-sessions").body()
             val apiSessions = response.toResult().getOrThrow()
             SyncReadingSessionsResponse(
                 readers =
-                    apiSessions.sessions.map { session ->
+                    apiSessions.readers.map { reader ->
                         SyncReadingSessionReaderResponse(
-                            bookId = session.bookId,
-                            userId = session.userId,
-                            displayName = session.displayName,
-                            avatarType = session.avatarType,
-                            avatarValue = session.avatarValue,
-                            avatarColor = session.avatarColor,
-                            isCurrentlyReading = false,
-                            currentProgress = 0.0,
-                            startedAt = session.startedAt,
-                            finishedAt = null,
-                            lastActivityAt = session.startedAt,
-                            completionCount = 0,
+                            bookId = reader.bookId,
+                            userId = reader.userId,
+                            displayName = reader.displayName,
+                            avatarType = reader.avatarType,
+                            avatarValue = reader.avatarValue,
+                            avatarColor = reader.avatarColor,
+                            isCurrentlyReading = reader.isCurrentlyReading,
+                            currentProgress = reader.currentProgress,
+                            startedAt = reader.startedAt,
+                            finishedAt = reader.finishedAt,
+                            lastActivityAt = reader.lastActivityAt,
+                            completionCount = reader.completionCount,
                         )
                     },
             )

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/SessionRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/SessionRepositoryImpl.kt
@@ -17,6 +17,7 @@ import com.calypsan.listenup.client.domain.repository.AuthSession
 import com.calypsan.listenup.client.domain.repository.SessionRepository
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.launch
 
 private val logger = KotlinLogging.logger {}
 
@@ -67,16 +68,23 @@ class SessionRepositoryImpl(
     override fun observeBookReaders(bookId: String): Flow<BookReadersResult> {
         logger.debug { "Starting observation of readers for book $bookId" }
 
-        // Data is populated by ReadingSessionPuller during initial sync
-        // and kept fresh by SSE events updating Room directly.
-        // No API calls needed here.
-        return kotlinx.coroutines.flow.flow {
+        return kotlinx.coroutines.flow.channelFlow {
             val currentUserId = authSession.getUserId()
             logger.debug { "Observing Room for book $bookId (currentUserId=$currentUserId)" }
 
+            // Trigger a background refresh so the cache is always up-to-date
+            launch {
+                try {
+                    refreshBookReaders(bookId)
+                } catch (e: Exception) {
+                    logger.warn(e) { "Background refresh of readers for book $bookId failed" }
+                }
+            }
+
+            // Emit from Room cache immediately (optimistic UI)
             readingSessionDao.observeByBookId(bookId).collect { entities ->
                 logger.debug { "Room emitted ${entities.size} reading sessions for book $bookId" }
-                emit(entitiesToBookReadersResult(entities, currentUserId))
+                send(entitiesToBookReadersResult(entities, currentUserId))
             }
         }
     }


### PR DESCRIPTION
## Problem
The Readers section never appears on book detail pages for in-progress or completed books. This has been a persistent bug since early development.

## Root Cause
Two issues:

### 1. Wrong deserialization model in `SyncApi.getReadingSessions()`
The `/api/v1/sync/reading-sessions` response was being deserialized as `ApiActiveSessions` (expects `{ sessions: [...] }`) instead of `ApiReadingSessions` (expects `{ readers: [...] }`). This caused either silent deserialization failure or data loss — all enriched fields (`isCurrentlyReading`, `currentProgress`, `finishedAt`, `completionCount`) were hardcoded to defaults.

### 2. No background refresh in `observeBookReaders()`
The repository only observed the Room cache without ever triggering a fresh API fetch. If the initial sync failed to populate readers (because of issue #1), the UI would show nothing forever.

## Fix
1. **SyncApi.kt**: Changed response type to `ApiReadingSessions` and mapped all reader fields correctly
2. **SessionRepositoryImpl.kt**: Converted to `channelFlow` and added a background `refreshBookReaders()` call so viewing a book detail page always fetches fresh data while showing cached data immediately (optimistic UI)