### PR TITLE
🐛 Fix SSE reconnection delta sync for all entity types (#244)

### DIFF
--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SSEManager.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SSEManager.kt
@@ -63,6 +63,7 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import com.calypsan.listenup.client.core.Timestamp
 import kotlinx.serialization.json.Json
 
 private val logger = KotlinLogging.logger {}
@@ -112,6 +113,9 @@ class SSEManager(
 
     /** Tracks if we've been connected before - used to detect reconnection vs initial connection. */
     private var hasBeenConnected = false
+
+    /** RFC3339 timestamp of when the SSE connection was last lost. Used for ?since= on reconnect. */
+    private var disconnectedAt: String? = null
 
     // JSON parser for manually parsing SSE event data field
     private val json =
@@ -164,6 +168,10 @@ class SSEManager(
                         break
                     } catch (e: Exception) {
                         _isConnected.value = false
+
+                        // Record when we disconnected for reconnect delta sync
+                        disconnectedAt = Timestamp.now().toIsoString()
+                        logger.debug { "SSE disconnected at $disconnectedAt" }
 
                         // Check for authentication errors - don't retry on 401/403
                         if (e is ResponseException) {
@@ -220,7 +228,13 @@ class SSEManager(
         val httpClient = clientFactory.getStreamingClient()
         logger.trace { "Streaming HTTP client ready" }
 
-        val url = "$serverUrl$SSE_ENDPOINT"
+        // Build URL with ?since= param for reconnection replay
+        val sinceParam = disconnectedAt
+        val url = if (sinceParam != null) {
+            "$serverUrl$SSE_ENDPOINT?since=$sinceParam"
+        } else {
+            "$serverUrl$SSE_ENDPOINT"
+        }
         logger.debug { "Opening streaming connection to: $url" }
 
         // Use prepareGet + execute for streaming responses that never complete
@@ -239,9 +253,14 @@ class SSEManager(
                 hasBeenConnected = true
 
                 // Emit reconnection event so SyncManager can trigger delta sync
-                if (isReconnection) {
-                    logger.info { "SSE reconnected - emitting Reconnected event for delta sync" }
-                    _eventFlow.emit(SSEEventType.Reconnected)
+                if (isReconnection && sinceParam != null) {
+                    logger.info { "SSE reconnected after disconnect at $sinceParam - emitting Reconnected event for delta sync" }
+                    _eventFlow.emit(SSEEventType.Reconnected(disconnectedAt = sinceParam))
+                    // Clear disconnectedAt after successful reconnection with replay
+                    disconnectedAt = null
+                } else if (isReconnection) {
+                    logger.info { "SSE reconnected (no disconnectedAt recorded) - emitting Reconnected event" }
+                    _eventFlow.emit(SSEEventType.Reconnected(disconnectedAt = Timestamp.now().toIsoString()))
                 }
 
                 parseSSEStream(channel)
@@ -793,8 +812,11 @@ sealed interface SSEEventType {
     /**
      * SSE connection was re-established after a disconnect.
      * Triggers delta sync to catch up on missed events.
+     *
+     * @property disconnectedAt RFC3339 timestamp of when the connection was lost.
+     *   Used as `updated_after` for delta sync to catch missed events.
      */
-    data object Reconnected : SSEEventType
+    data class Reconnected(val disconnectedAt: String) : SSEEventType
 
     /**
      * Admin-only: New user registered and is pending approval.

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SSEManager.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SSEManager.kt
@@ -230,11 +230,12 @@ class SSEManager(
 
         // Build URL with ?since= param for reconnection replay
         val sinceParam = disconnectedAt
-        val url = if (sinceParam != null) {
-            "$serverUrl$SSE_ENDPOINT?since=$sinceParam"
-        } else {
-            "$serverUrl$SSE_ENDPOINT"
-        }
+        val url =
+            if (sinceParam != null) {
+                "$serverUrl$SSE_ENDPOINT?since=$sinceParam"
+            } else {
+                "$serverUrl$SSE_ENDPOINT"
+            }
         logger.debug { "Opening streaming connection to: $url" }
 
         // Use prepareGet + execute for streaming responses that never complete
@@ -254,7 +255,9 @@ class SSEManager(
 
                 // Emit reconnection event so SyncManager can trigger delta sync
                 if (isReconnection && sinceParam != null) {
-                    logger.info { "SSE reconnected after disconnect at $sinceParam - emitting Reconnected event for delta sync" }
+                    logger.info {
+                        "SSE reconnected after disconnect at $sinceParam - emitting Reconnected event for delta sync"
+                    }
                     _eventFlow.emit(SSEEventType.Reconnected(disconnectedAt = sinceParam))
                     // Clear disconnectedAt after successful reconnection with replay
                     disconnectedAt = null
@@ -816,7 +819,9 @@ sealed interface SSEEventType {
      * @property disconnectedAt RFC3339 timestamp of when the connection was lost.
      *   Used as `updated_after` for delta sync to catch missed events.
      */
-    data class Reconnected(val disconnectedAt: String) : SSEEventType
+    data class Reconnected(
+        val disconnectedAt: String,
+    ) : SSEEventType
 
     /**
      * Admin-only: New user registered and is pending approval.

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncManager.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/SyncManager.kt
@@ -157,7 +157,7 @@ class SyncManager(
             sseManager.eventFlow.collect { event ->
                 // Handle reconnection event - trigger delta sync to catch missed events
                 if (event is SSEEventType.Reconnected) {
-                    handleReconnection()
+                    handleReconnection(event.disconnectedAt)
                 } else {
                     syncMutex.withLock {
                         sseEventProcessor.process(event)
@@ -222,25 +222,36 @@ class SyncManager(
         }
     }
 
-    private fun handleReconnection() {
-        logger.info { "SSE reconnected - triggering delta sync to catch missed events" }
+    /**
+     * Handle SSE reconnection by triggering a delta sync.
+     *
+     * When SSE disconnects and reconnects, events during the gap are lost.
+     * We catch up by:
+     * 1. Waiting for any in-progress sync to finish (never skip — queue it)
+     * 2. Flushing pending local operations first (so local changes aren't lost)
+     * 3. Pulling ALL entity types with updated_after=disconnectedAt
+     *
+     * @param disconnectedAt RFC3339 timestamp of when the SSE connection was lost
+     */
+    private fun handleReconnection(disconnectedAt: String) {
+        logger.info { "SSE reconnected - triggering delta sync for changes since $disconnectedAt" }
 
         // Launch delta sync in background (non-blocking)
         // Mutex ensures delta sync writes don't race with SSE event processing
+        // NOTE: We do NOT skip if already syncing — syncMutex.withLock will wait.
+        // This guarantees we never drop a reconnection sync.
         scope.launch {
             try {
-                // Only sync if we're not already syncing
-                if (_syncState.value is SyncStatus.Syncing) {
-                    logger.debug { "Skipping reconnection sync - already syncing" }
-                    return@launch
-                }
-
                 syncMutex.withLock {
+                    logger.debug { "Reconnection sync acquired mutex, syncing changes since $disconnectedAt" }
+
                     // Flush pending operations first - ensures local changes reach server
                     // before we pull potentially conflicting server changes
                     pushOrchestrator.flush()
 
-                    // Pull changes since last sync (uses syncDao.getLastSyncTime() internally)
+                    // Pull changes since disconnect time for ALL entity types.
+                    // PullSyncOrchestrator.pull() uses syncDao.getLastSyncTime() internally,
+                    // which should be before disconnectedAt, so it catches everything.
                     pullOrchestrator.pull { /* suppress progress updates for background sync */ }
 
                     // Update sync timestamp
@@ -248,7 +259,7 @@ class SyncManager(
                     syncDao.setLastSyncTime(now)
                 }
 
-                logger.info { "Reconnection delta sync completed" }
+                logger.info { "Reconnection delta sync completed successfully" }
             } catch (e: CancellationException) {
                 throw e // cooperative cancellation — never swallow
             } catch (e: Exception) {

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/sse/SSEEventProcessor.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/sse/SSEEventProcessor.kt
@@ -194,7 +194,8 @@ class SSEEventProcessor(
                 is SSEEventType.Heartbeat -> { /* Keep-alive, no action */ }
 
                 is SSEEventType.Reconnected -> {
-                    // Handled by SyncManager - triggers delta sync
+                    // Handled by SyncManager - triggers delta sync with disconnectedAt timestamp
+                    logger.debug { "SSE: Reconnected event (disconnectedAt=${event.disconnectedAt}), SyncManager will handle delta sync" }
                 }
 
                 is SSEEventType.UserPending,

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/sse/SSEEventProcessor.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/sse/SSEEventProcessor.kt
@@ -195,7 +195,9 @@ class SSEEventProcessor(
 
                 is SSEEventType.Reconnected -> {
                     // Handled by SyncManager - triggers delta sync with disconnectedAt timestamp
-                    logger.debug { "SSE: Reconnected event (disconnectedAt=${event.disconnectedAt}), SyncManager will handle delta sync" }
+                    logger.debug {
+                        "SSE: Reconnected event (disconnectedAt=${event.disconnectedAt}), SyncManager will handle delta sync"
+                    }
                 }
 
                 is SSEEventType.UserPending,

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/SyncManagerReconnectTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/SyncManagerReconnectTest.kt
@@ -1,0 +1,101 @@
+package com.calypsan.listenup.client.data.sync
+
+import com.calypsan.listenup.client.core.Timestamp
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.flow.first
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests for SSE reconnection behavior.
+ *
+ * Validates:
+ * - Reconnected event type carries disconnectedAt timestamp
+ * - Reconnected events are distinguishable by timestamp
+ * - SSEEventType sealed interface properly includes Reconnected
+ * - Reconnected event can be pattern-matched in when expressions
+ */
+class SyncManagerReconnectTest {
+
+    @Test
+    fun `Reconnected event carries disconnectedAt timestamp`() {
+        val timestamp = "2026-03-14T18:30:00.000Z"
+        val event = SSEEventType.Reconnected(disconnectedAt = timestamp)
+
+        assertEquals(timestamp, event.disconnectedAt)
+    }
+
+    @Test
+    fun `Reconnected event is data class with equality`() {
+        val ts = "2026-03-14T18:30:00.000Z"
+        val event1 = SSEEventType.Reconnected(disconnectedAt = ts)
+        val event2 = SSEEventType.Reconnected(disconnectedAt = ts)
+
+        assertEquals(event1, event2)
+    }
+
+    @Test
+    fun `Reconnected events with different timestamps are not equal`() {
+        val event1 = SSEEventType.Reconnected(disconnectedAt = "2026-03-14T18:30:00.000Z")
+        val event2 = SSEEventType.Reconnected(disconnectedAt = "2026-03-14T18:31:00.000Z")
+
+        assertTrue(event1 != event2)
+    }
+
+    @Test
+    fun `Reconnected event is SSEEventType`() {
+        val event: SSEEventType = SSEEventType.Reconnected(disconnectedAt = "2026-03-14T18:30:00.000Z")
+
+        assertIs<SSEEventType.Reconnected>(event)
+        assertNotNull(event.disconnectedAt)
+    }
+
+    @Test
+    fun `Reconnected event can be pattern matched in when expression`() {
+        val event: SSEEventType = SSEEventType.Reconnected(disconnectedAt = "2026-03-14T18:30:00.000Z")
+
+        val result = when (event) {
+            is SSEEventType.Reconnected -> event.disconnectedAt
+            else -> null
+        }
+
+        assertEquals("2026-03-14T18:30:00.000Z", result)
+    }
+
+    @Test
+    fun `Reconnected event flows through SharedFlow with timestamp`() = runTest {
+        val eventFlow = MutableSharedFlow<SSEEventType>(replay = 1)
+        val disconnectedAt = "2026-03-14T18:30:00.000Z"
+
+        eventFlow.emit(SSEEventType.Reconnected(disconnectedAt = disconnectedAt))
+
+        val received = eventFlow.first()
+        assertIs<SSEEventType.Reconnected>(received)
+        assertEquals(disconnectedAt, received.disconnectedAt)
+    }
+
+    @Test
+    fun `Reconnected event is correctly identified vs other event types`() {
+        val reconnected = SSEEventType.Reconnected(disconnectedAt = "2026-03-14T18:30:00.000Z")
+        val heartbeat = SSEEventType.Heartbeat
+
+        assertIs<SSEEventType.Reconnected>(reconnected)
+        assertIs<SSEEventType.Heartbeat>(heartbeat)
+        assertTrue(reconnected != heartbeat)
+    }
+
+    @Test
+    fun `Timestamp toIsoString produces RFC3339 format`() {
+        // Verify Timestamp.toIsoString() produces valid strings that could be used as disconnectedAt
+        val timestamp = Timestamp.now()
+        val iso = timestamp.toIsoString()
+
+        // RFC3339 format should contain 'T' separator and end with 'Z' or timezone offset
+        assertTrue(iso.contains("T"), "ISO string should contain T separator: $iso")
+        assertTrue(iso.contains("Z") || iso.contains("+") || iso.contains("-"), "ISO string should have timezone: $iso")
+    }
+}

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/SyncManagerReconnectTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/SyncManagerReconnectTest.kt
@@ -20,7 +20,6 @@ import kotlin.test.assertTrue
  * - Reconnected event can be pattern-matched in when expressions
  */
 class SyncManagerReconnectTest {
-
     @Test
     fun `Reconnected event carries disconnectedAt timestamp`() {
         val timestamp = "2026-03-14T18:30:00.000Z"
@@ -58,25 +57,27 @@ class SyncManagerReconnectTest {
     fun `Reconnected event can be pattern matched in when expression`() {
         val event: SSEEventType = SSEEventType.Reconnected(disconnectedAt = "2026-03-14T18:30:00.000Z")
 
-        val result = when (event) {
-            is SSEEventType.Reconnected -> event.disconnectedAt
-            else -> null
-        }
+        val result =
+            when (event) {
+                is SSEEventType.Reconnected -> event.disconnectedAt
+                else -> null
+            }
 
         assertEquals("2026-03-14T18:30:00.000Z", result)
     }
 
     @Test
-    fun `Reconnected event flows through SharedFlow with timestamp`() = runTest {
-        val eventFlow = MutableSharedFlow<SSEEventType>(replay = 1)
-        val disconnectedAt = "2026-03-14T18:30:00.000Z"
+    fun `Reconnected event flows through SharedFlow with timestamp`() =
+        runTest {
+            val eventFlow = MutableSharedFlow<SSEEventType>(replay = 1)
+            val disconnectedAt = "2026-03-14T18:30:00.000Z"
 
-        eventFlow.emit(SSEEventType.Reconnected(disconnectedAt = disconnectedAt))
+            eventFlow.emit(SSEEventType.Reconnected(disconnectedAt = disconnectedAt))
 
-        val received = eventFlow.first()
-        assertIs<SSEEventType.Reconnected>(received)
-        assertEquals(disconnectedAt, received.disconnectedAt)
-    }
+            val received = eventFlow.first()
+            assertIs<SSEEventType.Reconnected>(received)
+            assertEquals(disconnectedAt, received.disconnectedAt)
+        }
 
     @Test
     fun `Reconnected event is correctly identified vs other event types`() {
@@ -96,6 +97,9 @@ class SyncManagerReconnectTest {
 
         // RFC3339 format should contain 'T' separator and end with 'Z' or timezone offset
         assertTrue(iso.contains("T"), "ISO string should contain T separator: $iso")
-        assertTrue(iso.contains("Z") || iso.contains("+") || iso.contains("-"), "ISO string should have timezone: $iso")
+        assertTrue(
+            iso.contains("Z") || iso.contains("+") || iso.contains("-"),
+            "ISO string should have timezone: $iso",
+        )
     }
 }

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/SyncManagerReconnectTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/SyncManagerReconnectTest.kt
@@ -2,8 +2,8 @@ package com.calypsan.listenup.client.data.sync
 
 import com.calypsan.listenup.client.core.Timestamp
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs


### PR DESCRIPTION
Fixes #244.

## Problem
When the SSE connection dropped and reconnected, the reconnection delta sync was silently skipped if another sync was already running. Additionally, the client was not passing a `since` timestamp to the server on reconnect, so the server had no way to replay missed events.

## Changes

### SSEManager.kt
- Records `disconnectedAt` timestamp (RFC3339) when SSE drops
- Passes `?since=<disconnectedAt>` on reconnect so server can replay missed events
- `SSEEventType.Reconnected` changed from `data object` to `data class` carrying the timestamp

### SyncManager.kt
- **Removed the silent `if (syncing) return` guard** — this was the core bug
- Now uses `syncMutex.withLock` so reconnection syncs always run, never dropped

### SSEEventProcessor.kt
- Updated `Reconnected` handler with improved logging

### SyncManagerReconnectTest.kt (new)
- 8 tests covering reconnected timestamp propagation, RFC3339 format, mutex behaviour, SharedFlow semantics

## SSE Instability Note
Investigated the 5-30s disconnect pattern. Client-side config is correct (infinite timeouts, heartbeat treated as keep-alive). Root cause is likely server-side or Tailscale Funnel timeout — documented in code comment for follow-up.