### PR TITLE
🐛 Stabilize download status flow identity across recompositions (#239)

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/BookDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/BookDetailScreen.kt
@@ -102,14 +102,17 @@ fun BookDetailScreen(
     }
 
     val state by viewModel.state.collectAsState()
-    val isAdmin by userRepository.observeIsAdmin().collectAsState(initial = false)
-    val downloadStatus by platformActions
-        .observeBookStatus(BookId(bookId))
+    val isAdminFlow = remember { userRepository.observeIsAdmin() }
+    val isAdmin by isAdminFlow.collectAsState(initial = false)
+    val downloadStatusFlow = remember(bookId) { platformActions.observeBookStatus(BookId(bookId)) }
+    val downloadStatus by downloadStatusFlow
         .collectAsState(initial = BookDownloadStatus.notDownloaded(bookId))
 
     // WiFi-only download state detection
-    val wifiOnlyDownloads by platformActions.observeWifiOnlyDownloads().collectAsState(initial = false)
-    val isOnUnmeteredNetwork by platformActions.observeIsOnUnmeteredNetwork().collectAsState(initial = true)
+    val wifiOnlyFlow = remember { platformActions.observeWifiOnlyDownloads() }
+    val wifiOnlyDownloads by wifiOnlyFlow.collectAsState(initial = false)
+    val unmeteredFlow = remember { platformActions.observeIsOnUnmeteredNetwork() }
+    val isOnUnmeteredNetwork by unmeteredFlow.collectAsState(initial = true)
 
     // Show "Waiting for WiFi" when:
     // - Download is queued AND


### PR DESCRIPTION
## Summary

Fixes #239.

### Root Cause
`observeBookStatus()`, `observeWifiOnlyDownloads()`, and `observeIsOnUnmeteredNetwork()` were called directly in the composable body with no `remember` wrapper. Any recomposition (e.g. triggered by playback state change) recreated these flows, resetting the collected state to the `initial` value — causing the download button to snap back to 'to download' momentarily.

### Changes
- **`BookDetailScreen.kt`**: Wrapped all platform action flows in `remember` / `remember(bookId)` to stabilize flow identity across recompositions. State no longer resets on recompose.