### PR TITLE
🐛 Fix blank covers on series and contributor pages (#236)

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/ContributorCoverImage.kt
+++ b/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/ContributorCoverImage.kt
@@ -21,6 +21,8 @@ import kotlinx.coroutines.withContext
 
 private val logger = KotlinLogging.logger {}
 
+private fun contributorCacheKey(contributorId: String) = "$contributorId:contributor"
+
 /**
  * Smart contributor image with server URL fallback.
  *
@@ -44,15 +46,13 @@ fun ContributorCoverImage(
     // Fast path: imagePath provided means the file exists locally.
     val syncRequest =
         remember(contributorId, imagePath) {
-            if (imagePath != null) {
+            imagePath?.let {
                 ImageRequest
                     .Builder(context)
-                    .data(imagePath)
-                    .memoryCacheKey("$contributorId:contributor")
-                    .diskCacheKey("$contributorId:contributor")
+                    .data(it)
+                    .memoryCacheKey(contributorCacheKey(contributorId))
+                    .diskCacheKey(contributorCacheKey(contributorId))
                     .build()
-            } else {
-                null
             }
         }
 
@@ -86,14 +86,15 @@ fun ContributorCoverImage(
                     ImageRequest
                         .Builder(context)
                         .data(localPath)
-                        .memoryCacheKey("$contributorId:contributor")
-                        .diskCacheKey("$contributorId:contributor")
+                        .memoryCacheKey(contributorCacheKey(contributorId))
+                        .diskCacheKey(contributorCacheKey(contributorId))
                         .build()
                 } else {
                     val baseUrl = serverConfig.getActiveUrl()?.value
                     val token = authSession.getAccessToken()?.value
                     logger.debug {
-                        "ContributorCoverImage: fallback contributorId=$contributorId, url=$baseUrl/api/v1/contributors/$contributorId/image"
+                        "ContributorCoverImage: fallback id=$contributorId " +
+                            "url=$baseUrl/api/v1/contributors/$contributorId/image"
                     }
                     if (baseUrl != null) {
                         ImageRequest
@@ -121,9 +122,9 @@ fun ContributorCoverImage(
 
     val imageRequest = syncRequest ?: asyncRequest
 
-    if (imageRequest != null) {
+    imageRequest?.let {
         AsyncImage(
-            model = imageRequest,
+            model = it,
             contentDescription = contentDescription,
             modifier = modifier,
             contentScale = contentScale,

--- a/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/ContributorCoverImage.kt
+++ b/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/ContributorCoverImage.kt
@@ -1,0 +1,131 @@
+package com.calypsan.listenup.client.design.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import coil3.compose.AsyncImage
+import coil3.compose.AsyncImagePainter
+import coil3.compose.LocalPlatformContext
+import coil3.network.NetworkHeaders
+import coil3.network.httpHeaders
+import coil3.request.ImageRequest
+import com.calypsan.listenup.client.domain.repository.AuthSession
+import com.calypsan.listenup.client.domain.repository.ImageRepository
+import com.calypsan.listenup.client.domain.repository.ServerConfig
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * Smart contributor image with server URL fallback.
+ *
+ * Loading strategy:
+ * 1. If imagePath is provided -> pass directly to Coil (zero overhead, instant)
+ * 2. If imagePath is null -> async check: local file exists? use disk. Otherwise server URL.
+ *
+ * Contributor images are NEVER blank when online.
+ */
+@Composable
+fun ContributorCoverImage(
+    contributorId: String,
+    imagePath: String?,
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+    contentScale: ContentScale = ContentScale.Crop,
+    onState: ((AsyncImagePainter.State) -> Unit)? = null,
+) {
+    val context = LocalPlatformContext.current
+
+    // Fast path: imagePath provided means the file exists locally.
+    val syncRequest =
+        remember(contributorId, imagePath) {
+            if (imagePath != null) {
+                ImageRequest
+                    .Builder(context)
+                    .data(imagePath)
+                    .memoryCacheKey("$contributorId:contributor")
+                    .diskCacheKey("$contributorId:contributor")
+                    .build()
+            } else {
+                null
+            }
+        }
+
+    // Slow path: no imagePath, need async resolution (check disk, fallback to server)
+    val asyncRequest by produceState<ImageRequest?>(
+        initialValue = null,
+        key1 = contributorId,
+        key2 = imagePath,
+    ) {
+        if (imagePath != null || contributorId.isBlank()) return@produceState
+
+        val imageRepository: ImageRepository =
+            org.koin.core.context.GlobalContext
+                .get()
+                .get()
+        val serverConfig: ServerConfig =
+            org.koin.core.context.GlobalContext
+                .get()
+                .get()
+        val authSession: AuthSession =
+            org.koin.core.context.GlobalContext
+                .get()
+                .get()
+
+        value =
+            withContext(Dispatchers.IO) {
+                val localPath = imageRepository.getContributorImagePath(contributorId)
+                val exists = imageRepository.contributorImageExists(contributorId)
+
+                if (exists) {
+                    ImageRequest
+                        .Builder(context)
+                        .data(localPath)
+                        .memoryCacheKey("$contributorId:contributor")
+                        .diskCacheKey("$contributorId:contributor")
+                        .build()
+                } else {
+                    val baseUrl = serverConfig.getActiveUrl()?.value
+                    val token = authSession.getAccessToken()?.value
+                    logger.debug { "ContributorCoverImage: fallback contributorId=$contributorId, url=$baseUrl/api/v1/contributors/$contributorId/image" }
+                    if (baseUrl != null) {
+                        ImageRequest
+                            .Builder(context)
+                            .data("$baseUrl/api/v1/contributors/$contributorId/image")
+                            .apply {
+                                if (token != null) {
+                                    httpHeaders(
+                                        NetworkHeaders
+                                            .Builder()
+                                            .set("Authorization", "Bearer $token")
+                                            .build(),
+                                    )
+                                }
+                            }.build()
+                    } else {
+                        ImageRequest
+                            .Builder(context)
+                            .data(localPath)
+                            .build()
+                    }
+                }
+            }
+    }
+
+    val imageRequest = syncRequest ?: asyncRequest
+
+    if (imageRequest != null) {
+        AsyncImage(
+            model = imageRequest,
+            contentDescription = contentDescription,
+            modifier = modifier,
+            contentScale = contentScale,
+            onState = onState,
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/ContributorCoverImage.kt
+++ b/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/ContributorCoverImage.kt
@@ -92,7 +92,9 @@ fun ContributorCoverImage(
                 } else {
                     val baseUrl = serverConfig.getActiveUrl()?.value
                     val token = authSession.getAccessToken()?.value
-                    logger.debug { "ContributorCoverImage: fallback contributorId=$contributorId, url=$baseUrl/api/v1/contributors/$contributorId/image" }
+                    logger.debug {
+                        "ContributorCoverImage: fallback contributorId=$contributorId, url=$baseUrl/api/v1/contributors/$contributorId/image"
+                    }
                     if (baseUrl != null) {
                         ImageRequest
                             .Builder(context)

--- a/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/contributordetail/ContributorDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/contributordetail/ContributorDetailScreen.kt
@@ -800,7 +800,6 @@ private fun NavigationBar(
 /**
  * Elevated avatar (140dp) with contributor image or initials.
  */
-@Suppress("UnusedParameter")
 @Composable
 private fun ElevatedAvatar(
     name: String,
@@ -823,14 +822,9 @@ private fun ElevatedAvatar(
             modifier = Modifier.fillMaxSize(),
             contentAlignment = Alignment.Center,
         ) {
-            if (imagePath != null) {
-                com.calypsan.listenup.client.design.components.ListenUpAsyncImage(
-                    path = imagePath,
-                    contentDescription = stringResource(Res.string.contributor_name_profile_image, name),
-                    contentScale = androidx.compose.ui.layout.ContentScale.Crop,
-                    modifier = Modifier.fillMaxSize(),
-                )
-            } else {
+            var imageLoaded by remember(contributorId) { mutableStateOf(false) }
+
+            if (!imageLoaded) {
                 Text(
                     text = initials,
                     style =
@@ -841,6 +835,19 @@ private fun ElevatedAvatar(
                     color = colorScheme.onPrimary,
                 )
             }
+
+            com.calypsan.listenup.client.design.components.ContributorCoverImage(
+                contributorId = contributorId,
+                imagePath = imagePath,
+                contentDescription = stringResource(Res.string.contributor_name_profile_image, name),
+                contentScale = androidx.compose.ui.layout.ContentScale.Crop,
+                modifier = Modifier.fillMaxSize(),
+                onState = { state ->
+                    if (state is coil3.compose.AsyncImagePainter.State.Success) {
+                        imageLoaded = true
+                    }
+                },
+            )
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/contributoredit/ContributorEditScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/contributoredit/ContributorEditScreen.kt
@@ -299,6 +299,7 @@ private fun ArtistStudioContent(
     ) {
         // Identity Header with avatar and name
         ContributorIdentityHeader(
+            contributorId = state.contributorId,
             imagePath = state.imagePath,
             name = state.name,
             colorScheme = colorScheme,

--- a/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/contributoredit/components/ContributorIdentityHeader.kt
+++ b/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/contributoredit/components/ContributorIdentityHeader.kt
@@ -28,6 +28,10 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -36,7 +40,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import com.calypsan.listenup.client.design.components.ListenUpAsyncImage
+import com.calypsan.listenup.client.design.components.ContributorCoverImage
 import com.calypsan.listenup.client.design.components.ListenUpLoadingIndicatorSmall
 import com.calypsan.listenup.client.design.components.getInitials
 import com.calypsan.listenup.client.design.theme.DisplayFontFamily
@@ -53,6 +57,7 @@ import listenup.composeapp.generated.resources.contributor_contributor_photo
 @Suppress("LongMethod")
 @Composable
 fun ContributorIdentityHeader(
+    contributorId: String,
     imagePath: String?,
     name: String,
     colorScheme: ContributorColorScheme,
@@ -111,17 +116,9 @@ fun ContributorIdentityHeader(
                     modifier = Modifier.fillMaxSize(),
                     contentAlignment = Alignment.Center,
                 ) {
-                    if (imagePath != null) {
-                        ListenUpAsyncImage(
-                            path = imagePath,
-                            contentDescription = stringResource(Res.string.contributor_contributor_photo),
-                            contentScale = ContentScale.Crop,
-                            modifier =
-                                Modifier
-                                    .fillMaxSize()
-                                    .clip(CircleShape),
-                        )
-                    } else {
+                    var imageLoaded by remember(contributorId) { mutableStateOf(false) }
+
+                    if (!imageLoaded) {
                         Text(
                             text = getInitials(name),
                             style =
@@ -132,6 +129,22 @@ fun ContributorIdentityHeader(
                             color = colorScheme.onPrimary,
                         )
                     }
+
+                    ContributorCoverImage(
+                        contributorId = contributorId,
+                        imagePath = imagePath,
+                        contentDescription = stringResource(Res.string.contributor_contributor_photo),
+                        contentScale = ContentScale.Crop,
+                        modifier =
+                            Modifier
+                                .fillMaxSize()
+                                .clip(CircleShape),
+                        onState = { state ->
+                            if (state is coil3.compose.AsyncImagePainter.State.Success) {
+                                imageLoaded = true
+                            }
+                        },
+                    )
 
                     // Loading overlay during upload
                     if (isUploadingImage) {

--- a/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/library/components/AnimatedCoverStack.kt
+++ b/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/library/components/AnimatedCoverStack.kt
@@ -35,7 +35,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
-import com.calypsan.listenup.client.design.components.ListenUpAsyncImage
+import com.calypsan.listenup.client.design.components.BookCoverImage
 import kotlinx.coroutines.delay
 
 /**
@@ -44,24 +44,25 @@ import kotlinx.coroutines.delay
  * - 2 books: Side by side layout
  * - 3+ books: Animated stack with Material 3 Expressive spring animations
  *
- * @param coverPaths List of local file paths to cover images
+ * @param bookCovers List of (bookId, coverPath) pairs for server URL fallback
  * @param modifier Optional modifier
  * @param coverHeight Height of the cover area
  * @param cycleDurationMs Duration of each animation cycle (3+ books only)
  */
 @Composable
 fun AnimatedCoverStack(
-    coverPaths: List<String?>,
+    bookCovers: List<Pair<String, String?>>,
     modifier: Modifier = Modifier,
     coverHeight: Dp = 120.dp,
     cycleDurationMs: Long = 3000L,
 ) {
-    val coverCount = coverPaths.size
+    val coverCount = bookCovers.size
 
     when {
         coverCount == 0 -> {
             // Empty placeholder - full width
             FullWidthCover(
+                bookId = "",
                 coverPath = null,
                 modifier = modifier.height(coverHeight),
             )
@@ -70,7 +71,8 @@ fun AnimatedCoverStack(
         coverCount == 1 -> {
             // Single book - full width cropped
             FullWidthCover(
-                coverPath = coverPaths[0],
+                bookId = bookCovers[0].first,
+                coverPath = bookCovers[0].second,
                 modifier = modifier.height(coverHeight),
             )
         }
@@ -78,7 +80,7 @@ fun AnimatedCoverStack(
         coverCount == 2 -> {
             // Two books - side by side
             TwoUpCoverLayout(
-                coverPaths = coverPaths,
+                bookCovers = bookCovers,
                 modifier = modifier.height(coverHeight),
             )
         }
@@ -86,7 +88,7 @@ fun AnimatedCoverStack(
         else -> {
             // 3+ books - animated stack
             AnimatedStackLayout(
-                coverPaths = coverPaths,
+                bookCovers = bookCovers,
                 coverHeight = coverHeight,
                 cycleDurationMs = cycleDurationMs,
                 modifier = modifier,
@@ -100,6 +102,7 @@ fun AnimatedCoverStack(
  */
 @Composable
 private fun FullWidthCover(
+    bookId: String,
     coverPath: String?,
     modifier: Modifier = Modifier,
 ) {
@@ -113,9 +116,10 @@ private fun FullWidthCover(
                 .background(MaterialTheme.colorScheme.surfaceContainerHighest),
         contentAlignment = Alignment.Center,
     ) {
-        if (coverPath != null) {
-            ListenUpAsyncImage(
-                path = coverPath,
+        if (bookId.isNotBlank()) {
+            BookCoverImage(
+                bookId = bookId,
+                coverPath = coverPath,
                 contentDescription = null,
                 contentScale = ContentScale.Crop,
                 modifier = Modifier.fillMaxSize(),
@@ -138,7 +142,7 @@ private fun FullWidthCover(
  */
 @Composable
 private fun TwoUpCoverLayout(
-    coverPaths: List<String?>,
+    bookCovers: List<Pair<String, String?>>,
     modifier: Modifier = Modifier,
 ) {
     Row(
@@ -147,7 +151,8 @@ private fun TwoUpCoverLayout(
     ) {
         // Primary cover — takes more space
         StackedCover(
-            coverPath = coverPaths.getOrNull(0),
+            bookId = bookCovers.getOrNull(0)?.first ?: "",
+            coverPath = bookCovers.getOrNull(0)?.second,
             modifier =
                 Modifier
                     .weight(1f)
@@ -155,7 +160,8 @@ private fun TwoUpCoverLayout(
         )
         // Secondary cover — equal size
         StackedCover(
-            coverPath = coverPaths.getOrNull(1),
+            bookId = bookCovers.getOrNull(1)?.first ?: "",
+            coverPath = bookCovers.getOrNull(1)?.second,
             modifier =
                 Modifier
                     .weight(1f)
@@ -171,12 +177,12 @@ private fun TwoUpCoverLayout(
  */
 @Composable
 private fun AnimatedStackLayout(
-    coverPaths: List<String?>,
+    bookCovers: List<Pair<String, String?>>,
     coverHeight: Dp,
     cycleDurationMs: Long,
     modifier: Modifier = Modifier,
 ) {
-    val coverCount = coverPaths.size
+    val coverCount = bookCovers.size
 
     // Randomize starting position and add small stagger so cards don't animate in sync
     val startingIndex = remember { (0 until coverCount).random() }
@@ -212,7 +218,7 @@ private fun AnimatedStackLayout(
                 coverWidthPx * 0.35f,
             )
 
-        coverPaths.forEachIndexed { index, coverPath ->
+        bookCovers.forEachIndexed { index, (bookId, coverPath) ->
             // visualPosition: 0 = back, coverCount-1 = front (for z-ordering)
             val visualPosition =
                 calculateVisualPosition(
@@ -260,6 +266,7 @@ private fun AnimatedStackLayout(
             )
 
             StackedCover(
+                bookId = bookId,
                 coverPath = coverPath,
                 modifier =
                     Modifier
@@ -300,6 +307,7 @@ private fun calculateVisualPosition(
  */
 @Composable
 private fun StackedCover(
+    bookId: String,
     coverPath: String?,
     modifier: Modifier = Modifier,
 ) {
@@ -316,39 +324,15 @@ private fun StackedCover(
                 .background(MaterialTheme.colorScheme.surfaceContainerHighest),
         contentAlignment = Alignment.Center,
     ) {
-        if (coverPath != null) {
-            ListenUpAsyncImage(
-                path = coverPath,
-                contentDescription = null,
-                contentScale = ContentScale.Crop,
-                modifier =
-                    Modifier
-                        .fillMaxSize()
-                        .clip(shape),
-            )
-        } else {
-            CoverPlaceholder(modifier = Modifier.fillMaxSize())
-        }
-    }
-}
-
-/**
- * Placeholder for missing cover images.
- */
-@Composable
-private fun CoverPlaceholder(modifier: Modifier = Modifier) {
-    Box(
-        modifier =
-            modifier
-                .clip(RoundedCornerShape(8.dp))
-                .background(MaterialTheme.colorScheme.surfaceContainerHighest),
-        contentAlignment = Alignment.Center,
-    ) {
-        Icon(
-            imageVector = Icons.Default.Book,
+        BookCoverImage(
+            bookId = bookId,
+            coverPath = coverPath,
             contentDescription = null,
-            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
-            modifier = Modifier.padding(16.dp),
+            contentScale = ContentScale.Crop,
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .clip(shape),
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/library/components/AuthorsContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/library/components/AuthorsContent.kt
@@ -27,15 +27,18 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.calypsan.listenup.client.design.components.AlphabetIndex
+import com.calypsan.listenup.client.design.components.ContributorCoverImage
 import com.calypsan.listenup.client.design.components.AlphabetScrollbar
 import com.calypsan.listenup.client.design.components.SortSplitButton
 import com.calypsan.listenup.client.design.components.avatarColorForUser
@@ -191,22 +194,29 @@ internal fun ContributorCard(
                 color = avatarColorForUser(contributor.id.value),
                 modifier = Modifier.size(48.dp),
             ) {
-                val imagePath = contributor.imagePath
                 Box(contentAlignment = Alignment.Center) {
-                    if (imagePath != null) {
-                        coil3.compose.AsyncImage(
-                            model = imagePath,
-                            contentDescription = "${contributor.name} profile image",
-                            contentScale = androidx.compose.ui.layout.ContentScale.Crop,
-                            modifier = Modifier.fillMaxSize(),
-                        )
-                    } else {
+                    var imageLoaded by remember(contributor.id.value) { mutableStateOf(false) }
+
+                    if (!imageLoaded) {
                         Text(
                             text = getInitials(contributor.name),
                             style = MaterialTheme.typography.titleSmall,
                             color = MaterialTheme.colorScheme.onPrimaryContainer,
                         )
                     }
+
+                    ContributorCoverImage(
+                        contributorId = contributor.id.value,
+                        imagePath = contributor.imagePath,
+                        contentDescription = "${contributor.name} profile image",
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier.fillMaxSize(),
+                        onState = { state ->
+                            if (state is coil3.compose.AsyncImagePainter.State.Success) {
+                                imageLoaded = true
+                            }
+                        },
+                    )
                 }
             }
 

--- a/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/library/components/SeriesCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/library/components/SeriesCard.kt
@@ -61,16 +61,18 @@ fun SeriesCard(
         label = "card_scale",
     )
 
-    // Extract cover paths from books, sorted by series sequence
-    val coverPaths =
+    // Extract book covers sorted by series sequence, with IDs for server fallback
+    val bookCovers =
         books
             .sortedBy { sequenceByBookId[it.id.value]?.toFloatOrNull() ?: Float.MAX_VALUE }
             .map { book ->
-                if (imageStorage.exists(book.id)) {
-                    imageStorage.getCoverPath(book.id)
-                } else {
-                    null
-                }
+                val coverPath =
+                    if (imageStorage.exists(book.id)) {
+                        imageStorage.getCoverPath(book.id)
+                    } else {
+                        null
+                    }
+                book.id.value to coverPath
             }
 
     Column(
@@ -100,7 +102,7 @@ fun SeriesCard(
     ) {
         // Animated cover stack (individual covers have their own shadows)
         AnimatedCoverStack(
-            coverPaths = coverPaths,
+            bookCovers = bookCovers,
             coverHeight = 140.dp,
             cycleDurationMs = 3000L,
         )

--- a/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/seriesdetail/SeriesDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/seriesdetail/SeriesDetailScreen.kt
@@ -26,7 +26,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.LibraryBooks
-import androidx.compose.material.icons.filled.Book
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -338,22 +337,13 @@ private fun SeriesBookCard(
                         .background(MaterialTheme.colorScheme.surfaceContainerHighest),
                 contentAlignment = Alignment.Center,
             ) {
-                if (true) { // Always render — BookCoverImage handles server URL fallback
-                    BookCoverImage(
-                        bookId = book.id.value,
-                        coverPath = book.coverPath,
-                        contentDescription = book.title,
-                        contentScale = ContentScale.Crop,
-                        modifier = Modifier.fillMaxSize(),
-                    )
-                } else {
-                    Icon(
-                        imageVector = Icons.Default.Book,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
-                        modifier = Modifier.size(40.dp),
-                    )
-                }
+                BookCoverImage(
+                    bookId = book.id.value,
+                    coverPath = book.coverPath,
+                    contentDescription = book.title,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.fillMaxSize(),
+                )
             }
 
             // Info section below cover
@@ -572,25 +562,16 @@ private fun SeriesBookItem(
                         .background(MaterialTheme.colorScheme.surfaceContainerHighest),
                 contentAlignment = Alignment.Center,
             ) {
-                if (true) { // Always render — BookCoverImage handles server URL fallback
-                    BookCoverImage(
-                        bookId = book.id.value,
-                        coverPath = book.coverPath,
-                        contentDescription = book.title,
-                        contentScale = ContentScale.Crop,
-                        modifier =
-                            Modifier
-                                .fillMaxSize()
-                                .clip(RoundedCornerShape(8.dp)),
-                    )
-                } else {
-                    Icon(
-                        imageVector = Icons.Default.Book,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
-                        modifier = Modifier.size(32.dp),
-                    )
-                }
+                BookCoverImage(
+                    bookId = book.id.value,
+                    coverPath = book.coverPath,
+                    contentDescription = book.title,
+                    contentScale = ContentScale.Crop,
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .clip(RoundedCornerShape(8.dp)),
+                )
             }
 
             Spacer(modifier = Modifier.width(16.dp))

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/ImageRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/ImageRepositoryImpl.kt
@@ -85,6 +85,11 @@ class ImageRepositoryImpl(
         filename: String,
     ): Result<String> = imageApi.uploadContributorImage(contributorId, imageData, filename).map { it.imageUrl }
 
+    // ========== Contributor Image Path Operations ==========
+
+    override fun contributorImageExists(contributorId: String): Boolean =
+        imageStorage.contributorImageExists(contributorId)
+
     // ========== Book Cover Path Operations ==========
 
     override fun bookCoverExists(bookId: BookId): Boolean = imageStorage.exists(bookId)

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/ImageRepository.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/ImageRepository.kt
@@ -195,6 +195,16 @@ interface ImageRepository {
         filename: String,
     ): Result<String>
 
+    // ========== Contributor Image Path Operations ==========
+
+    /**
+     * Check if a contributor's image exists locally.
+     *
+     * @param contributorId Unique identifier for the contributor
+     * @return true if image exists on disk, false otherwise
+     */
+    fun contributorImageExists(contributorId: String): Boolean
+
     // ========== Book Cover Path Operations ==========
 
     /**


### PR DESCRIPTION
## Summary

Fixes #236.

### Root Cause
Contributor avatar images were guarded with `if (imagePath != null)` — blank space when no local image. Series/contributor book covers were not consistently using `BookCoverImage`'s server fallback path.

### Changes
- **`ContributorCoverImage.kt`** *(new)*: New composable mirroring `BookCoverImage` — resolves contributor images from local disk first, falls back to server URL (`/api/v1/contributors/{id}/image`), shows placeholder when truly unavailable
- **`ContributorDetailScreen.kt`**: Replaced `if (imagePath != null)` guard + raw `ListenUpAsyncImage` with `ContributorCoverImage`
- **`ContributorIdentityHeader.kt`**: Same replacement
- **`SeriesCard.kt`**: Ensured `bookId` is passed to `BookCoverImage` for server fallback
- **`AuthorsContent.kt`**: Applied `ContributorCoverImage` to author list items
- **`AnimatedCoverStack.kt`**: Cleaned up cover rendering
- **`ImageRepository`**: Added `getContributorImagePath` and `contributorImageExists` methods