### PR TITLE
🐛 Decouple server reachability from download button gate (#235, #237)

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/BookDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/BookDetailScreen.kt
@@ -3,18 +3,25 @@
 package com.calypsan.listenup.client.features.bookdetail
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
@@ -133,6 +140,12 @@ fun BookDetailScreen(
     // While check is in progress (null), assume playable to avoid flicker for fast connections
     val canPlay = downloadStatus.isFullyDownloaded || isServerReachable != false
 
+    // Downloads are always allowed — they queue locally and don't need the server to be reachable
+    val canDownload = platformActions.isPlaybackAvailable
+
+    // Show warning when server is unreachable and book isn't downloaded (informational only)
+    val showServerWarning = isServerReachable == false && !downloadStatus.isFullyDownloaded
+
     var showDeleteDialog by remember { mutableStateOf(false) }
     var showMarkCompleteDialog by remember { mutableStateOf(false) }
 
@@ -206,10 +219,12 @@ fun BookDetailScreen(
                     onDeleteBookClick = { /* TODO: Implement */ },
                     onPlayClick = { platformActions.playBook(BookId(bookId)) },
                     canPlay = canPlay,
+                    canDownload = canDownload,
+                    showServerWarning = showServerWarning,
                     onPlayDisabledClick = {
                         scope.launch {
                             snackbarHostState.showSnackbar(
-                                "Server is unreachable. Connect to your server to play or download this book.",
+                                "Server is unreachable. Connect to your server to stream this book, or download it for offline playback.",
                             )
                         }
                     },
@@ -323,6 +338,8 @@ fun BookDetailContent(
     onDeleteBookClick: () -> Unit,
     onPlayClick: () -> Unit,
     canPlay: Boolean,
+    canDownload: Boolean,
+    showServerWarning: Boolean,
     onPlayDisabledClick: () -> Unit,
     onDownloadClick: () -> Unit,
     onCancelClick: () -> Unit,
@@ -364,6 +381,8 @@ fun BookDetailContent(
             onCancelClick = onCancelClick,
             onDeleteClick = onDeleteClick,
             playEnabled = canPlay,
+            downloadEnabled = canDownload,
+            showServerWarning = showServerWarning,
             onPlayDisabledClick = onPlayDisabledClick,
             onSeriesClick = onSeriesClick,
             onContributorClick = onContributorClick,
@@ -391,6 +410,8 @@ fun BookDetailContent(
             onDeleteBookClick = onDeleteBookClick,
             onPlayClick = onPlayClick,
             canPlay = canPlay,
+            canDownload = canDownload,
+            showServerWarning = showServerWarning,
             onPlayDisabledClick = onPlayDisabledClick,
             onDownloadClick = onDownloadClick,
             onCancelClick = onCancelClick,
@@ -433,6 +454,8 @@ private fun ImmersiveBookDetail(
     onDeleteBookClick: () -> Unit,
     onPlayClick: () -> Unit,
     canPlay: Boolean,
+    canDownload: Boolean,
+    showServerWarning: Boolean,
     onPlayDisabledClick: () -> Unit,
     onDownloadClick: () -> Unit,
     onCancelClick: () -> Unit,
@@ -509,8 +532,18 @@ private fun ImmersiveBookDetail(
                     modifier = Modifier.padding(horizontal = 24.dp, vertical = 16.dp),
                     isWaitingForWifi = isWaitingForWifi,
                     playEnabled = canPlay,
+                    downloadEnabled = canDownload,
                     onPlayDisabledClick = onPlayDisabledClick,
                 )
+            }
+
+            // Server unreachable warning — informational only, does not disable buttons
+            if (showServerWarning) {
+                item {
+                    ServerUnreachableBanner(
+                        modifier = Modifier.padding(horizontal = 24.dp),
+                    )
+                }
             }
         }
 
@@ -596,6 +629,34 @@ private fun ImmersiveBookDetail(
                     }
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun ServerUnreachableBanner(modifier: Modifier = Modifier) {
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(12.dp),
+        color = MaterialTheme.colorScheme.errorContainer,
+        tonalElevation = 1.dp,
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                Icons.Default.Warning,
+                contentDescription = null,
+                modifier = Modifier.size(20.dp),
+                tint = MaterialTheme.colorScheme.onErrorContainer,
+            )
+            Text(
+                text = stringResource(Res.string.book_detail_server_is_unreachable_connect_to),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onErrorContainer,
+            )
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/BookDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/BookDetailScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape

--- a/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/components/PrimaryActionsSection.kt
+++ b/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/components/PrimaryActionsSection.kt
@@ -46,6 +46,7 @@ fun PrimaryActionsSection(
     modifier: Modifier = Modifier,
     isWaitingForWifi: Boolean = false,
     playEnabled: Boolean = true,
+    downloadEnabled: Boolean = true,
     requestFocus: Boolean = false,
     onPlayDisabledClick: () -> Unit = {},
 ) {
@@ -107,15 +108,14 @@ fun PrimaryActionsSection(
 
         // Download Button - icon-only square (hidden on TV/Auto — stream only)
         if (LocalDeviceContext.current.supportsDownloads) {
-            // When server is unavailable and book isn't downloaded, disable download too
             DownloadButton(
                 status = downloadStatus,
-                onDownloadClick = if (playEnabled) onDownloadClick else onPlayDisabledClick,
+                onDownloadClick = onDownloadClick,
                 onCancelClick = onCancelClick,
                 onDeleteClick = onDeleteClick,
                 modifier = Modifier.size(64.dp),
                 isWaitingForWifi = isWaitingForWifi,
-                enabled = playEnabled || downloadStatus.isFullyDownloaded,
+                enabled = downloadEnabled,
             )
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/components/WideBookDetail.kt
+++ b/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/components/WideBookDetail.kt
@@ -435,6 +435,7 @@ private fun ServerUnreachableWarning() {
     }
 }
 
+@Suppress("LongParameterList")
 @Composable
 private fun WideBookDetailAppBarActions(
     deviceContext: com.calypsan.listenup.client.device.DeviceContext,

--- a/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/components/WideBookDetail.kt
+++ b/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/components/WideBookDetail.kt
@@ -25,14 +25,17 @@ import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Share
+import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
@@ -62,6 +65,9 @@ import com.calypsan.listenup.client.domain.model.BookDownloadStatus
 import com.calypsan.listenup.client.features.bookdetail.TagsSection
 import com.calypsan.listenup.client.presentation.bookdetail.BookDetailUiState
 import com.calypsan.listenup.client.presentation.bookdetail.ChapterUiModel
+import listenup.composeapp.generated.resources.Res
+import listenup.composeapp.generated.resources.book_detail_server_is_unreachable_connect_to
+import org.jetbrains.compose.resources.stringResource
 
 /**
  * Wide book detail layout for tablets, foldables, desktop, and TV.
@@ -93,6 +99,8 @@ fun WideBookDetail(
     onCancelClick: () -> Unit,
     onDeleteClick: () -> Unit,
     playEnabled: Boolean = true,
+    downloadEnabled: Boolean = true,
+    showServerWarning: Boolean = false,
     onPlayDisabledClick: () -> Unit = {},
     onSeriesClick: (seriesId: String) -> Unit,
     onContributorClick: (contributorId: String) -> Unit,
@@ -294,10 +302,41 @@ fun WideBookDetail(
                                     modifier = Modifier.widthIn(max = 400.dp),
                                     isWaitingForWifi = isWaitingForWifi,
                                     playEnabled = playEnabled,
+                                    downloadEnabled = downloadEnabled,
                                     onPlayDisabledClick = onPlayDisabledClick,
                                     requestFocus = LocalDeviceContext.current.hasDpad,
                                 )
                             }
+                        }
+                    }
+                }
+            }
+
+            // Server unreachable warning — informational only, does not disable buttons
+            if (showServerWarning) {
+                item {
+                    Surface(
+                        modifier = Modifier.fillMaxWidth().padding(horizontal = 32.dp, vertical = 8.dp),
+                        shape = RoundedCornerShape(12.dp),
+                        color = MaterialTheme.colorScheme.errorContainer,
+                        tonalElevation = 1.dp,
+                    ) {
+                        Row(
+                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+                            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Icon(
+                                Icons.Default.Warning,
+                                contentDescription = null,
+                                modifier = Modifier.size(20.dp),
+                                tint = MaterialTheme.colorScheme.onErrorContainer,
+                            )
+                            Text(
+                                text = stringResource(Res.string.book_detail_server_is_unreachable_connect_to),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onErrorContainer,
+                            )
                         }
                     }
                 }

--- a/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/components/WideBookDetail.kt
+++ b/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/components/WideBookDetail.kt
@@ -151,58 +151,20 @@ fun WideBookDetail(
                 }
             },
             actions = {
-                if (!deviceContext.isLeanback) {
-                    IconButton(onClick = onShareClick) {
-                        Icon(Icons.Default.Share, contentDescription = "Share")
-                    }
-                }
-                if (deviceContext.canEdit) {
-                    var showMenu by remember { mutableStateOf(false) }
-                    Box {
-                        IconButton(onClick = { showMenu = true }) {
-                            Icon(Icons.Default.MoreVert, contentDescription = "More options")
-                        }
-                        BookActionsMenu(
-                            expanded = showMenu,
-                            onDismiss = { showMenu = false },
-                            isComplete = isComplete,
-                            hasProgress = hasProgress,
-                            isAdmin = isAdmin,
-                            onEditClick = {
-                                showMenu = false
-                                onEditClick()
-                            },
-                            onFindMetadataClick = {
-                                showMenu = false
-                                onFindMetadataClick()
-                            },
-                            onMarkCompleteClick = {
-                                showMenu = false
-                                onMarkCompleteClick()
-                            },
-                            onDiscardProgressClick = {
-                                showMenu = false
-                                onDiscardProgressClick()
-                            },
-                            onAddToShelfClick = {
-                                showMenu = false
-                                onAddToShelfClick()
-                            },
-                            onAddToCollectionClick = {
-                                showMenu = false
-                                onAddToCollectionClick()
-                            },
-                            onShareClick = {
-                                showMenu = false
-                                onShareClick()
-                            },
-                            onDeleteClick = {
-                                showMenu = false
-                                onDeleteBookClick()
-                            },
-                        )
-                    }
-                }
+                WideBookDetailAppBarActions(
+                    deviceContext = deviceContext,
+                    isComplete = isComplete,
+                    hasProgress = hasProgress,
+                    isAdmin = isAdmin,
+                    onShareClick = onShareClick,
+                    onEditClick = onEditClick,
+                    onFindMetadataClick = onFindMetadataClick,
+                    onMarkCompleteClick = onMarkCompleteClick,
+                    onDiscardProgressClick = onDiscardProgressClick,
+                    onAddToShelfClick = onAddToShelfClick,
+                    onAddToCollectionClick = onAddToCollectionClick,
+                    onDeleteBookClick = onDeleteBookClick,
+                )
             },
             colors =
                 TopAppBarDefaults.topAppBarColors(
@@ -468,6 +430,51 @@ private fun ServerUnreachableWarning() {
                 text = stringResource(Res.string.book_detail_server_is_unreachable_connect_to),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onErrorContainer,
+            )
+        }
+    }
+}
+
+@Composable
+private fun WideBookDetailAppBarActions(
+    deviceContext: com.calypsan.listenup.client.device.DeviceContext,
+    isComplete: Boolean,
+    hasProgress: Boolean,
+    isAdmin: Boolean,
+    onShareClick: () -> Unit,
+    onEditClick: () -> Unit,
+    onFindMetadataClick: () -> Unit,
+    onMarkCompleteClick: () -> Unit,
+    onDiscardProgressClick: () -> Unit,
+    onAddToShelfClick: () -> Unit,
+    onAddToCollectionClick: () -> Unit,
+    onDeleteBookClick: () -> Unit,
+) {
+    if (!deviceContext.isLeanback) {
+        IconButton(onClick = onShareClick) {
+            Icon(Icons.Default.Share, contentDescription = "Share")
+        }
+    }
+    if (deviceContext.canEdit) {
+        var showMenu by remember { mutableStateOf(false) }
+        Box {
+            IconButton(onClick = { showMenu = true }) {
+                Icon(Icons.Default.MoreVert, contentDescription = "More options")
+            }
+            BookActionsMenu(
+                expanded = showMenu,
+                onDismiss = { showMenu = false },
+                isComplete = isComplete,
+                hasProgress = hasProgress,
+                isAdmin = isAdmin,
+                onEditClick = { showMenu = false; onEditClick() },
+                onFindMetadataClick = { showMenu = false; onFindMetadataClick() },
+                onMarkCompleteClick = { showMenu = false; onMarkCompleteClick() },
+                onDiscardProgressClick = { showMenu = false; onDiscardProgressClick() },
+                onAddToShelfClick = { showMenu = false; onAddToShelfClick() },
+                onAddToCollectionClick = { showMenu = false; onAddToCollectionClick() },
+                onShareClick = { showMenu = false; onShareClick() },
+                onDeleteClick = { showMenu = false; onDeleteBookClick() },
             )
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/components/WideBookDetail.kt
+++ b/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/components/WideBookDetail.kt
@@ -467,14 +467,38 @@ private fun WideBookDetailAppBarActions(
                 isComplete = isComplete,
                 hasProgress = hasProgress,
                 isAdmin = isAdmin,
-                onEditClick = { showMenu = false; onEditClick() },
-                onFindMetadataClick = { showMenu = false; onFindMetadataClick() },
-                onMarkCompleteClick = { showMenu = false; onMarkCompleteClick() },
-                onDiscardProgressClick = { showMenu = false; onDiscardProgressClick() },
-                onAddToShelfClick = { showMenu = false; onAddToShelfClick() },
-                onAddToCollectionClick = { showMenu = false; onAddToCollectionClick() },
-                onShareClick = { showMenu = false; onShareClick() },
-                onDeleteClick = { showMenu = false; onDeleteBookClick() },
+                onEditClick = {
+                    showMenu = false
+                    onEditClick()
+                },
+                onFindMetadataClick = {
+                    showMenu = false
+                    onFindMetadataClick()
+                },
+                onMarkCompleteClick = {
+                    showMenu = false
+                    onMarkCompleteClick()
+                },
+                onDiscardProgressClick = {
+                    showMenu = false
+                    onDiscardProgressClick()
+                },
+                onAddToShelfClick = {
+                    showMenu = false
+                    onAddToShelfClick()
+                },
+                onAddToCollectionClick = {
+                    showMenu = false
+                    onAddToCollectionClick()
+                },
+                onShareClick = {
+                    showMenu = false
+                    onShareClick()
+                },
+                onDeleteClick = {
+                    showMenu = false
+                    onDeleteBookClick()
+                },
             )
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/components/WideBookDetail.kt
+++ b/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/components/WideBookDetail.kt
@@ -314,32 +314,7 @@ fun WideBookDetail(
 
             // Server unreachable warning — informational only, does not disable buttons
             if (showServerWarning) {
-                item {
-                    Surface(
-                        modifier = Modifier.fillMaxWidth().padding(horizontal = 32.dp, vertical = 8.dp),
-                        shape = RoundedCornerShape(12.dp),
-                        color = MaterialTheme.colorScheme.errorContainer,
-                        tonalElevation = 1.dp,
-                    ) {
-                        Row(
-                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
-                            horizontalArrangement = Arrangement.spacedBy(12.dp),
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            Icon(
-                                Icons.Default.Warning,
-                                contentDescription = null,
-                                modifier = Modifier.size(20.dp),
-                                tint = MaterialTheme.colorScheme.onErrorContainer,
-                            )
-                            Text(
-                                text = stringResource(Res.string.book_detail_server_is_unreachable_connect_to),
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onErrorContainer,
-                            )
-                        }
-                    }
-                }
+                item { ServerUnreachableWarning() }
             }
 
             // Content below hero — standard surface background
@@ -467,5 +442,33 @@ private fun ChapterListItemCompact(
             style = MaterialTheme.typography.labelSmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
+    }
+}
+
+@Composable
+private fun ServerUnreachableWarning() {
+    Surface(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 32.dp, vertical = 8.dp),
+        shape = RoundedCornerShape(12.dp),
+        color = MaterialTheme.colorScheme.errorContainer,
+        tonalElevation = 1.dp,
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                Icons.Default.Warning,
+                contentDescription = null,
+                modifier = Modifier.size(20.dp),
+                tint = MaterialTheme.colorScheme.onErrorContainer,
+            )
+            Text(
+                text = stringResource(Res.string.book_detail_server_is_unreachable_connect_to),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onErrorContainer,
+            )
+        }
     }
 }

--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -59,9 +59,6 @@
     <ID>UnusedImports:BookCard.kt$import androidx.compose.material.icons.filled.Book</ID>
     <ID>UnusedImports:BookCard.kt$import androidx.compose.ui.graphics.Brush</ID>
     <ID>UnusedImports:BookCoverImage.kt$import org.koin.compose.koinInject</ID>
-    <ID>UnusedImports:BookDetailScreen.kt$import listenup.composeapp.generated.resources.Res</ID>
-    <ID>UnusedImports:BookDetailScreen.kt$import listenup.composeapp.generated.resources.book_detail_server_is_unreachable_connect_to</ID>
-    <ID>UnusedImports:BookDetailScreen.kt$import org.jetbrains.compose.resources.stringResource</ID>
     <ID>UnusedImports:ContributorBooksScreen.kt$import androidx.compose.foundation.layout.width</ID>
     <ID>UnusedImports:ContributorDetailScreen.kt$import androidx.compose.foundation.layout.heightIn</ID>
     <ID>UnusedImports:CreateInviteScreen.kt$import listenup.composeapp.generated.resources.admin_invite_created_link_copied_to</ID>

--- a/shared/src/commonMain/resources/strings/en.json
+++ b/shared/src/commonMain/resources/strings/en.json
@@ -211,7 +211,7 @@
     "detail_remove_the_downloaded_files_for": "Remove the downloaded files for “%1$s”? ",
     "detail_retry_download": "Retry download",
     "detail_see_all_chapters": "See All %1$d Chapters",
-    "detail_server_is_unreachable_connect_to": "Server is unreachable. Connect to your server to play or download this book.",
+    "detail_server_is_unreachable_connect_to": "Server is unreachable. Connect to your server to stream this book, or download it for offline playback.",
     "detail_show_less": "Show Less",
     "detail_synopsis": "Synopsis",
     "detail_tags": "Tags",


### PR DESCRIPTION
## Summary

Fixes #235 and #237.

### Root Cause
`checkServerReachable()` fires on screen load via `LaunchedEffect`. If it returns `false`, `canPlay` was set to `false` — disabling **both** the play button and the download button. The pause button bypassed this gate entirely (direct MediaController toggle), which is why pausing worked while play was disabled.

### Changes
- **`BookDetailScreen.kt`**: Split `canPlay` into two concerns:
  - `canDownload` = always `true` when `isPlaybackAvailable` — server not needed to queue a download
  - `canPlay` = existing logic (stream requires server reachability)
  - `showServerWarning` = informational banner only, never disables buttons
- **`WideBookDetail.kt`**: Threaded `downloadEnabled` and `showServerWarning` for tablet layout
- **`PrimaryActionsSection.kt`**: Download button now uses `downloadEnabled` independently
- **`NowPlayingBar.kt` / `NowPlayingScreen.kt`**: Added buffering indicator to play/pause button
- **`ProgressTracker.kt`**: Fixed read-modify-write race — position updates now use `updatePositionOnly` to avoid clobbering `hasCustomSpeed` set by concurrent `onSpeedChanged`
- **`DownloadStateResumeTest.kt`**: New test covering download button availability when server is unreachable