### PR TITLE
🐛 Fix loading screen on resume and mini player visibility

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/nowplaying/NowPlayingHost.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/features/nowplaying/NowPlayingHost.kt
@@ -26,7 +26,6 @@ import com.calypsan.listenup.client.device.DeviceType
 import com.calypsan.listenup.client.features.shell.components.NavigationBarHeight
 import com.calypsan.listenup.client.playback.ContributorPickerType
 import com.calypsan.listenup.client.playback.NowPlayingViewModel
-import org.koin.compose.viewmodel.koinViewModel
 
 /** Height of a standard snackbar for padding calculations */
 private val SnackbarHeight = 48.dp
@@ -47,8 +46,8 @@ fun NowPlayingHost(
     onNavigateToBook: (String) -> Unit,
     onNavigateToSeries: (String) -> Unit,
     onNavigateToContributor: (String) -> Unit,
+    viewModel: NowPlayingViewModel,
     modifier: Modifier = Modifier,
-    viewModel: NowPlayingViewModel = koinViewModel(),
 ) {
     val state by viewModel.state.collectAsState()
     val sleepTimerState by viewModel.sleepTimerState.collectAsState()

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/ListenUpNavigation.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/ListenUpNavigation.kt
@@ -395,20 +395,21 @@ private fun AuthenticatedNavigation(
     val startupViewModel: AppStartupViewModel = koinViewModel()
     val startupState by startupViewModel.state.collectAsState()
 
-    // Show loading only while the cold-start library-setup check is in progress.
-    // After the first check completes the ViewModel retains the result, so subsequent
-    // recompositions (config change, brief background resume) skip straight to the app.
-    if (startupState.isChecking) {
-        FullScreenLoadingIndicator()
-        return
-    }
-
-    // Determine starting route based on library setup needs
-    val startRoute: Route = if (startupState.needsLibrarySetup) LibrarySetup else Shell
-    val backStack = remember(startRoute) { mutableStateListOf(startRoute) }
+    // Hoist navigation state above the isChecking check so it survives loading periods.
+    // Using remember without key ensures the backStack persists when isChecking toggles,
+    // preventing navigation position from being lost on app resume.
+    val backStack = remember { mutableStateListOf<Route>(Shell) }
 
     // Track shell tab state here so it survives navigation to detail screens
     var currentShellDestination by remember { mutableStateOf<ShellDestination>(ShellDestination.Home) }
+
+    // Navigate to LibrarySetup when the check completes and setup is needed
+    LaunchedEffect(startupState.needsLibrarySetup, startupState.isChecking) {
+        if (!startupState.isChecking && startupState.needsLibrarySetup) {
+            backStack.clear()
+            backStack.add(LibrarySetup)
+        }
+    }
 
     // Track profile refresh - incremented when profile is updated to trigger refresh
     var profileRefreshKey by remember { mutableStateOf(0) }
@@ -1088,6 +1089,8 @@ private fun AuthenticatedNavigation(
             // Now Playing overlay - persistent across all navigation
             // Position adjusts based on whether bottom nav is visible (Shell vs detail screens)
             // Also animates up when snackbar is visible
+            // Pass viewModel explicitly to ensure NowPlayingHost shares the same instance
+            // as NowPlayingBar in AppShell - prevents state divergence between screens
             NowPlayingHost(
                 hasBottomNav = backStack.lastOrNull() == Shell,
                 snackbarHostState = snackbarHostState,
@@ -1100,6 +1103,7 @@ private fun AuthenticatedNavigation(
                 onNavigateToContributor = { contributorId ->
                     backStack.add(ContributorDetail(contributorId))
                 },
+                viewModel = nowPlayingViewModel,
             )
 
             // App-wide snackbar - positioned at bottom, mini player animates up when visible
@@ -1110,6 +1114,12 @@ private fun AuthenticatedNavigation(
                         .align(Alignment.BottomCenter)
                         .padding(bottom = 16.dp),
             )
+
+            // Overlay loading indicator while startup check is in progress.
+            // Using an overlay instead of early return preserves the backStack state.
+            if (startupState.isChecking) {
+                FullScreenLoadingIndicator()
+            }
         }
     }
 }

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/startup/AppStartupViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/startup/AppStartupViewModel.kt
@@ -49,7 +49,7 @@ class AppStartupViewModel(
 
     companion object {
         /** Apps backgrounded longer than this will re-run the library-setup check on resume. */
-        const val BACKGROUND_THRESHOLD_MS = 5 * 60 * 1000L // 5 minutes
+        const val BACKGROUND_THRESHOLD_MS = 30 * 60 * 1000L // 30 minutes
     }
 
     init {

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/startup/AppStartupViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/startup/AppStartupViewModelTest.kt
@@ -59,7 +59,9 @@ class AppStartupViewModelTest {
         isAdmin: Boolean = false,
     ): User =
         User(
-            id = com.calypsan.listenup.client.core.UserId(id),
+            id =
+                com.calypsan.listenup.client.core
+                    .UserId(id),
             email = "test@example.com",
             displayName = "Test User",
             firstName = null,
@@ -128,13 +130,14 @@ class AppStartupViewModelTest {
             val adminUser = createTestUser(isAdmin = true)
             everySuspend { userRepository.refreshCurrentUser() } returns adminUser
             everySuspend { userRepository.getCurrentUser() } returns adminUser
-            everySuspend { setupApi.getLibraryStatus() } returns LibraryStatusResponse(
-                exists = false,
-                library = null,
-                needsSetup = true,
-                bookCount = 0,
-                isScanning = false,
-            )
+            everySuspend { setupApi.getLibraryStatus() } returns
+                LibraryStatusResponse(
+                    exists = false,
+                    library = null,
+                    needsSetup = true,
+                    bookCount = 0,
+                    isScanning = false,
+                )
 
             // When
             val viewModel = AppStartupViewModel(userRepository, setupApi)
@@ -224,13 +227,14 @@ class AppStartupViewModelTest {
             val adminUser = createTestUser(isAdmin = true)
             everySuspend { userRepository.refreshCurrentUser() } returns adminUser
             everySuspend { userRepository.getCurrentUser() } returns adminUser
-            everySuspend { setupApi.getLibraryStatus() } returns LibraryStatusResponse(
-                exists = false,
-                library = null,
-                needsSetup = true,
-                bookCount = 0,
-                isScanning = false,
-            )
+            everySuspend { setupApi.getLibraryStatus() } returns
+                LibraryStatusResponse(
+                    exists = false,
+                    library = null,
+                    needsSetup = true,
+                    bookCount = 0,
+                    isScanning = false,
+                )
 
             val viewModel = AppStartupViewModel(userRepository, setupApi)
             advanceUntilIdle()

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/startup/AppStartupViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/startup/AppStartupViewModelTest.kt
@@ -1,0 +1,253 @@
+package com.calypsan.listenup.client.presentation.startup
+
+import com.calypsan.listenup.client.data.remote.LibraryStatusResponse
+import com.calypsan.listenup.client.data.remote.SetupApiContract
+import com.calypsan.listenup.client.domain.model.User
+import com.calypsan.listenup.client.domain.repository.UserRepository
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.mock
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests for AppStartupViewModel.
+ *
+ * Tests cover:
+ * - Initial state and library setup check
+ * - onAppBackgrounded() records timestamp
+ * - onAppForegrounded() behavior for short vs long background periods
+ * - Threshold constant value
+ *
+ * Uses Mokkery for mocking and follows Given-When-Then style.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class AppStartupViewModelTest {
+    private val testDispatcher = StandardTestDispatcher()
+
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    // ========== Test Data Factories ==========
+
+    private fun createMockUserRepository(): UserRepository = mock<UserRepository>()
+
+    private fun createMockSetupApi(): SetupApiContract = mock<SetupApiContract>()
+
+    private fun createTestUser(
+        id: String = "user-001",
+        isAdmin: Boolean = false,
+    ): User =
+        User(
+            id = com.calypsan.listenup.client.core.UserId(id),
+            email = "test@example.com",
+            displayName = "Test User",
+            firstName = null,
+            lastName = null,
+            isAdmin = isAdmin,
+            avatarType = "auto",
+            avatarValue = null,
+            avatarColor = "#3B82F6",
+            tagline = null,
+            createdAtMs = 1704067200000L,
+            updatedAtMs = 1704153600000L,
+        )
+
+    // ========== Threshold Constant Tests ==========
+
+    @Test
+    fun `BACKGROUND_THRESHOLD_MS is 30 minutes`() {
+        // Given/When/Then
+        val expectedMs = 30 * 60 * 1000L
+        assertEquals(expectedMs, AppStartupViewModel.BACKGROUND_THRESHOLD_MS)
+    }
+
+    // ========== Initial State Tests ==========
+
+    @Test
+    fun `initial state has isChecking true`() =
+        runTest {
+            // Given
+            val userRepository = createMockUserRepository()
+            val setupApi = createMockSetupApi()
+            everySuspend { userRepository.refreshCurrentUser() } returns null
+            everySuspend { userRepository.getCurrentUser() } returns null
+
+            // When
+            val viewModel = AppStartupViewModel(userRepository, setupApi)
+
+            // Then - initial state before coroutine completes
+            assertTrue(viewModel.state.value.isChecking)
+        }
+
+    @Test
+    fun `initial check completes and sets isChecking false for non-admin user`() =
+        runTest {
+            // Given
+            val userRepository = createMockUserRepository()
+            val setupApi = createMockSetupApi()
+            val regularUser = createTestUser(isAdmin = false)
+            everySuspend { userRepository.refreshCurrentUser() } returns regularUser
+            everySuspend { userRepository.getCurrentUser() } returns regularUser
+
+            // When
+            val viewModel = AppStartupViewModel(userRepository, setupApi)
+            advanceUntilIdle()
+
+            // Then
+            assertFalse(viewModel.state.value.isChecking)
+            assertFalse(viewModel.state.value.needsLibrarySetup)
+        }
+
+    @Test
+    fun `initial check completes and sets needsLibrarySetup true for admin when library needs setup`() =
+        runTest {
+            // Given
+            val userRepository = createMockUserRepository()
+            val setupApi = createMockSetupApi()
+            val adminUser = createTestUser(isAdmin = true)
+            everySuspend { userRepository.refreshCurrentUser() } returns adminUser
+            everySuspend { userRepository.getCurrentUser() } returns adminUser
+            everySuspend { setupApi.getLibraryStatus() } returns LibraryStatusResponse(
+                exists = false,
+                library = null,
+                needsSetup = true,
+                bookCount = 0,
+                isScanning = false,
+            )
+
+            // When
+            val viewModel = AppStartupViewModel(userRepository, setupApi)
+            advanceUntilIdle()
+
+            // Then
+            assertFalse(viewModel.state.value.isChecking)
+            assertTrue(viewModel.state.value.needsLibrarySetup)
+        }
+
+    // ========== onAppBackgrounded Tests ==========
+
+    @Test
+    fun `onAppBackgrounded records timestamp`() =
+        runTest {
+            // Given
+            val userRepository = createMockUserRepository()
+            val setupApi = createMockSetupApi()
+            everySuspend { userRepository.refreshCurrentUser() } returns null
+            everySuspend { userRepository.getCurrentUser() } returns null
+            val viewModel = AppStartupViewModel(userRepository, setupApi)
+            advanceUntilIdle()
+
+            // When
+            viewModel.onAppBackgrounded()
+
+            // Then
+            assertNotNull(viewModel.state.value.backgroundedAtMs)
+        }
+
+    // ========== onAppForegrounded Tests ==========
+
+    @Test
+    fun `onAppForegrounded does nothing when backgroundedAtMs is null`() =
+        runTest {
+            // Given
+            val userRepository = createMockUserRepository()
+            val setupApi = createMockSetupApi()
+            everySuspend { userRepository.refreshCurrentUser() } returns null
+            everySuspend { userRepository.getCurrentUser() } returns null
+            val viewModel = AppStartupViewModel(userRepository, setupApi)
+            advanceUntilIdle()
+
+            // Verify backgroundedAtMs is null before the call
+            assertNull(viewModel.state.value.backgroundedAtMs)
+            val isCheckingBefore = viewModel.state.value.isChecking
+
+            // When
+            viewModel.onAppForegrounded()
+            advanceUntilIdle()
+
+            // Then - state unchanged
+            assertEquals(isCheckingBefore, viewModel.state.value.isChecking)
+        }
+
+    @Test
+    fun `onAppForegrounded does NOT reset isChecking for short background period`() =
+        runTest {
+            // Given
+            val userRepository = createMockUserRepository()
+            val setupApi = createMockSetupApi()
+            everySuspend { userRepository.refreshCurrentUser() } returns null
+            everySuspend { userRepository.getCurrentUser() } returns null
+            val viewModel = AppStartupViewModel(userRepository, setupApi)
+            advanceUntilIdle()
+
+            // Initial check is complete, isChecking should be false
+            assertFalse(viewModel.state.value.isChecking)
+
+            // Simulate backgrounding and immediate foregrounding (short period)
+            viewModel.onAppBackgrounded()
+
+            // When - foreground immediately (elapsed time ~0ms, well under 30 min threshold)
+            viewModel.onAppForegrounded()
+            advanceUntilIdle()
+
+            // Then - isChecking should still be false (no re-check triggered)
+            assertFalse(viewModel.state.value.isChecking)
+        }
+
+    @Test
+    fun `onAppForegrounded preserves needsLibrarySetup state for short background period`() =
+        runTest {
+            // Given - admin user with library needing setup
+            val userRepository = createMockUserRepository()
+            val setupApi = createMockSetupApi()
+            val adminUser = createTestUser(isAdmin = true)
+            everySuspend { userRepository.refreshCurrentUser() } returns adminUser
+            everySuspend { userRepository.getCurrentUser() } returns adminUser
+            everySuspend { setupApi.getLibraryStatus() } returns LibraryStatusResponse(
+                exists = false,
+                library = null,
+                needsSetup = true,
+                bookCount = 0,
+                isScanning = false,
+            )
+
+            val viewModel = AppStartupViewModel(userRepository, setupApi)
+            advanceUntilIdle()
+
+            // Verify initial state
+            assertFalse(viewModel.state.value.isChecking)
+            assertTrue(viewModel.state.value.needsLibrarySetup)
+
+            // Simulate short background period
+            viewModel.onAppBackgrounded()
+
+            // When - foreground after short period
+            viewModel.onAppForegrounded()
+            advanceUntilIdle()
+
+            // Then - state preserved, no re-check
+            assertFalse(viewModel.state.value.isChecking)
+            assertTrue(viewModel.state.value.needsLibrarySetup)
+        }
+}


### PR DESCRIPTION
## What

Two UX bugs fixed:

### Bug 1 — Loading screen on every resume + always navigates to Home

**Root causes:**
1. `BACKGROUND_THRESHOLD_MS` was 5 minutes — too low. Android fires `onPause` for transient events (notification shade, screen lock) so returning quickly after a brief distraction still triggered the check.
2. When `isChecking` reset to `true`, `AuthenticatedNavigation` returned early and unmounted entirely, discarding the `backStack` held in `remember`. On remount, `backStack` always reinitialised to `Shell` (Home).

**Fix:**
- Bumped threshold to 30 minutes
- Loading indicator now overlays on top of `NavDisplay` instead of replacing it — `backStack` survives
- Added `LaunchedEffect` to handle `LibrarySetup` navigation post-check
- Unit tests added for the short-background (no-reset) case

### Bug 2 — Mini player sometimes missing until navigating to another page

**Root cause:** `NowPlayingHost` used `koinViewModel()` while `AuthenticatedNavigation` used `koinInject()`. These resolved to different ViewModel instances. Playback state flowed into one; the mini player observed the other — so `isVisible` never became `true` on the watched instance.

**Fix:**
- `NowPlayingHost` now takes `viewModel: NowPlayingViewModel` as a required parameter
- `AuthenticatedNavigation` passes its own instance, guaranteeing a single shared ViewModel

## Files changed
- `NowPlayingHost.kt` — ViewModel now a required param
- `ListenUpNavigation.kt` — back stack hoisted above loading check, overlay approach
- `AppStartupViewModel.kt` — threshold 5 min → 30 min
- `AppStartupViewModelTest.kt` — new test file