### PR TITLE
W6 Phase C — ProgressPuller delta-sync + transactional seams + drift #2/#3 closed

### DIFF
--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/PendingOperationDao.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/PendingOperationDao.kt
@@ -12,6 +12,12 @@ import kotlinx.coroutines.flow.Flow
  *
  * Manages the unified queue for all push sync operations.
  * Supports coalescing, batching, and status tracking.
+ *
+ * Status column is stored as the string name of [OperationStatus] (e.g. 'PENDING'),
+ * so all WHERE/SET clauses use string literals, not ordinals.
+ *
+ * OperationType column is stored as the string name of [OperationType] (e.g. 'USER_PREFERENCES'),
+ * so all WHERE clauses that filter by type also use string literals.
  */
 @Dao
 interface PendingOperationDao {
@@ -33,7 +39,7 @@ interface PendingOperationDao {
         SELECT * FROM pending_operations
         WHERE operationType = :type
           AND entityId = :entityId
-          AND status = ${OperationStatus.PENDING_ORDINAL}
+          AND status = 'PENDING'
         LIMIT 1
         """,
     )
@@ -49,8 +55,8 @@ interface PendingOperationDao {
     @Query(
         """
         SELECT * FROM pending_operations
-        WHERE operationType = ${OperationType.USER_PREFERENCES_ORDINAL}
-          AND status = ${OperationStatus.PENDING_ORDINAL}
+        WHERE operationType = 'USER_PREFERENCES'
+          AND status = 'PENDING'
         LIMIT 1
         """,
     )
@@ -62,7 +68,7 @@ interface PendingOperationDao {
     @Query(
         """
         SELECT * FROM pending_operations
-        WHERE status = ${OperationStatus.PENDING_ORDINAL}
+        WHERE status = 'PENDING'
         ORDER BY createdAt ASC
         LIMIT 1
         """,
@@ -77,7 +83,7 @@ interface PendingOperationDao {
         """
         SELECT * FROM pending_operations
         WHERE batchKey = :batchKey
-          AND status = ${OperationStatus.PENDING_ORDINAL}
+          AND status = 'PENDING'
         ORDER BY createdAt ASC
         LIMIT :limit
         """,
@@ -93,7 +99,7 @@ interface PendingOperationDao {
     @Query(
         """
         SELECT * FROM pending_operations
-        WHERE status = ${OperationStatus.PENDING_ORDINAL}
+        WHERE status = 'PENDING'
         ORDER BY createdAt ASC
         LIMIT :limit
         """,
@@ -106,7 +112,7 @@ interface PendingOperationDao {
     @Query(
         """
         UPDATE pending_operations
-        SET status = ${OperationStatus.IN_PROGRESS_ORDINAL}
+        SET status = 'IN_PROGRESS'
         WHERE id IN (:ids)
         """,
     )
@@ -124,7 +130,7 @@ interface PendingOperationDao {
     @Query(
         """
         UPDATE pending_operations
-        SET status = ${OperationStatus.FAILED_ORDINAL},
+        SET status = 'FAILED',
             lastError = :error,
             attemptCount = attemptCount + 1
         WHERE id = :id
@@ -141,7 +147,7 @@ interface PendingOperationDao {
     @Query(
         """
         UPDATE pending_operations
-        SET status = ${OperationStatus.PENDING_ORDINAL},
+        SET status = 'PENDING',
             attemptCount = 0,
             lastError = NULL
         WHERE id = :id
@@ -161,7 +167,7 @@ interface PendingOperationDao {
     @Query(
         """
         SELECT COUNT(*) FROM pending_operations
-        WHERE status = ${OperationStatus.PENDING_ORDINAL}
+        WHERE status = 'PENDING'
         """,
     )
     fun observePendingCount(): Flow<Int>
@@ -172,7 +178,7 @@ interface PendingOperationDao {
     @Query(
         """
         SELECT * FROM pending_operations
-        WHERE status = ${OperationStatus.FAILED_ORDINAL}
+        WHERE status = 'FAILED'
         ORDER BY updatedAt DESC
         """,
     )
@@ -184,7 +190,7 @@ interface PendingOperationDao {
     @Query(
         """
         SELECT * FROM pending_operations
-        WHERE status = ${OperationStatus.IN_PROGRESS_ORDINAL}
+        WHERE status = 'IN_PROGRESS'
         LIMIT 1
         """,
     )
@@ -210,8 +216,8 @@ interface PendingOperationDao {
     @Query(
         """
         UPDATE pending_operations
-        SET status = ${OperationStatus.PENDING_ORDINAL}
-        WHERE status = ${OperationStatus.IN_PROGRESS_ORDINAL}
+        SET status = 'PENDING'
+        WHERE status = 'IN_PROGRESS'
         """,
     )
     suspend fun resetStuckOperations()
@@ -223,8 +229,8 @@ interface PendingOperationDao {
     @Query(
         """
         SELECT entityId FROM pending_operations
-        WHERE operationType = ${OperationType.MARK_COMPLETE_ORDINAL}
-          AND status IN (${OperationStatus.PENDING_ORDINAL}, ${OperationStatus.IN_PROGRESS_ORDINAL})
+        WHERE operationType = 'MARK_COMPLETE'
+          AND status IN ('PENDING', 'IN_PROGRESS')
         """,
     )
     suspend fun getPendingMarkCompleteBookIds(): List<String>

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/PendingOperationEntity.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/PendingOperationEntity.kt
@@ -79,22 +79,6 @@ enum class OperationType {
     MARK_COMPLETE,
     ;
 
-    companion object {
-        // Ordinal constants for Room @Query annotations
-        const val BOOK_UPDATE_ORDINAL = 0
-        const val CONTRIBUTOR_UPDATE_ORDINAL = 1
-        const val SERIES_UPDATE_ORDINAL = 2
-        const val SET_BOOK_CONTRIBUTORS_ORDINAL = 3
-        const val SET_BOOK_SERIES_ORDINAL = 4
-        const val MERGE_CONTRIBUTOR_ORDINAL = 5
-        const val UNMERGE_CONTRIBUTOR_ORDINAL = 6
-        const val LISTENING_EVENT_ORDINAL = 7
-        const val PLAYBACK_POSITION_ORDINAL = 8
-        const val USER_PREFERENCES_ORDINAL = 9
-        const val PROFILE_UPDATE_ORDINAL = 10
-        const val PROFILE_AVATAR_ORDINAL = 11
-        const val MARK_COMPLETE_ORDINAL = 12
-    }
 }
 
 /**
@@ -108,13 +92,6 @@ enum class EntityType {
     SHELF,
     ;
 
-    companion object {
-        const val BOOK_ORDINAL = 0
-        const val CONTRIBUTOR_ORDINAL = 1
-        const val SERIES_ORDINAL = 2
-        const val USER_ORDINAL = 3
-        const val SHELF_ORDINAL = 4
-    }
 }
 
 /**
@@ -131,9 +108,4 @@ enum class OperationStatus {
     FAILED,
     ;
 
-    companion object {
-        const val PENDING_ORDINAL = 0
-        const val IN_PROGRESS_ORDINAL = 1
-        const val FAILED_ORDINAL = 2
-    }
 }

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/PendingOperationEntity.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/PendingOperationEntity.kt
@@ -77,8 +77,6 @@ enum class OperationType {
 
     // Mark book as complete (retry on failure)
     MARK_COMPLETE,
-    ;
-
 }
 
 /**
@@ -90,8 +88,6 @@ enum class EntityType {
     SERIES,
     USER,
     SHELF,
-    ;
-
 }
 
 /**
@@ -106,6 +102,4 @@ enum class OperationStatus {
 
     /** Failed after retries, awaiting user action */
     FAILED,
-    ;
-
 }

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ApiContracts.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/ApiContracts.kt
@@ -151,17 +151,18 @@ interface SyncApiContract {
     suspend fun getContinueListening(limit: Int = 10): AppResult<List<ContinueListeningItemResponse>>
 
     /**
-     * Get all playback progress for the current user (for sync).
+     * Get all playback progress records for the authenticated user.
      *
-     * Returns all progress records including isFinished status.
+     * Returns progress records filtered by `updated_after` if provided, otherwise all.
      * Used for bulk sync to ensure client has accurate finished state.
      *
      * Endpoint: GET /api/v1/listening/progress
      * Auth: Required
      *
-     * @return Result containing AllProgressResponse with all progress items
+     * @param updatedAfter Optional ISO-8601 timestamp; server returns only rows updated after this point (SP2).
+     * @return Result containing AllProgressResponse with filtered (or all) progress items
      */
-    suspend fun getAllProgress(): AppResult<AllProgressResponse>
+    suspend fun getAllProgress(updatedAfter: String? = null): AppResult<AllProgressResponse>
 
     /**
      * Get a single book by ID.

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/SyncApi.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/SyncApi.kt
@@ -305,11 +305,14 @@ class SyncApi(
             response.toResult().getOrThrow().items
         }
 
-    override suspend fun getAllProgress(): AppResult<AllProgressResponse> =
+    override suspend fun getAllProgress(updatedAfter: String?): AppResult<AllProgressResponse> =
         suspendRunCatching {
             val client = clientFactory.getClient()
             val response: ApiResponse<AllProgressResponse> =
-                client.get("/api/v1/listening/progress").body()
+                client
+                    .get("/api/v1/listening/progress") {
+                        updatedAfter?.let { parameter("updated_after", it) }
+                    }.body()
             response.toResult().getOrThrow()
         }
 

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/AvatarDownloadRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/AvatarDownloadRepositoryImpl.kt
@@ -1,0 +1,37 @@
+package com.calypsan.listenup.client.data.repository
+
+import com.calypsan.listenup.client.data.sync.ImageDownloaderContract
+import com.calypsan.listenup.client.domain.repository.AvatarDownloadRepository
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * [AvatarDownloadRepository] implementation backed by [ImageDownloaderContract].
+ *
+ * Mirrors [CoverDownloadRepositoryImpl]. No `touchUpdatedAt` post-fetch — avatars paint
+ * from a stable file path and do not require a Room invalidation signal for UI refresh.
+ *
+ * @property imageDownloader underlying downloader (platform-specific through Koin).
+ * @property scope the repository's structured-concurrency scope. Child jobs launched
+ *   here are bounded by the scope's lifecycle — typically the application scope.
+ */
+class AvatarDownloadRepositoryImpl(
+    private val imageDownloader: ImageDownloaderContract,
+    private val scope: CoroutineScope,
+) : AvatarDownloadRepository {
+    override fun queueAvatarDownload(userId: String) {
+        scope.launch {
+            try {
+                imageDownloader.downloadUserAvatar(userId, forceRefresh = false)
+                logger.debug { "Queued avatar download for user $userId" }
+            } catch (e: kotlin.coroutines.cancellation.CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                logger.warn(e) { "Failed to download avatar for user $userId" }
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/pull/ProgressPuller.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/pull/ProgressPuller.kt
@@ -30,20 +30,22 @@ class ProgressPuller(
     private val pendingOperationDao: PendingOperationDao,
 ) : Puller {
     /**
-     * Pull all progress from server and upsert locally.
+     * Pull progress from server and upsert locally.
      *
      * Merges server progress with local records, preserving local-only fields
      * (playbackSpeed, hasCustomSpeed) while syncing server fields (position,
      * isFinished, lastPlayedAt).
      *
-     * @param updatedAfter Ignored - always fetches all progress
-     * @param onProgress Callback for progress updates
+     * @param updatedAfter ISO-8601 timestamp; when non-null, only rows updated server-side
+     *                     after this point are returned (SP2 delta sync). When null, all
+     *                     progress is fetched (used for full sync and `refreshListeningHistory`).
+     * @param onProgress Callback for progress updates.
      */
     override suspend fun pull(
         updatedAfter: String?,
         onProgress: (SyncStatus) -> Unit,
     ) {
-        logger.debug { "Starting progress sync..." }
+        logger.debug { "Starting progress sync (updatedAfter=$updatedAfter)..." }
 
         onProgress(
             SyncStatus.Progress(
@@ -55,7 +57,7 @@ class ProgressPuller(
         )
 
         try {
-            when (val result = syncApi.getAllProgress()) {
+            when (val result = syncApi.getAllProgress(updatedAfter)) {
                 is Success -> {
                     val items = result.data.items
                     logger.info { "Fetched ${items.size} progress records from server" }

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/pull/ProgressPuller.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/pull/ProgressPuller.kt
@@ -4,6 +4,7 @@ import com.calypsan.listenup.client.core.BookId
 import com.calypsan.listenup.client.data.local.db.PendingOperationDao
 import com.calypsan.listenup.client.data.local.db.PlaybackPositionDao
 import com.calypsan.listenup.client.data.local.db.PlaybackPositionEntity
+import com.calypsan.listenup.client.data.local.db.TransactionRunner
 import com.calypsan.listenup.client.data.remote.SyncApiContract
 import com.calypsan.listenup.client.data.sync.model.SyncPhase
 import com.calypsan.listenup.client.data.sync.model.SyncStatus
@@ -28,6 +29,7 @@ class ProgressPuller(
     private val syncApi: SyncApiContract,
     private val playbackPositionDao: PlaybackPositionDao,
     private val pendingOperationDao: PendingOperationDao,
+    private val transactionRunner: TransactionRunner,
 ) : Puller {
     /**
      * Pull progress from server and upsert locally.
@@ -109,56 +111,33 @@ class ProgressPuller(
     }
 
     /**
-     * Apply pending MARK_COMPLETE guards, persist entities, and verify isFinished state.
+     * Apply pending MARK_COMPLETE guards and persist entities in one transaction.
      *
-     * Ensures books with pending local MARK_COMPLETE operations retain isFinished=true
-     * even if the server hasn't processed the operation yet.
+     * Reads pending MARK_COMPLETE ids and writes the guarded entity rows inside a single
+     * write transaction so a concurrent MARK_COMPLETE queue cannot commit between the
+     * read and the write — closing the single-pull window where a server "not finished"
+     * reply could overwrite the user's mark-complete intent.
      */
     private suspend fun guardAndSaveEntities(entities: List<PlaybackPositionEntity>) {
-        val finishedEntities = entities.filter { it.isFinished }
-        logger.debug {
-            "Entities with isFinished=true BEFORE saveAll: ${finishedEntities.size}"
-        }
-        if (finishedEntities.isNotEmpty()) {
-            val sample = finishedEntities.take(3)
-            logger.debug {
-                "Sample finished entities: ${sample.map {
-                    "${it.bookId.value}: isFinished=${it.isFinished}"
-                }}"
-            }
-        }
-
-        // Guard: don't overwrite isFinished for books with pending MARK_COMPLETE
-        val pendingCompleteBookIds =
-            pendingOperationDao.getPendingMarkCompleteBookIds().toSet()
-        val guardedEntities =
-            if (pendingCompleteBookIds.isEmpty()) {
-                entities
-            } else {
-                entities.map { entity ->
-                    if (entity.bookId.value in pendingCompleteBookIds && !entity.isFinished) {
-                        logger.info {
-                            "Preserving isFinished=true for ${entity.bookId.value} (pending MARK_COMPLETE)"
+        transactionRunner.atomically {
+            val pendingCompleteBookIds =
+                pendingOperationDao.getPendingMarkCompleteBookIds().toSet()
+            val guardedEntities =
+                if (pendingCompleteBookIds.isEmpty()) {
+                    entities
+                } else {
+                    entities.map { entity ->
+                        if (entity.bookId.value in pendingCompleteBookIds && !entity.isFinished) {
+                            logger.info {
+                                "Preserving isFinished=true for ${entity.bookId.value} (pending MARK_COMPLETE)"
+                            }
+                            entity.copy(isFinished = true)
+                        } else {
+                            entity
                         }
-                        entity.copy(isFinished = true)
-                    } else {
-                        entity
                     }
                 }
-            }
-
-        playbackPositionDao.saveAll(guardedEntities)
-
-        // Debug: Verify what's in DB after save
-        val dbCheck = playbackPositionDao.getByBookIds(entities.map { it.bookId })
-        val dbFinishedCount = dbCheck.count { it.isFinished }
-        logger.debug {
-            "DB check AFTER saveAll: ${dbCheck.size} positions, $dbFinishedCount finished"
-        }
-        if (dbFinishedCount == 0 && finishedEntities.isNotEmpty()) {
-            logger.warn {
-                "BUG: isFinished not persisting! ${finishedEntities.size} entities had isFinished=true but DB shows 0"
-            }
+            playbackPositionDao.saveAll(guardedEntities)
         }
     }
 }

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/push/PendingOperationRepository.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/push/PendingOperationRepository.kt
@@ -138,50 +138,50 @@ class PendingOperationRepository(
     ) {
         val now = currentEpochMilliseconds()
 
-        // Check for existing operation to coalesce with
-        val existing = findExistingForCoalesce(type, entityId)
+        transactionRunner.atomically {
+            val existing = findExistingForCoalesce(type, entityId)
 
-        // Try to coalesce if there's an existing operation
-        val merged =
-            existing?.let {
-                val existingPayload = handler.parsePayload(it.payload)
-                handler.tryCoalesce(it, existingPayload, payload)
+            val merged =
+                existing?.let {
+                    val existingPayload = handler.parsePayload(it.payload)
+                    handler.tryCoalesce(it, existingPayload, payload)
+                }
+
+            if (existing != null && merged != null) {
+                val updated =
+                    existing.copy(
+                        payload = handler.serializePayload(merged),
+                        updatedAt = now,
+                        attemptCount = 0,
+                        status = OperationStatus.PENDING,
+                        lastError = null,
+                    )
+                dao.update(updated)
+                logger.debug { "Coalesced operation: ${type.name} for entity $entityId" }
+            } else {
+                val batchKey = handler.batchKey(payload)
+                val operation =
+                    PendingOperationEntity(
+                        id = NanoId.generate("op"),
+                        operationType = type,
+                        entityType = entityType,
+                        entityId = entityId,
+                        payload = handler.serializePayload(payload),
+                        batchKey = batchKey,
+                        status = OperationStatus.PENDING,
+                        createdAt = now,
+                        updatedAt = now,
+                        attemptCount = 0,
+                        lastError = null,
+                    )
+                dao.insert(operation)
+                logger.debug { "Queued operation: ${type.name} for entity $entityId (batch=$batchKey)" }
             }
-
-        if (existing != null && merged != null) {
-            // Coalesce succeeded - update existing operation with merged payload
-            val updated =
-                existing.copy(
-                    payload = handler.serializePayload(merged),
-                    updatedAt = now,
-                    attemptCount = 0,
-                    status = OperationStatus.PENDING,
-                    lastError = null,
-                )
-            dao.update(updated)
-            logger.debug { "Coalesced operation: ${type.name} for entity $entityId" }
-        } else {
-            // No existing operation or coalesce not possible - insert new
-            val batchKey = handler.batchKey(payload)
-            val operation =
-                PendingOperationEntity(
-                    id = NanoId.generate("op"),
-                    operationType = type,
-                    entityType = entityType,
-                    entityId = entityId,
-                    payload = handler.serializePayload(payload),
-                    batchKey = batchKey,
-                    status = OperationStatus.PENDING,
-                    createdAt = now,
-                    updatedAt = now,
-                    attemptCount = 0,
-                    lastError = null,
-                )
-            dao.insert(operation)
-            logger.debug { "Queued operation: ${type.name} for entity $entityId (batch=$batchKey)" }
         }
 
-        // Notify orchestrator that a new operation was queued (triggers flush if online)
+        // Notify orchestrator that a new operation was queued (triggers flush if online).
+        // OUTSIDE the transaction per DatabaseTransactions.kt guidance — flow emission is
+        // not a DB write and should not hold the single writer connection.
         _newOperationQueued.tryEmit(Unit)
     }
 

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/sse/SSEEventProcessor.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/sse/SSEEventProcessor.kt
@@ -31,16 +31,15 @@ import com.calypsan.listenup.client.data.sync.SSEEvent
 import com.calypsan.listenup.client.data.sync.SessionDaos
 import com.calypsan.listenup.client.data.sync.UserDaos
 import com.calypsan.listenup.client.data.sync.pull.BookRelationshipDaos
+import com.calypsan.listenup.client.domain.repository.AvatarDownloadRepository
 import com.calypsan.listenup.client.domain.repository.CoverDownloadRepository
 import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.launch
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 
@@ -81,7 +80,7 @@ class SSEEventProcessor(
     sseExternalServices: SSEExternalServices,
     private val activityDao: ActivityDao,
     private val coverDownloadRepository: CoverDownloadRepository,
-    private val scope: CoroutineScope,
+    private val avatarDownloadRepository: AvatarDownloadRepository,
 ) {
     private val bookContributorDao = bookRelationshipDaos.bookContributorDao
     private val bookSeriesDao = bookRelationshipDaos.bookSeriesDao
@@ -1009,21 +1008,11 @@ class SSEEventProcessor(
         val payload = event.data
         logger.debug { "SSE: Session started - ${payload.sessionId} for user ${payload.userId}" }
 
-        // Download user's avatar if they have an image avatar and it's not cached locally
-        // Do this BEFORE storing the session so the avatar file exists when UI renders
+        // Queue avatar download via the repository (owns its own scope — no fire-and-forget
+        // launch inside a suspend handler). The repo internally skips if the file is cached.
         val userProfile = userProfileDao.getById(payload.userId)
         if (userProfile != null && userProfile.avatarType == "image") {
-            scope.launch {
-                try {
-                    // downloadUserAvatar checks if file exists locally and skips if so
-                    imageDownloader.downloadUserAvatar(payload.userId, forceRefresh = false)
-                    logger.debug { "SSE: Ensured avatar exists for user ${payload.userId}" }
-                } catch (e: kotlin.coroutines.cancellation.CancellationException) {
-                    throw e
-                } catch (e: Exception) {
-                    logger.warn(e) { "SSE: Failed to download avatar for user ${payload.userId}" }
-                }
-            }
+            avatarDownloadRepository.queueAvatarDownload(payload.userId)
         }
 
         val startedAtMs = parseTimestamp(payload.startedAt).epochMillis

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/sse/SSEEventProcessor.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/sse/SSEEventProcessor.kt
@@ -56,6 +56,24 @@ private fun parseTimestamp(isoString: String): Timestamp =
     }
 
 /**
+ * Parse an ISO-8601 timestamp from the wire, returning null on any parse failure.
+ *
+ * Used for fields where a silent fallback to "now" is a lie of omission — e.g.,
+ * `progress_updated.last_played_at`. Callers log and skip the affected row when
+ * this returns null; next full sync reconciles.
+ *
+ * Contrast with [parseTimestamp], which falls back to `Timestamp.now()` for fields
+ * where the fallback is semantically acceptable (e.g., session `startedAt` defaults
+ * to "now" if malformed).
+ */
+private fun parseLastPlayedOrNull(isoString: String): Timestamp? =
+    try {
+        Timestamp.fromEpochMillis(Instant.parse(isoString).toEpochMilliseconds())
+    } catch (_: Exception) {
+        null
+    }
+
+/**
  * Processes real-time Server-Sent Events and applies changes to local database.
  *
  * Handles:
@@ -826,7 +844,15 @@ class SSEEventProcessor(
             return
         }
 
-        val lastPlayedAtMs = parseTimestamp(payload.lastPlayedAt).epochMillis
+        val lastPlayedAt =
+            parseLastPlayedOrNull(payload.lastPlayedAt) ?: run {
+                logger.warn {
+                    "SSE: malformed last_played_at '${payload.lastPlayedAt}' for book ${payload.bookId} — " +
+                        "skipping row; next sync will reconcile"
+                }
+                return
+            }
+        val lastPlayedAtMs = lastPlayedAt.epochMillis
         val finishedAtMs = payload.finishedAt?.let { parseTimestamp(it).epochMillis }
         val startedAtMs = payload.startedAt?.let { parseTimestamp(it).epochMillis }
 

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/di/Koin.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/di/Koin.kt
@@ -1098,6 +1098,7 @@ val syncModule =
                 syncApi = get<SyncApiContract>(),
                 playbackPositionDao = get(),
                 pendingOperationDao = get(),
+                transactionRunner = get(),
             )
         }
 

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/di/Koin.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/di/Koin.kt
@@ -58,6 +58,7 @@ import com.calypsan.listenup.client.data.repository.AuthRepositoryImpl
 import com.calypsan.listenup.client.data.repository.BookEditRepositoryImpl
 import com.calypsan.listenup.client.data.repository.BookRepositoryImpl
 import com.calypsan.listenup.client.data.repository.CollectionRepositoryImpl
+import com.calypsan.listenup.client.data.repository.AvatarDownloadRepositoryImpl
 import com.calypsan.listenup.client.data.repository.CoverDownloadRepositoryImpl
 import com.calypsan.listenup.client.data.repository.DeepLinkManager
 import com.calypsan.listenup.client.data.repository.ShortcutActionManager
@@ -144,6 +145,7 @@ import com.calypsan.listenup.client.domain.repository.AuthSession
 import com.calypsan.listenup.client.domain.repository.BookRepository
 import com.calypsan.listenup.client.domain.repository.CollectionRepository
 import com.calypsan.listenup.client.domain.repository.ContributorEditRepository
+import com.calypsan.listenup.client.domain.repository.AvatarDownloadRepository
 import com.calypsan.listenup.client.domain.repository.CoverDownloadRepository
 import com.calypsan.listenup.client.domain.repository.GenreRepository
 import com.calypsan.listenup.client.domain.repository.HomeRepository
@@ -903,6 +905,19 @@ val syncModule =
             )
         }
 
+        // AvatarDownloadRepository - owns scope for fire-and-forget avatar downloads (mirrors CoverDownloadRepository)
+        single<AvatarDownloadRepository> {
+            AvatarDownloadRepositoryImpl(
+                imageDownloader = get(),
+                scope =
+                    get(
+                        qualifier =
+                            org.koin.core.qualifier
+                                .named("appScope"),
+                    ),
+            )
+        }
+
         // SSEEventProcessor - processes real-time SSE events
         single {
             SSEEventProcessor(
@@ -939,12 +954,7 @@ val syncModule =
                     ),
                 activityDao = get(),
                 coverDownloadRepository = get(),
-                scope =
-                    get(
-                        qualifier =
-                            org.koin.core.qualifier
-                                .named("appScope"),
-                    ),
+                avatarDownloadRepository = get(),
             )
         }
 

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/AvatarDownloadRepository.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/AvatarDownloadRepository.kt
@@ -1,0 +1,24 @@
+package com.calypsan.listenup.client.domain.repository
+
+/**
+ * Repository for downloading user avatar images from the server and persisting them locally.
+ *
+ * Owns its own [kotlinx.coroutines.CoroutineScope] so callers can invoke [queueAvatarDownload]
+ * from suspend contexts without launching unstructured child coroutines on the caller's scope
+ * — the repository is the single structured-concurrency boundary for this work.
+ *
+ * Mirrors [CoverDownloadRepository] for avatars. No `touchUpdatedAt` analogue — avatars paint
+ * from a stable file path; no Room-invalidation signal is needed.
+ */
+interface AvatarDownloadRepository {
+    /**
+     * Request that the avatar for [userId] be downloaded.
+     *
+     * Returns immediately; the download happens on the repository's internal scope.
+     * If the avatar is already present locally, no work is done. On failure, the error
+     * is logged and dropped — the next SSE session-started event or manual refresh will retry.
+     *
+     * @param userId the user whose avatar should be fetched.
+     */
+    fun queueAvatarDownload(userId: String)
+}

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/pull/ProgressPullerDeltaSyncTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/pull/ProgressPullerDeltaSyncTest.kt
@@ -3,6 +3,7 @@ package com.calypsan.listenup.client.data.sync.pull
 import com.calypsan.listenup.client.core.Success
 import com.calypsan.listenup.client.data.local.db.PendingOperationDao
 import com.calypsan.listenup.client.data.local.db.PlaybackPositionDao
+import com.calypsan.listenup.client.data.local.db.TransactionRunner
 import com.calypsan.listenup.client.data.remote.SyncApiContract
 import com.calypsan.listenup.client.data.remote.model.AllProgressResponse
 import dev.mokkery.answering.calls
@@ -16,11 +17,23 @@ import kotlin.test.assertEquals
 
 /**
  * Proves `ProgressPuller.pull` forwards `updatedAfter` to the SyncApi, enabling
- * SP2-backed delta sync. Prior to this commit, `updatedAfter` was documented as
+ * SP2-backed delta sync. Prior to Commit 1, `updatedAfter` was documented as
  * "ignored" and the API call was parameterless — every sync re-downloaded the full
  * progress table.
+ *
+ * Test TransactionRunner is a straight pass-through that invokes the block directly —
+ * the atomicity invariant of Commit 2 is covered by the separate ProgressPullerAtomicityTest
+ * (jvmTest) using a real in-memory DB + RoomTransactionRunner.
  */
 class ProgressPullerDeltaSyncTest {
+    private fun passthroughTxRunner() = mock<TransactionRunner> {
+        everySuspend { atomically(any<suspend () -> Any>()) } calls { args ->
+            @Suppress("UNCHECKED_CAST")
+            val block = args.arg(0) as suspend () -> Any
+            block()
+        }
+    }
+
     @Test
     fun `pull with updatedAfter forwards it to getAllProgress`() =
         runTest {
@@ -39,7 +52,12 @@ class ProgressPullerDeltaSyncTest {
                 everySuspend { getPendingMarkCompleteBookIds() } returns emptyList()
             }
 
-            val puller = ProgressPuller(syncApi, playbackPositionDao, pendingOperationDao)
+            val puller = ProgressPuller(
+                syncApi,
+                playbackPositionDao,
+                pendingOperationDao,
+                passthroughTxRunner(),
+            )
 
             puller.pull(updatedAfter = "2026-04-19T10:00:00Z") {}
 
@@ -64,7 +82,12 @@ class ProgressPullerDeltaSyncTest {
                 everySuspend { getPendingMarkCompleteBookIds() } returns emptyList()
             }
 
-            val puller = ProgressPuller(syncApi, playbackPositionDao, pendingOperationDao)
+            val puller = ProgressPuller(
+                syncApi,
+                playbackPositionDao,
+                pendingOperationDao,
+                passthroughTxRunner(),
+            )
 
             puller.pull(updatedAfter = null) {}
 

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/pull/ProgressPullerDeltaSyncTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/pull/ProgressPullerDeltaSyncTest.kt
@@ -1,0 +1,73 @@
+package com.calypsan.listenup.client.data.sync.pull
+
+import com.calypsan.listenup.client.core.Success
+import com.calypsan.listenup.client.data.local.db.PendingOperationDao
+import com.calypsan.listenup.client.data.local.db.PlaybackPositionDao
+import com.calypsan.listenup.client.data.remote.SyncApiContract
+import com.calypsan.listenup.client.data.remote.model.AllProgressResponse
+import dev.mokkery.answering.calls
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Proves `ProgressPuller.pull` forwards `updatedAfter` to the SyncApi, enabling
+ * SP2-backed delta sync. Prior to this commit, `updatedAfter` was documented as
+ * "ignored" and the API call was parameterless — every sync re-downloaded the full
+ * progress table.
+ */
+class ProgressPullerDeltaSyncTest {
+    @Test
+    fun `pull with updatedAfter forwards it to getAllProgress`() =
+        runTest {
+            val capturedUpdatedAfter = mutableListOf<String?>()
+            val syncApi = mock<SyncApiContract> {
+                everySuspend { getAllProgress(any()) } calls { args ->
+                    capturedUpdatedAfter.add(args.arg(0) as String?)
+                    Success(AllProgressResponse(items = emptyList()))
+                }
+            }
+            val playbackPositionDao = mock<PlaybackPositionDao> {
+                everySuspend { getByBookIds(any()) } returns emptyList()
+                everySuspend { saveAll(any()) } returns Unit
+            }
+            val pendingOperationDao = mock<PendingOperationDao> {
+                everySuspend { getPendingMarkCompleteBookIds() } returns emptyList()
+            }
+
+            val puller = ProgressPuller(syncApi, playbackPositionDao, pendingOperationDao)
+
+            puller.pull(updatedAfter = "2026-04-19T10:00:00Z") {}
+
+            assertEquals(listOf<String?>("2026-04-19T10:00:00Z"), capturedUpdatedAfter)
+        }
+
+    @Test
+    fun `pull with null updatedAfter forwards null to getAllProgress`() =
+        runTest {
+            val capturedUpdatedAfter = mutableListOf<String?>()
+            val syncApi = mock<SyncApiContract> {
+                everySuspend { getAllProgress(any()) } calls { args ->
+                    capturedUpdatedAfter.add(args.arg(0) as String?)
+                    Success(AllProgressResponse(items = emptyList()))
+                }
+            }
+            val playbackPositionDao = mock<PlaybackPositionDao> {
+                everySuspend { getByBookIds(any()) } returns emptyList()
+                everySuspend { saveAll(any()) } returns Unit
+            }
+            val pendingOperationDao = mock<PendingOperationDao> {
+                everySuspend { getPendingMarkCompleteBookIds() } returns emptyList()
+            }
+
+            val puller = ProgressPuller(syncApi, playbackPositionDao, pendingOperationDao)
+
+            puller.pull(updatedAfter = null) {}
+
+            assertEquals(listOf<String?>(null), capturedUpdatedAfter)
+        }
+}

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/pull/ProgressPullerDeltaSyncTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/pull/ProgressPullerDeltaSyncTest.kt
@@ -26,38 +26,43 @@ import kotlin.test.assertEquals
  * (jvmTest) using a real in-memory DB + RoomTransactionRunner.
  */
 class ProgressPullerDeltaSyncTest {
-    private fun passthroughTxRunner() = mock<TransactionRunner> {
-        everySuspend { atomically(any<suspend () -> Any>()) } calls { args ->
-            @Suppress("UNCHECKED_CAST")
-            val block = args.arg(0) as suspend () -> Any
-            block()
+    private fun passthroughTxRunner() =
+        mock<TransactionRunner> {
+            everySuspend { atomically(any<suspend () -> Any>()) } calls { args ->
+                @Suppress("UNCHECKED_CAST")
+                val block = args.arg(0) as suspend () -> Any
+                block()
+            }
         }
-    }
 
     @Test
     fun `pull with updatedAfter forwards it to getAllProgress`() =
         runTest {
             val capturedUpdatedAfter = mutableListOf<String?>()
-            val syncApi = mock<SyncApiContract> {
-                everySuspend { getAllProgress(any()) } calls { args ->
-                    capturedUpdatedAfter.add(args.arg(0) as String?)
-                    Success(AllProgressResponse(items = emptyList()))
+            val syncApi =
+                mock<SyncApiContract> {
+                    everySuspend { getAllProgress(any()) } calls { args ->
+                        capturedUpdatedAfter.add(args.arg(0) as String?)
+                        Success(AllProgressResponse(items = emptyList()))
+                    }
                 }
-            }
-            val playbackPositionDao = mock<PlaybackPositionDao> {
-                everySuspend { getByBookIds(any()) } returns emptyList()
-                everySuspend { saveAll(any()) } returns Unit
-            }
-            val pendingOperationDao = mock<PendingOperationDao> {
-                everySuspend { getPendingMarkCompleteBookIds() } returns emptyList()
-            }
+            val playbackPositionDao =
+                mock<PlaybackPositionDao> {
+                    everySuspend { getByBookIds(any()) } returns emptyList()
+                    everySuspend { saveAll(any()) } returns Unit
+                }
+            val pendingOperationDao =
+                mock<PendingOperationDao> {
+                    everySuspend { getPendingMarkCompleteBookIds() } returns emptyList()
+                }
 
-            val puller = ProgressPuller(
-                syncApi,
-                playbackPositionDao,
-                pendingOperationDao,
-                passthroughTxRunner(),
-            )
+            val puller =
+                ProgressPuller(
+                    syncApi,
+                    playbackPositionDao,
+                    pendingOperationDao,
+                    passthroughTxRunner(),
+                )
 
             puller.pull(updatedAfter = "2026-04-19T10:00:00Z") {}
 
@@ -68,26 +73,30 @@ class ProgressPullerDeltaSyncTest {
     fun `pull with null updatedAfter forwards null to getAllProgress`() =
         runTest {
             val capturedUpdatedAfter = mutableListOf<String?>()
-            val syncApi = mock<SyncApiContract> {
-                everySuspend { getAllProgress(any()) } calls { args ->
-                    capturedUpdatedAfter.add(args.arg(0) as String?)
-                    Success(AllProgressResponse(items = emptyList()))
+            val syncApi =
+                mock<SyncApiContract> {
+                    everySuspend { getAllProgress(any()) } calls { args ->
+                        capturedUpdatedAfter.add(args.arg(0) as String?)
+                        Success(AllProgressResponse(items = emptyList()))
+                    }
                 }
-            }
-            val playbackPositionDao = mock<PlaybackPositionDao> {
-                everySuspend { getByBookIds(any()) } returns emptyList()
-                everySuspend { saveAll(any()) } returns Unit
-            }
-            val pendingOperationDao = mock<PendingOperationDao> {
-                everySuspend { getPendingMarkCompleteBookIds() } returns emptyList()
-            }
+            val playbackPositionDao =
+                mock<PlaybackPositionDao> {
+                    everySuspend { getByBookIds(any()) } returns emptyList()
+                    everySuspend { saveAll(any()) } returns Unit
+                }
+            val pendingOperationDao =
+                mock<PendingOperationDao> {
+                    everySuspend { getPendingMarkCompleteBookIds() } returns emptyList()
+                }
 
-            val puller = ProgressPuller(
-                syncApi,
-                playbackPositionDao,
-                pendingOperationDao,
-                passthroughTxRunner(),
-            )
+            val puller =
+                ProgressPuller(
+                    syncApi,
+                    playbackPositionDao,
+                    pendingOperationDao,
+                    passthroughTxRunner(),
+                )
 
             puller.pull(updatedAfter = null) {}
 

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/sse/SSEEventProcessorTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/sse/SSEEventProcessorTest.kt
@@ -42,6 +42,7 @@ import com.calypsan.listenup.client.data.sync.ImageDownloaderContract
 import com.calypsan.listenup.client.data.sync.SessionDaos
 import com.calypsan.listenup.client.data.sync.UserDaos
 import com.calypsan.listenup.client.data.sync.pull.BookRelationshipDaos
+import com.calypsan.listenup.client.domain.repository.AvatarDownloadRepository
 import com.calypsan.listenup.client.domain.repository.SessionRepository
 import com.calypsan.listenup.client.data.sync.BookPayload
 import com.calypsan.listenup.client.data.sync.BookDeletedPayload
@@ -49,6 +50,7 @@ import com.calypsan.listenup.client.data.sync.SSEChannelMessage
 import com.calypsan.listenup.client.data.sync.SSEEvent
 import com.calypsan.listenup.client.data.sync.ScanCompletedPayload
 import com.calypsan.listenup.client.data.sync.ScanStartedPayload
+import com.calypsan.listenup.client.data.sync.SessionStartedPayload
 import com.calypsan.listenup.client.download.DownloadResult
 import com.calypsan.listenup.client.download.DownloadService
 import dev.mokkery.answering.returns
@@ -58,6 +60,7 @@ import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.matcher.matches
 import dev.mokkery.mock
+import dev.mokkery.verify
 import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -157,6 +160,7 @@ class SSEEventProcessorTest {
         val imageDownloader: ImageDownloaderContract = mock()
         val playbackStateProvider: PlaybackStateProvider = mock()
         val downloadService: DownloadService = mock()
+        val avatarDownloadRepository: AvatarDownloadRepository = mock()
 
         // StateFlow for current book ID
         private val currentBookIdFlow = MutableStateFlow<BookId?>(null)
@@ -202,6 +206,9 @@ class SSEEventProcessorTest {
             everySuspend { imageDownloader.downloadUserAvatar(any(), any()) } returns Success(false)
             everySuspend { imageDownloader.deleteUserAvatar(any()) } returns Success(Unit)
 
+            // AvatarDownloadRepository stubs
+            every { avatarDownloadRepository.queueAvatarDownload(any()) } returns Unit
+
             // PlaybackStateProvider stubs
             every { playbackStateProvider.currentBookId } returns currentBookIdFlow
             every { playbackStateProvider.clearPlayback() } returns Unit
@@ -221,7 +228,7 @@ class SSEEventProcessorTest {
             currentBookIdFlow.value = bookId
         }
 
-        fun build(): SSEEventProcessor =
+        fun build(avatarRepo: AvatarDownloadRepository = avatarDownloadRepository): SSEEventProcessor =
             SSEEventProcessor(
                 transactionRunner = transactionRunner,
                 bookDao = bookDao,
@@ -261,7 +268,7 @@ class SSEEventProcessorTest {
                         bookDao = bookDao,
                         scope = scope,
                     ),
-                scope = scope,
+                avatarDownloadRepository = avatarRepo,
             )
     }
 
@@ -860,6 +867,44 @@ class SSEEventProcessorTest {
             // SSEEventProcessor itself must NOT write to DAOs for this message.
             verifySuspend(VerifyMode.not) { fixture.bookDao.upsert(any<BookEntity>()) }
             verifySuspend(VerifyMode.not) { fixture.bookDao.deleteById(any()) }
+        }
+
+    // ========== SessionStarted Avatar Download Tests ==========
+
+    @Test
+    fun `handleSessionStarted delegates avatar download to AvatarDownloadRepository`() =
+        runTest {
+            val testUserId = "user-avatar-test"
+            val fixture = TestFixture(this)
+
+            // Stub userProfileDao to return a profile with avatarType = "image" for this user
+            everySuspend { fixture.userProfileDao.getById(testUserId) } returns
+                UserProfileEntity(
+                    id = testUserId,
+                    displayName = "Avatar User",
+                    avatarType = "image",
+                    avatarValue = "/avatars/user-avatar-test.jpg",
+                    avatarColor = "#6B7280",
+                    updatedAt = 1_700_000_000_000L,
+                )
+
+            val processor = fixture.build()
+
+            val event =
+                SSEEvent.SessionStarted(
+                    timestamp = "2026-04-19T10:00:00Z",
+                    data =
+                        SessionStartedPayload(
+                            sessionId = "session-avatar-test",
+                            userId = testUserId,
+                            bookId = "book-1",
+                            startedAt = "2026-04-19T10:00:00Z",
+                        ),
+                )
+            processor.process(SSEChannelMessage.Wire(event))
+            advanceUntilIdle()
+
+            verify { fixture.avatarDownloadRepository.queueAvatarDownload(testUserId) }
         }
 
     companion object {

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/pull/ProgressPullerAtomicityTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/pull/ProgressPullerAtomicityTest.kt
@@ -48,36 +48,42 @@ class ProgressPullerAtomicityTest {
     @Test
     fun `no rows persist when saveAll throws inside transaction`() =
         runTest {
-            val syncApi = mock<SyncApiContract> {
-                everySuspend { getAllProgress(any()) } returns Success(
-                    AllProgressResponse(
-                        items = listOf(
-                            ProgressSyncItem(
-                                bookId = "book-rollback",
-                                currentPositionMs = 1000L,
-                                isFinished = false,
-                                lastPlayedAt = "2026-04-19T10:00:00Z",
-                                updatedAt = "2026-04-19T10:00:00Z",
+            val syncApi =
+                mock<SyncApiContract> {
+                    everySuspend { getAllProgress(any()) } returns
+                        Success(
+                            AllProgressResponse(
+                                items =
+                                    listOf(
+                                        ProgressSyncItem(
+                                            bookId = "book-rollback",
+                                            currentPositionMs = 1000L,
+                                            isFinished = false,
+                                            lastPlayedAt = "2026-04-19T10:00:00Z",
+                                            updatedAt = "2026-04-19T10:00:00Z",
+                                        ),
+                                    ),
                             ),
-                        ),
-                    ),
-                )
-            }
-            val failingPlaybackPositionDao = mock<PlaybackPositionDao> {
-                everySuspend { getByBookIds(any()) } returns emptyList()
-                everySuspend { saveAll(any()) } throws RuntimeException("simulated save failure")
-            }
-            val pendingOperationDao = mock<PendingOperationDao> {
-                everySuspend { getPendingMarkCompleteBookIds() } returns emptyList()
-            }
+                        )
+                }
+            val failingPlaybackPositionDao =
+                mock<PlaybackPositionDao> {
+                    everySuspend { getByBookIds(any()) } returns emptyList()
+                    everySuspend { saveAll(any()) } throws RuntimeException("simulated save failure")
+                }
+            val pendingOperationDao =
+                mock<PendingOperationDao> {
+                    everySuspend { getPendingMarkCompleteBookIds() } returns emptyList()
+                }
             val realTransactionRunner = RoomTransactionRunner(db)
 
-            val puller = ProgressPuller(
-                syncApi,
-                failingPlaybackPositionDao,
-                pendingOperationDao,
-                realTransactionRunner,
-            )
+            val puller =
+                ProgressPuller(
+                    syncApi,
+                    failingPlaybackPositionDao,
+                    pendingOperationDao,
+                    realTransactionRunner,
+                )
 
             // ProgressPuller.pull catches Exception at the outer envelope and logs —
             // it does NOT propagate. So we assert the DB state directly.

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/pull/ProgressPullerAtomicityTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/pull/ProgressPullerAtomicityTest.kt
@@ -1,0 +1,80 @@
+package com.calypsan.listenup.client.data.sync.pull
+
+import com.calypsan.listenup.client.core.Success
+import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
+import com.calypsan.listenup.client.data.local.db.PendingOperationDao
+import com.calypsan.listenup.client.data.local.db.PlaybackPositionDao
+import com.calypsan.listenup.client.data.local.db.RoomTransactionRunner
+import com.calypsan.listenup.client.data.remote.SyncApiContract
+import com.calypsan.listenup.client.data.remote.model.AllProgressResponse
+import com.calypsan.listenup.client.data.remote.model.ProgressSyncItem
+import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
+import dev.mokkery.answering.returns
+import dev.mokkery.answering.throws
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import kotlinx.coroutines.test.runTest
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Proves `ProgressPuller.guardAndSaveEntities` is atomic — when `saveAll` throws
+ * mid-transaction, no rows persist. Mirrors `BookPullerAtomicityTest` precedent (W4.2).
+ *
+ * Uses a real in-memory [ListenUpDatabase] so transaction semantics are exercised
+ * end-to-end; a fake TransactionRunner cannot prove rollback. The `PlaybackPositionDao`
+ * is mocked to throw, forcing the failure after the pending-ids read.
+ */
+class ProgressPullerAtomicityTest {
+    private val db: ListenUpDatabase = createInMemoryTestDatabase()
+
+    @AfterTest
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun `rollback when saveAll throws mid-transaction`() =
+        runTest {
+            val syncApi = mock<SyncApiContract> {
+                everySuspend { getAllProgress(any()) } returns Success(
+                    AllProgressResponse(
+                        items = listOf(
+                            ProgressSyncItem(
+                                bookId = "book-rollback",
+                                currentPositionMs = 1000L,
+                                isFinished = false,
+                                lastPlayedAt = "2026-04-19T10:00:00Z",
+                                updatedAt = "2026-04-19T10:00:00Z",
+                            ),
+                        ),
+                    ),
+                )
+            }
+            val failingPlaybackPositionDao = mock<PlaybackPositionDao> {
+                everySuspend { getByBookIds(any()) } returns emptyList()
+                everySuspend { saveAll(any()) } throws RuntimeException("simulated save failure")
+            }
+            val pendingOperationDao = mock<PendingOperationDao> {
+                everySuspend { getPendingMarkCompleteBookIds() } returns emptyList()
+            }
+            val realTransactionRunner = RoomTransactionRunner(db)
+
+            val puller = ProgressPuller(
+                syncApi,
+                failingPlaybackPositionDao,
+                pendingOperationDao,
+                realTransactionRunner,
+            )
+
+            // ProgressPuller.pull catches Exception at the outer envelope and logs —
+            // it does NOT propagate. So we assert the DB state directly: zero rows
+            // in playback_positions after pull returns.
+            puller.pull(updatedAfter = null) {}
+
+            val persisted = db.playbackPositionDao().getByBookIds(emptyList())
+            assertEquals(0, persisted.size, "no rows should have persisted after rollback")
+        }
+}

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/pull/ProgressPullerAtomicityTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/pull/ProgressPullerAtomicityTest.kt
@@ -1,5 +1,6 @@
 package com.calypsan.listenup.client.data.sync.pull
 
+import com.calypsan.listenup.client.core.BookId
 import com.calypsan.listenup.client.core.Success
 import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
 import com.calypsan.listenup.client.data.local.db.PendingOperationDao
@@ -18,14 +19,23 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 /**
- * Proves `ProgressPuller.guardAndSaveEntities` is atomic — when `saveAll` throws
- * mid-transaction, no rows persist. Mirrors `BookPullerAtomicityTest` precedent (W4.2).
+ * Proves `ProgressPuller.guardAndSaveEntities` reaches the transactional seam and
+ * no partial writes persist when the seam's inner body throws.
  *
- * Uses a real in-memory [ListenUpDatabase] so transaction semantics are exercised
- * end-to-end; a fake TransactionRunner cannot prove rollback. The `PlaybackPositionDao`
- * is mocked to throw, forcing the failure after the pending-ids read.
+ * Uses a real in-memory [ListenUpDatabase] and real [RoomTransactionRunner] so
+ * transaction semantics are exercised end-to-end; `PlaybackPositionDao` is mocked
+ * to throw on `saveAll`.
+ *
+ * Honest scope: `guardAndSaveEntities` contains only one DAO write (`saveAll`), so
+ * exception-driven rollback cannot be distinguished from "throw before write" at the
+ * single-write level. The stronger invariant — serialisation against concurrent
+ * MARK_COMPLETE queue inserts — is not exercised here because `runTest`'s
+ * single-threaded dispatcher cannot reproduce the concurrent race. That invariant is
+ * defended structurally: the production code's `atomically { read; compute; saveAll }`
+ * block matches the W4 precedent (`BookPullerAtomicityTest.kt`) and rubric §P-R1.
  */
 class ProgressPullerAtomicityTest {
     private val db: ListenUpDatabase = createInMemoryTestDatabase()
@@ -36,7 +46,7 @@ class ProgressPullerAtomicityTest {
     }
 
     @Test
-    fun `rollback when saveAll throws mid-transaction`() =
+    fun `no rows persist when saveAll throws inside transaction`() =
         runTest {
             val syncApi = mock<SyncApiContract> {
                 everySuspend { getAllProgress(any()) } returns Success(
@@ -70,11 +80,13 @@ class ProgressPullerAtomicityTest {
             )
 
             // ProgressPuller.pull catches Exception at the outer envelope and logs —
-            // it does NOT propagate. So we assert the DB state directly: zero rows
-            // in playback_positions after pull returns.
+            // it does NOT propagate. So we assert the DB state directly.
             puller.pull(updatedAfter = null) {}
 
-            val persisted = db.playbackPositionDao().getByBookIds(emptyList())
-            assertEquals(0, persisted.size, "no rows should have persisted after rollback")
+            val rolledBackRow = db.playbackPositionDao().get(BookId("book-rollback"))
+            assertNull(rolledBackRow, "book-rollback row must not persist after transaction rollback")
+
+            val unsyncedAfterRollback = db.playbackPositionDao().getUnsyncedPositions()
+            assertEquals(0, unsyncedAfterRollback.size, "no rows should exist in playback_positions after rollback")
         }
 }

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/push/PendingOperationRepositoryCoalesceAtomicityTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/push/PendingOperationRepositoryCoalesceAtomicityTest.kt
@@ -1,0 +1,169 @@
+package com.calypsan.listenup.client.data.sync.push
+
+import com.calypsan.listenup.client.core.AppResult
+import com.calypsan.listenup.client.core.Success
+import com.calypsan.listenup.client.data.local.db.EntityType
+import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
+import com.calypsan.listenup.client.data.local.db.OperationType
+import com.calypsan.listenup.client.data.local.db.PendingOperationEntity
+import com.calypsan.listenup.client.data.local.db.RoomTransactionRunner
+import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+/**
+ * Proves two invariants for `PendingOperationRepository.queue`:
+ *
+ * 1. Sequential `queue` calls on the same entity coalesce into exactly one row
+ *    (the transactional wrap serializes the find+insert window). The stronger
+ *    concurrent-coalesce invariant — serialisation against concurrent queue inserts
+ *    — is defended structurally by the `atomically` wrap (matching W4 rubric §P-R1
+ *    precedent) but cannot be physically reproduced at unit level because Room's
+ *    IO-dispatched DAO queries do not participate in the caller's `useWriterConnection`
+ *    scope in the in-memory test database. The structural guarantee holds in production
+ *    where SQLite's single-writer serialisation enforces it.
+ *
+ * 2. Calling `queue` from inside an outer `atomically` block is safe — the inner
+ *    transaction participates in the outer scope (Room KMP 2.8 full-atomic
+ *    semantics, confirmed empirically at plan-write-time). This invariant is
+ *    relevant for `ContributorEditRepository`'s three existing call sites that
+ *    already invoke `queue` from inside `atomically`.
+ *
+ * Uses a real in-memory [ListenUpDatabase] and real [RoomTransactionRunner].
+ */
+class PendingOperationRepositoryCoalesceAtomicityTest {
+    private val testHandler = object : OperationHandler<String> {
+        override val operationType = OperationType.PLAYBACK_POSITION
+
+        override fun batchKey(payload: String): String? = null
+
+        override fun serializePayload(payload: String): String = payload
+
+        override fun parsePayload(raw: String): String = raw
+
+        override fun tryCoalesce(
+            existing: PendingOperationEntity,
+            existingPayload: String,
+            newPayload: String,
+        ): String? = newPayload  // always coalesce — take the newer payload
+
+        override suspend fun execute(
+            operation: PendingOperationEntity,
+            payload: String,
+        ): AppResult<Unit> = Success(Unit)
+    }
+
+    private val db: ListenUpDatabase = createInMemoryTestDatabase()
+
+    private fun buildRepo(): PendingOperationRepository {
+        val txRunner = RoomTransactionRunner(db)
+        return PendingOperationRepository(
+            transactionRunner = txRunner,
+            dao = db.pendingOperationDao(),
+            bookDao = db.bookDao(),
+            contributorDao = db.contributorDao(),
+            seriesDao = db.seriesDao(),
+            shelfDao = db.shelfDao(),
+        )
+    }
+
+    @AfterTest
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun `sequential queue for same entity produces exactly one row`() =
+        runTest {
+            val repo = buildRepo()
+
+            repo.queue(
+                type = OperationType.PLAYBACK_POSITION,
+                entityType = EntityType.BOOK,
+                entityId = "book-coalesce",
+                payload = "payload-a",
+                handler = testHandler,
+            )
+            repo.queue(
+                type = OperationType.PLAYBACK_POSITION,
+                entityType = EntityType.BOOK,
+                entityId = "book-coalesce",
+                payload = "payload-b",
+                handler = testHandler,
+            )
+
+            val rows = db.pendingOperationDao().observeAll().first().filter {
+                it.entityId == "book-coalesce" && it.operationType == OperationType.PLAYBACK_POSITION
+            }
+            assertEquals(1, rows.size, "sequential queue calls should coalesce to exactly one row")
+        }
+
+    @Test
+    fun `queue called from inside outer atomically participates in outer tx - success path`() =
+        runTest {
+            val txRunner = RoomTransactionRunner(db)
+            val repo = PendingOperationRepository(
+                transactionRunner = txRunner,
+                dao = db.pendingOperationDao(),
+                bookDao = db.bookDao(),
+                contributorDao = db.contributorDao(),
+                seriesDao = db.seriesDao(),
+                shelfDao = db.shelfDao(),
+            )
+
+            txRunner.atomically {
+                repo.queue(
+                    type = OperationType.PLAYBACK_POSITION,
+                    entityType = EntityType.BOOK,
+                    entityId = "book-nested-success",
+                    payload = "payload-nested",
+                    handler = testHandler,
+                )
+            }
+
+            val rows = db.pendingOperationDao().observeAll().first().filter {
+                it.entityId == "book-nested-success"
+            }
+            assertEquals(1, rows.size, "queue called inside outer atomically should commit normally")
+        }
+
+    @Test
+    fun `queue called from inside outer atomically rolls back when outer throws`() =
+        runTest {
+            val txRunner = RoomTransactionRunner(db)
+            val repo = PendingOperationRepository(
+                transactionRunner = txRunner,
+                dao = db.pendingOperationDao(),
+                bookDao = db.bookDao(),
+                contributorDao = db.contributorDao(),
+                seriesDao = db.seriesDao(),
+                shelfDao = db.shelfDao(),
+            )
+
+            val caught = try {
+                txRunner.atomically {
+                    repo.queue(
+                        type = OperationType.PLAYBACK_POSITION,
+                        entityType = EntityType.BOOK,
+                        entityId = "book-nested-throw",
+                        payload = "payload-throw",
+                        handler = testHandler,
+                    )
+                    throw RuntimeException("outer throws after inner queue")
+                }
+                null
+            } catch (e: Exception) {
+                e
+            }
+
+            assertNotNull(caught, "outer throw must propagate")
+            val rows = db.pendingOperationDao().observeAll().first().filter {
+                it.entityId == "book-nested-throw"
+            }
+            assertEquals(0, rows.size, "queue's write must roll back when outer tx throws")
+        }
+}

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/push/PendingOperationRepositoryCoalesceAtomicityTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/push/PendingOperationRepositoryCoalesceAtomicityTest.kt
@@ -12,8 +12,8 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import kotlin.test.AfterTest
 import kotlin.test.Test
+import kotlin.test.assertFailsWith
 import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
 
 /**
  * Proves two invariants for `PendingOperationRepository.queue`:
@@ -149,24 +149,18 @@ class PendingOperationRepositoryCoalesceAtomicityTest {
                     shelfDao = db.shelfDao(),
                 )
 
-            val caught =
-                try {
-                    txRunner.atomically {
-                        repo.queue(
-                            type = OperationType.PLAYBACK_POSITION,
-                            entityType = EntityType.BOOK,
-                            entityId = "book-nested-throw",
-                            payload = "payload-throw",
-                            handler = testHandler,
-                        )
-                        throw RuntimeException("outer throws after inner queue")
-                    }
-                    null
-                } catch (e: Exception) {
-                    e
+            assertFailsWith<RuntimeException> {
+                txRunner.atomically {
+                    repo.queue(
+                        type = OperationType.PLAYBACK_POSITION,
+                        entityType = EntityType.BOOK,
+                        entityId = "book-nested-throw",
+                        payload = "payload-throw",
+                        handler = testHandler,
+                    )
+                    throw RuntimeException("outer throws after inner queue")
                 }
-
-            assertNotNull(caught, "outer throw must propagate")
+            }
             val rows =
                 db.pendingOperationDao().observeAll().first().filter {
                     it.entityId == "book-nested-throw"

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/push/PendingOperationRepositoryCoalesceAtomicityTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/push/PendingOperationRepositoryCoalesceAtomicityTest.kt
@@ -36,26 +36,27 @@ import kotlin.test.assertNotNull
  * Uses a real in-memory [ListenUpDatabase] and real [RoomTransactionRunner].
  */
 class PendingOperationRepositoryCoalesceAtomicityTest {
-    private val testHandler = object : OperationHandler<String> {
-        override val operationType = OperationType.PLAYBACK_POSITION
+    private val testHandler =
+        object : OperationHandler<String> {
+            override val operationType = OperationType.PLAYBACK_POSITION
 
-        override fun batchKey(payload: String): String? = null
+            override fun batchKey(payload: String): String? = null
 
-        override fun serializePayload(payload: String): String = payload
+            override fun serializePayload(payload: String): String = payload
 
-        override fun parsePayload(raw: String): String = raw
+            override fun parsePayload(raw: String): String = raw
 
-        override fun tryCoalesce(
-            existing: PendingOperationEntity,
-            existingPayload: String,
-            newPayload: String,
-        ): String? = newPayload  // always coalesce — take the newer payload
+            override fun tryCoalesce(
+                existing: PendingOperationEntity,
+                existingPayload: String,
+                newPayload: String,
+            ): String? = newPayload // always coalesce — take the newer payload
 
-        override suspend fun execute(
-            operation: PendingOperationEntity,
-            payload: String,
-        ): AppResult<Unit> = Success(Unit)
-    }
+            override suspend fun execute(
+                operation: PendingOperationEntity,
+                payload: String,
+            ): AppResult<Unit> = Success(Unit)
+        }
 
     private val db: ListenUpDatabase = createInMemoryTestDatabase()
 
@@ -96,9 +97,10 @@ class PendingOperationRepositoryCoalesceAtomicityTest {
                 handler = testHandler,
             )
 
-            val rows = db.pendingOperationDao().observeAll().first().filter {
-                it.entityId == "book-coalesce" && it.operationType == OperationType.PLAYBACK_POSITION
-            }
+            val rows =
+                db.pendingOperationDao().observeAll().first().filter {
+                    it.entityId == "book-coalesce" && it.operationType == OperationType.PLAYBACK_POSITION
+                }
             assertEquals(1, rows.size, "sequential queue calls should coalesce to exactly one row")
         }
 
@@ -106,14 +108,15 @@ class PendingOperationRepositoryCoalesceAtomicityTest {
     fun `queue called from inside outer atomically participates in outer tx - success path`() =
         runTest {
             val txRunner = RoomTransactionRunner(db)
-            val repo = PendingOperationRepository(
-                transactionRunner = txRunner,
-                dao = db.pendingOperationDao(),
-                bookDao = db.bookDao(),
-                contributorDao = db.contributorDao(),
-                seriesDao = db.seriesDao(),
-                shelfDao = db.shelfDao(),
-            )
+            val repo =
+                PendingOperationRepository(
+                    transactionRunner = txRunner,
+                    dao = db.pendingOperationDao(),
+                    bookDao = db.bookDao(),
+                    contributorDao = db.contributorDao(),
+                    seriesDao = db.seriesDao(),
+                    shelfDao = db.shelfDao(),
+                )
 
             txRunner.atomically {
                 repo.queue(
@@ -125,9 +128,10 @@ class PendingOperationRepositoryCoalesceAtomicityTest {
                 )
             }
 
-            val rows = db.pendingOperationDao().observeAll().first().filter {
-                it.entityId == "book-nested-success"
-            }
+            val rows =
+                db.pendingOperationDao().observeAll().first().filter {
+                    it.entityId == "book-nested-success"
+                }
             assertEquals(1, rows.size, "queue called inside outer atomically should commit normally")
         }
 
@@ -135,35 +139,38 @@ class PendingOperationRepositoryCoalesceAtomicityTest {
     fun `queue called from inside outer atomically rolls back when outer throws`() =
         runTest {
             val txRunner = RoomTransactionRunner(db)
-            val repo = PendingOperationRepository(
-                transactionRunner = txRunner,
-                dao = db.pendingOperationDao(),
-                bookDao = db.bookDao(),
-                contributorDao = db.contributorDao(),
-                seriesDao = db.seriesDao(),
-                shelfDao = db.shelfDao(),
-            )
+            val repo =
+                PendingOperationRepository(
+                    transactionRunner = txRunner,
+                    dao = db.pendingOperationDao(),
+                    bookDao = db.bookDao(),
+                    contributorDao = db.contributorDao(),
+                    seriesDao = db.seriesDao(),
+                    shelfDao = db.shelfDao(),
+                )
 
-            val caught = try {
-                txRunner.atomically {
-                    repo.queue(
-                        type = OperationType.PLAYBACK_POSITION,
-                        entityType = EntityType.BOOK,
-                        entityId = "book-nested-throw",
-                        payload = "payload-throw",
-                        handler = testHandler,
-                    )
-                    throw RuntimeException("outer throws after inner queue")
+            val caught =
+                try {
+                    txRunner.atomically {
+                        repo.queue(
+                            type = OperationType.PLAYBACK_POSITION,
+                            entityType = EntityType.BOOK,
+                            entityId = "book-nested-throw",
+                            payload = "payload-throw",
+                            handler = testHandler,
+                        )
+                        throw RuntimeException("outer throws after inner queue")
+                    }
+                    null
+                } catch (e: Exception) {
+                    e
                 }
-                null
-            } catch (e: Exception) {
-                e
-            }
 
             assertNotNull(caught, "outer throw must propagate")
-            val rows = db.pendingOperationDao().observeAll().first().filter {
-                it.entityId == "book-nested-throw"
-            }
+            val rows =
+                db.pendingOperationDao().observeAll().first().filter {
+                    it.entityId == "book-nested-throw"
+                }
             assertEquals(0, rows.size, "queue's write must roll back when outer tx throws")
         }
 }

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/sse/SSEEventProcessorAtomicityTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/sse/SSEEventProcessorAtomicityTest.kt
@@ -32,6 +32,7 @@ import com.calypsan.listenup.client.data.sync.SSEEvent
 import com.calypsan.listenup.client.data.sync.SessionDaos
 import com.calypsan.listenup.client.data.sync.UserDaos
 import com.calypsan.listenup.client.data.sync.pull.BookRelationshipDaos
+import com.calypsan.listenup.client.domain.repository.AvatarDownloadRepository
 import com.calypsan.listenup.client.domain.repository.CoverDownloadRepository
 import com.calypsan.listenup.client.domain.repository.SessionRepository
 import com.calypsan.listenup.client.download.DownloadService
@@ -42,9 +43,7 @@ import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import kotlin.test.AfterTest
 import kotlin.test.Test
@@ -64,6 +63,11 @@ class SSEEventProcessorAtomicityTest {
     private val noOpCoverDownloadRepository =
         object : CoverDownloadRepository {
             override fun queueCoverDownload(bookId: BookId) = Unit
+        }
+
+    private val noOpAvatarDownloadRepository =
+        object : AvatarDownloadRepository {
+            override fun queueAvatarDownload(userId: String) = Unit
         }
 
     @AfterTest
@@ -166,7 +170,7 @@ class SSEEventProcessorAtomicityTest {
                         ),
                     activityDao = activityDao,
                     coverDownloadRepository = noOpCoverDownloadRepository,
-                    scope = CoroutineScope(TestScope(testScheduler).coroutineContext),
+                    avatarDownloadRepository = noOpAvatarDownloadRepository,
                 )
 
             processor.process(
@@ -308,7 +312,7 @@ class SSEEventProcessorAtomicityTest {
                         ),
                     activityDao = activityDao,
                     coverDownloadRepository = noOpCoverDownloadRepository,
-                    scope = CoroutineScope(TestScope(testScheduler).coroutineContext),
+                    avatarDownloadRepository = noOpAvatarDownloadRepository,
                 )
 
             processor.process(
@@ -438,7 +442,7 @@ class SSEEventProcessorAtomicityTest {
                         ),
                     activityDao = activityDao,
                     coverDownloadRepository = noOpCoverDownloadRepository,
-                    scope = CoroutineScope(TestScope(testScheduler).coroutineContext),
+                    avatarDownloadRepository = noOpAvatarDownloadRepository,
                 )
 
             processor.process(

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/sse/SSEEventProcessorProgressMergeTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/sse/SSEEventProcessorProgressMergeTest.kt
@@ -304,4 +304,79 @@ class SSEEventProcessorProgressMergeTest {
             assertNotNull(unchanged)
             assertEquals(50_000L, unchanged.positionMs) // NOT overwritten.
         }
+
+    @Test
+    fun `handleProgressUpdated skips row when last_played_at is malformed`() =
+        runTest {
+            val processor = createProcessor()
+            val bookId = BookId("book-malformed-ts")
+
+            val event =
+                SSEEvent.ProgressUpdated(
+                    timestamp = "2026-04-19T10:00:00Z",
+                    data =
+                        ProgressPayload(
+                            bookId = bookId.value,
+                            currentPositionMs = 1000L,
+                            progress = 0.01,
+                            totalListenTimeMs = 100L,
+                            isFinished = false,
+                            lastPlayedAt = "not-a-valid-timestamp",
+                            startedAt = null,
+                            finishedAt = null,
+                        ),
+                )
+
+            processor.process(SSEChannelMessage.Wire(event))
+
+            assertNull(
+                playbackPositionDao.get(bookId),
+                "malformed timestamp should cause row skip, not fabricated persistence",
+            )
+        }
+
+    @Test
+    fun `handleProgressUpdated still persists adjacent valid event after malformed one`() =
+        runTest {
+            val processor = createProcessor()
+            val malformedBookId = BookId("book-malformed-ts-adj")
+            val validBookId = BookId("book-valid-adj")
+
+            val malformedEvent =
+                SSEEvent.ProgressUpdated(
+                    timestamp = "2026-04-19T10:00:00Z",
+                    data =
+                        ProgressPayload(
+                            bookId = malformedBookId.value,
+                            currentPositionMs = 1000L,
+                            progress = 0.01,
+                            totalListenTimeMs = 100L,
+                            isFinished = false,
+                            lastPlayedAt = "2026-99-99T99:99:99Z",
+                            startedAt = null,
+                            finishedAt = null,
+                        ),
+                )
+            val validEvent =
+                SSEEvent.ProgressUpdated(
+                    timestamp = "2026-04-19T10:00:01Z",
+                    data =
+                        ProgressPayload(
+                            bookId = validBookId.value,
+                            currentPositionMs = 2000L,
+                            progress = 0.02,
+                            totalListenTimeMs = 200L,
+                            isFinished = false,
+                            lastPlayedAt = "2026-04-19T10:00:00Z",
+                            startedAt = null,
+                            finishedAt = null,
+                        ),
+                )
+
+            processor.process(SSEChannelMessage.Wire(malformedEvent))
+            processor.process(SSEChannelMessage.Wire(validEvent))
+
+            assertNull(playbackPositionDao.get(malformedBookId), "malformed row should be skipped")
+            assertNotNull(playbackPositionDao.get(validBookId), "adjacent valid row should still persist")
+        }
 }

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/sse/SSEEventProcessorProgressMergeTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/sse/SSEEventProcessorProgressMergeTest.kt
@@ -23,6 +23,7 @@ import com.calypsan.listenup.client.data.sync.SSEEvent
 import com.calypsan.listenup.client.data.sync.SessionDaos
 import com.calypsan.listenup.client.data.sync.UserDaos
 import com.calypsan.listenup.client.data.sync.pull.BookRelationshipDaos
+import com.calypsan.listenup.client.domain.repository.AvatarDownloadRepository
 import com.calypsan.listenup.client.domain.repository.CoverDownloadRepository
 import com.calypsan.listenup.client.domain.repository.SessionRepository
 import com.calypsan.listenup.client.download.DownloadService
@@ -30,7 +31,6 @@ import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.mock
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
@@ -60,6 +60,11 @@ class SSEEventProcessorProgressMergeTest {
     private val noOpCoverDownloadRepository =
         object : CoverDownloadRepository {
             override fun queueCoverDownload(bookId: BookId) = Unit
+        }
+
+    private val noOpAvatarDownloadRepository =
+        object : AvatarDownloadRepository {
+            override fun queueAvatarDownload(userId: String) = Unit
         }
 
     @AfterTest
@@ -122,7 +127,7 @@ class SSEEventProcessorProgressMergeTest {
                 ),
             activityDao = activityDao,
             coverDownloadRepository = noOpCoverDownloadRepository,
-            scope = CoroutineScope(TestScope(testScheduler).coroutineContext),
+            avatarDownloadRepository = noOpAvatarDownloadRepository,
         )
     }
 


### PR DESCRIPTION
## Summary

W6 Phase C of the client restoration initiative. Nine commits (6 canonical tasks + 3 supporting) closing two drift rows from Phase B, uncovering and fixing one latent DAO bug, and opening one new drift row for later disposition.

**Canonical commits:**
- `464e48ea` ✨ wire `ProgressPuller` for delta sync via `updated_after` (honors server SP2)
- `2b88c805` 🔒 wrap `ProgressPuller.guardAndSaveEntities` in `TransactionRunner.atomically` (Task 4 forensic-log removal folded in)
- `4e8ff249` 🔒 wrap `PendingOperationRepository.queue` coalesce in `TransactionRunner.atomically`
- `b7b2458b` ♻️ extract `AvatarDownloadRepository` — mirrors Phase B `CoverDownloadRepository`; **closes drift row #2** (C6 fire-and-forget in `handleSessionStarted`). Side effect: `scope` constructor param removed from `SSEEventProcessor` (both prior `scope.launch` sites now repo-owned).
- `26084a15` 🐛 skip SSE progress rows with malformed `last_played_at` — **closes drift row #3**. New helper `parseLastPlayedOrNull` contrasts with tolerant `parseTimestamp` per SOUL "honest over silent."

**Supporting in-range:**
- `9be85a58` sharpened `ProgressPullerAtomicityTest` assertion
- `50a76d05` 🐛 fix `PendingOperationDao` enum-ordinal WHERE/SET clauses (all pending-op filter queries silently returned zero rows in prod — uncovered during Task 3 execution; see drift row #4)
- `83c3d31c` `assertFailsWith` in coalesce nested-throw test
- `b6b79db9` spotlessApply

## Drift log (`docs/architecture/w6-drift-log.md`)

- Row #1 (Random-unstarted siblings) — Open, Phase F-bound
- Row #2 (avatar fire-and-forget) — **Closed** via `b7b2458b`
- Row #3 (malformed `last_played_at`) — **Closed** via `26084a15`
- Row #4 (DAO enum-ordinal mismatch) — **Closed** via `50a76d05` (retroactive audit-trail row)
- Row #5 (`handleProfileUpdated` still uses `imageDownloader` directly — consistency gap with new `AvatarDownloadRepository`; not a regression) — Open, disposition pending

## Reviewer notes

- `AvatarDownloadRepositoryImpl` parallels `CoverDownloadRepositoryImpl` exactly (same constructor shape, same `appScope` qualifier, same CE rethrow+log discipline). Deliberate divergence: no `touchUpdatedAt` — avatars paint from a stable file path.
- Transaction-nesting audit (Task 3 Step 1): `PendingOperationRepository.queue` is reachable from pre-existing `atomically` blocks in `ContributorEditRepository` / `ProfileEditRepositoryImpl` / `BookEditRepositoryImpl`. Room KMP 2.8 savepoint-scopes re-entrant calls via `useWriterConnection { immediateTransaction { ... } }`. Empirically defended by new coalesce-atomicity tests (`queue from inside outer atomically` — both success and rollback paths).
- Mandatory §M1 code-reviewer pass: **PASS** with no blocking issues. All five checklist items (EM-R1, SE-R5, C6, P-R1, R-R1/R-R2; CE-rethrow grep; transaction nesting; test coverage; new-drift scan) confirmed.

## Test plan

- [x] `./gradlew :shared:jvmTest --no-daemon` — green
- [x] `./gradlew spotlessCheck detekt --no-daemon` — green
- [ ] `Build APK` expected red on `AudiobookNotificationProvider` Media3 baseline (W7 territory, accepted per `restoration-roadmap.md` → "Known Baseline Breakage")
- [ ] User approves handoff before Phase D (BookPuller) brainstorming opens

## Plan + spec

- Plan (with end-of-phase state): `docs/superpowers/plans/2026-04-19-w6-c-progress-puller.md`
- Spec: `docs/superpowers/specs/2026-04-19-w6-c-progress-puller-design.md`