### PR TITLE
W6 Phase D — BookPuller D11 cleanup + BookRelationshipWriter extraction

### DIFF
--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/pull/BookPuller.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/pull/BookPuller.kt
@@ -50,17 +50,12 @@ class BookPuller(
     private val syncApi: SyncApiContract,
     private val bookDao: BookDao,
     private val chapterDao: ChapterDao,
-    relationshipDaos: BookRelationshipDaos,
+    private val genreDao: GenreDao,
+    private val bookRelationshipWriter: BookRelationshipWriter,
     private val conflictDetector: ConflictDetectorContract,
     private val imageDownloader: ImageDownloaderContract,
     private val coverDownloadDao: com.calypsan.listenup.client.data.local.db.CoverDownloadDao,
 ) : Puller {
-    private val bookContributorDao: BookContributorDao = relationshipDaos.bookContributorDao
-    private val bookSeriesDao: BookSeriesDao = relationshipDaos.bookSeriesDao
-    private val tagDao: TagDao = relationshipDaos.tagDao
-    private val genreDao: GenreDao = relationshipDaos.genreDao
-    private val audioFileDao: AudioFileDao = relationshipDaos.audioFileDao
-
     /**
      * Pull all books from server with pagination.
      *
@@ -126,13 +121,14 @@ class BookPuller(
     /**
      * Process server books: detect conflicts, upsert, sync related entities.
      *
-     * All DB writes for a page — conflict marks, book upsert, chapters, contributor
-     * and series cross-refs, tags, cover-download tasks — commit atomically. If any
-     * step throws, Room rolls the transaction back so the DB never holds a half-synced
+     * All DB writes for a page — conflict marks, book upsert, chapters, per-book junction
+     * replacements via [BookRelationshipWriter], cover-download tasks — commit atomically.
+     * If any step throws, Room rolls the transaction back so the DB never holds a half-synced
      * book (Finding 05 D2).
      *
-     * Reads and disk I/O run outside the transaction so the writer connection is held
-     * only long enough to apply the actual mutations.
+     * Pure collection (bundles, tag catalog, genre name→id resolution) and disk I/O run
+     * outside the transaction so the writer connection is held only long enough to apply
+     * the actual mutations.
      */
     private suspend fun processServerBooks(
         serverBooks: List<BookEntity>,
@@ -157,6 +153,13 @@ class BookPuller(
 
         val booksWithColors = preserveLocalColors(booksToUpsert)
 
+        // Pure-collection phase — no DB writes, reads only. Held outside the transaction.
+        val responseById = response.books.associateBy { it.id }
+        val chaptersToUpsert = collectChapters(booksToUpsert, responseById)
+        val tagCatalog = collectTagCatalog(booksToUpsert, responseById)
+        val genreNameToId = resolveGenreNameToId(booksToUpsert, responseById)
+        val bundles = collectBundles(booksToUpsert, responseById, genreNameToId)
+
         transactionRunner.atomically {
             conflicts.forEach { (bookId, serverVersion) ->
                 bookDao.markConflict(bookId, serverVersion)
@@ -164,13 +167,11 @@ class BookPuller(
 
             bookDao.upsertAll(booksWithColors)
 
-            syncChapters(response, booksToUpsert)
+            if (chaptersToUpsert.isNotEmpty()) {
+                chapterDao.upsertAll(chaptersToUpsert)
+            }
 
-            syncBookContributors(response, booksToUpsert)
-            syncBookSeries(response, booksToUpsert)
-            syncBookTags(response, booksToUpsert)
-            syncBookGenres(response, booksToUpsert)
-            syncBookAudioFiles(response, booksToUpsert)
+            bookRelationshipWriter.replaceAll(bundles, tagCatalog)
 
             enqueueCoverDownloads(booksToUpsert)
         }
@@ -224,181 +225,112 @@ class BookPuller(
         }
     }
 
-    private suspend fun syncChapters(
-        response: SyncBooksResponse,
-        upsertedBooks: List<BookEntity>,
-    ) {
-        val chaptersToUpsert =
-            response.books
-                .filter { bookResponse -> upsertedBooks.any { it.id.value == bookResponse.id } }
-                .flatMap { bookResponse ->
-                    bookResponse.chapters.mapIndexed { index, chapter ->
-                        chapter.toEntity(BookId(bookResponse.id), index)
-                    }
-                }
-
-        logger.debug { "Upserting ${chaptersToUpsert.size} chapters total" }
-        if (chaptersToUpsert.isNotEmpty()) {
-            chapterDao.upsertAll(chaptersToUpsert)
+    private fun collectChapters(
+        booksToUpsert: List<BookEntity>,
+        responseById: Map<String, com.calypsan.listenup.client.data.remote.model.BookResponse>,
+    ): List<com.calypsan.listenup.client.data.local.db.ChapterEntity> =
+        booksToUpsert.flatMap { book ->
+            val bookResponse = responseById[book.id.value] ?: return@flatMap emptyList()
+            bookResponse.chapters.mapIndexed { index, chapter ->
+                chapter.toEntity(book.id, index)
+            }
         }
+
+    private fun collectTagCatalog(
+        booksToUpsert: List<BookEntity>,
+        responseById: Map<String, com.calypsan.listenup.client.data.remote.model.BookResponse>,
+    ): List<com.calypsan.listenup.client.data.local.db.TagEntity> =
+        booksToUpsert
+            .mapNotNull { responseById[it.id.value] }
+            .flatMap { it.tags }
+            .distinctBy { it.id }
+            .map { tag ->
+                com.calypsan.listenup.client.data.local.db.TagEntity(
+                    id = tag.id,
+                    slug = tag.slug,
+                    bookCount = tag.bookCount,
+                    createdAt = Timestamp.now(),
+                )
+            }
+
+    /**
+     * Resolve genre names (server-side representation) to local catalog IDs. Genres not
+     * present in the local catalog are logged and silently dropped from the cross-refs —
+     * next full sync populates them. Runs outside the transaction; the genre catalog is
+     * immutable within a pull cycle (no concurrent writer), so this read is race-free.
+     */
+    private suspend fun resolveGenreNameToId(
+        booksToUpsert: List<BookEntity>,
+        responseById: Map<String, com.calypsan.listenup.client.data.remote.model.BookResponse>,
+    ): Map<String, String> {
+        val allNames =
+            booksToUpsert
+                .mapNotNull { responseById[it.id.value] }
+                .flatMap { it.genres.orEmpty() }
+                .distinctBy { it.lowercase() }
+
+        if (allNames.isEmpty()) return emptyMap()
+
+        return genreDao.getIdsByNames(allNames).associate { it.name.lowercase() to it.id }
     }
 
-    private suspend fun syncBookContributors(
-        response: SyncBooksResponse,
-        upsertedBooks: List<BookEntity>,
-    ) {
-        val bookContributorsToUpsert =
-            response.books
-                .filter { bookResponse -> upsertedBooks.any { it.id.value == bookResponse.id } }
-                .flatMap { bookResponse ->
-                    bookContributorDao.deleteContributorsForBook(BookId(bookResponse.id))
+    private fun collectBundles(
+        booksToUpsert: List<BookEntity>,
+        responseById: Map<String, com.calypsan.listenup.client.data.remote.model.BookResponse>,
+        genreNameToId: Map<String, String>,
+    ): List<BookRelationshipBundle> =
+        booksToUpsert.mapNotNull { book ->
+            val bookResponse = responseById[book.id.value] ?: return@mapNotNull null
 
-                    bookResponse.contributors.flatMap { contributorResponse ->
-                        contributorResponse.roles.map { role ->
-                            contributorResponse.toEntity(BookId(bookResponse.id), role)
-                        }
-                    }
+            val contributors =
+                bookResponse.contributors.flatMap { contributor ->
+                    contributor.roles.map { role -> contributor.toEntity(book.id, role) }
                 }
 
-        if (bookContributorsToUpsert.isNotEmpty()) {
-            bookContributorDao.insertAll(bookContributorsToUpsert)
-        }
-    }
+            val series = bookResponse.seriesInfo.map { it.toEntity(book.id) }
 
-    private suspend fun syncBookSeries(
-        response: SyncBooksResponse,
-        upsertedBooks: List<BookEntity>,
-    ) {
-        val bookSeriesToUpsert =
-            response.books
-                .filter { bookResponse -> upsertedBooks.any { it.id.value == bookResponse.id } }
-                .flatMap { bookResponse ->
-                    bookSeriesDao.deleteSeriesForBook(BookId(bookResponse.id))
-
-                    bookResponse.seriesInfo.map { seriesInfo ->
-                        seriesInfo.toEntity(BookId(bookResponse.id))
-                    }
-                }
-
-        if (bookSeriesToUpsert.isNotEmpty()) {
-            bookSeriesDao.insertAll(bookSeriesToUpsert)
-        }
-    }
-
-    private suspend fun syncBookTags(
-        response: SyncBooksResponse,
-        upsertedBooks: List<BookEntity>,
-    ) {
-        // First, collect all unique tags and upsert them
-        val allTags =
-            response.books
-                .filter { bookResponse -> upsertedBooks.any { it.id.value == bookResponse.id } }
-                .flatMap { it.tags }
-                .distinctBy { it.id }
-                .map { tag ->
-                    TagEntity(
-                        id = tag.id,
-                        slug = tag.slug,
-                        bookCount = tag.bookCount,
-                        createdAt = Timestamp.now(),
+            val tags =
+                bookResponse.tags.map {
+                    com.calypsan.listenup.client.data.local.db.BookTagCrossRef(
+                        bookId = book.id,
+                        tagId = it.id,
                     )
                 }
 
-        if (allTags.isNotEmpty()) {
-            tagDao.upsertAll(allTags)
-            logger.debug { "Upserted ${allTags.size} unique tags" }
-        }
-
-        // Then create book-tag cross references
-        val bookTagCrossRefs =
-            response.books
-                .filter { bookResponse -> upsertedBooks.any { it.id.value == bookResponse.id } }
-                .flatMap { bookResponse ->
-                    tagDao.deleteTagsForBook(BookId(bookResponse.id))
-
-                    bookResponse.tags.map { tag ->
-                        BookTagCrossRef(bookId = BookId(bookResponse.id), tagId = tag.id)
-                    }
-                }
-
-        if (bookTagCrossRefs.isNotEmpty()) {
-            tagDao.insertAllBookTags(bookTagCrossRefs)
-            logger.debug { "Created ${bookTagCrossRefs.size} book-tag relationships" }
-        }
-    }
-
-    private suspend fun syncBookGenres(
-        response: SyncBooksResponse,
-        upsertedBooks: List<BookEntity>,
-    ) {
-        val upsertedIds = upsertedBooks.map { it.id.value }.toSet()
-        val perBook: List<Pair<String, List<String>>> =
-            response.books
-                .filter { it.id in upsertedIds }
-                .map { it.id to it.genres.orEmpty() }
-
-        val allNames = perBook.flatMap { it.second }.distinctBy { it.lowercase() }
-
-        if (allNames.isEmpty()) {
-            // Server sent no genres for these books — clear any existing junctions
-            // so the server remains the authoritative source of record.
-            upsertedIds.forEach { genreDao.deleteGenresForBook(BookId(it)) }
-            return
-        }
-
-        val nameToId: Map<String, String> =
-            genreDao.getIdsByNames(allNames).associate { it.name.lowercase() to it.id }
-
-        val crossRefs =
-            perBook.flatMap { (bookIdStr, names) ->
-                val bookId = BookId(bookIdStr)
-                genreDao.deleteGenresForBook(bookId)
-                names.mapNotNull { name ->
-                    val id = nameToId[name.lowercase()]
+            val genres =
+                bookResponse.genres.orEmpty().mapNotNull { name ->
+                    val id = genreNameToId[name.lowercase()]
                     if (id == null) {
-                        logger.warn { "Genre '$name' not in catalog; skipping for book $bookIdStr" }
+                        logger.warn { "Genre '$name' not in catalog; skipping for book ${book.id.value}" }
                         null
                     } else {
-                        BookGenreCrossRef(bookId = bookId, genreId = id)
-                    }
-                }
-            }
-
-        if (crossRefs.isNotEmpty()) {
-            genreDao.insertAllBookGenres(crossRefs)
-            logger.debug { "Created ${crossRefs.size} book-genre relationships" }
-        }
-    }
-
-    private suspend fun syncBookAudioFiles(
-        response: SyncBooksResponse,
-        upsertedBooks: List<BookEntity>,
-    ) {
-        val upsertedIds = upsertedBooks.map { it.id.value }.toSet()
-        val rows =
-            response.books
-                .filter { it.id in upsertedIds }
-                .flatMap { bookResponse ->
-                    audioFileDao.deleteForBook(bookResponse.id)
-                    bookResponse.audioFiles.mapIndexed { idx, af ->
-                        AudioFileEntity(
-                            bookId = BookId(bookResponse.id),
-                            index = idx,
-                            id = af.id,
-                            filename = af.filename,
-                            format = af.format,
-                            codec = af.codec,
-                            duration = af.duration,
-                            size = af.size,
-                        )
+                        BookGenreCrossRef(bookId = book.id, genreId = id)
                     }
                 }
 
-        if (rows.isNotEmpty()) {
-            audioFileDao.upsertAll(rows)
-            logger.debug { "Created ${rows.size} audio-file rows across ${upsertedIds.size} books" }
+            val audioFiles =
+                bookResponse.audioFiles.mapIndexed { idx, af ->
+                    AudioFileEntity(
+                        bookId = book.id,
+                        index = idx,
+                        id = af.id,
+                        filename = af.filename,
+                        format = af.format,
+                        codec = af.codec,
+                        duration = af.duration,
+                        size = af.size,
+                    )
+                }
+
+            BookRelationshipBundle(
+                bookId = book.id,
+                contributors = contributors,
+                series = series,
+                tags = tags,
+                genres = genres,
+                audioFiles = audioFiles,
+            )
         }
-    }
 
     /**
      * Enqueue cover downloads for the given books into the persistent queue.

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/pull/BookPuller.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/pull/BookPuller.kt
@@ -11,11 +11,13 @@ import com.calypsan.listenup.client.data.local.db.BookGenreCrossRef
 import com.calypsan.listenup.client.data.local.db.BookSeriesDao
 import com.calypsan.listenup.client.data.local.db.BookTagCrossRef
 import com.calypsan.listenup.client.data.local.db.ChapterDao
+import com.calypsan.listenup.client.data.local.db.ChapterEntity
 import com.calypsan.listenup.client.data.local.db.GenreDao
 import com.calypsan.listenup.client.data.local.db.TagDao
 import com.calypsan.listenup.client.data.local.db.TagEntity
 import com.calypsan.listenup.client.data.local.db.TransactionRunner
 import com.calypsan.listenup.client.data.remote.SyncApiContract
+import com.calypsan.listenup.client.data.remote.model.BookResponse
 import com.calypsan.listenup.client.data.remote.model.SyncBooksResponse
 import com.calypsan.listenup.client.data.remote.model.toEntity
 import com.calypsan.listenup.client.data.sync.ImageDownloaderContract
@@ -154,11 +156,21 @@ class BookPuller(
         val booksWithColors = preserveLocalColors(booksToUpsert)
 
         // Pure-collection phase — no DB writes, reads only. Held outside the transaction.
+        // Pair each book with its response once, enforcing the invariant that every booksToUpsert
+        // entry has a matching response (they are derived from the same response.books list).
         val responseById = response.books.associateBy { it.id }
-        val chaptersToUpsert = collectChapters(booksToUpsert, responseById)
-        val tagCatalog = collectTagCatalog(booksToUpsert, responseById)
-        val genreNameToId = resolveGenreNameToId(booksToUpsert, responseById)
-        val bundles = collectBundles(booksToUpsert, responseById, genreNameToId)
+        val pairedBooks: List<Pair<BookEntity, BookResponse>> =
+            booksToUpsert.map { book ->
+                val bookResponse =
+                    requireNotNull(responseById[book.id.value]) {
+                        "invariant: booksToUpsert entry ${book.id.value} has no matching response"
+                    }
+                book to bookResponse
+            }
+        val chaptersToUpsert = collectChapters(pairedBooks)
+        val tagCatalog = collectTagCatalog(pairedBooks)
+        val genreNameToId = resolveGenreNameToId(pairedBooks)
+        val bundles = collectBundles(pairedBooks, genreNameToId)
 
         transactionRunner.atomically {
             conflicts.forEach { (bookId, serverVersion) ->
@@ -225,27 +237,19 @@ class BookPuller(
         }
     }
 
-    private fun collectChapters(
-        booksToUpsert: List<BookEntity>,
-        responseById: Map<String, com.calypsan.listenup.client.data.remote.model.BookResponse>,
-    ): List<com.calypsan.listenup.client.data.local.db.ChapterEntity> =
-        booksToUpsert.flatMap { book ->
-            val bookResponse = responseById[book.id.value] ?: return@flatMap emptyList()
+    private fun collectChapters(pairedBooks: List<Pair<BookEntity, BookResponse>>): List<ChapterEntity> =
+        pairedBooks.flatMap { (book, bookResponse) ->
             bookResponse.chapters.mapIndexed { index, chapter ->
                 chapter.toEntity(book.id, index)
             }
         }
 
-    private fun collectTagCatalog(
-        booksToUpsert: List<BookEntity>,
-        responseById: Map<String, com.calypsan.listenup.client.data.remote.model.BookResponse>,
-    ): List<com.calypsan.listenup.client.data.local.db.TagEntity> =
-        booksToUpsert
-            .mapNotNull { responseById[it.id.value] }
-            .flatMap { it.tags }
+    private fun collectTagCatalog(pairedBooks: List<Pair<BookEntity, BookResponse>>): List<TagEntity> =
+        pairedBooks
+            .flatMap { (_, bookResponse) -> bookResponse.tags }
             .distinctBy { it.id }
             .map { tag ->
-                com.calypsan.listenup.client.data.local.db.TagEntity(
+                TagEntity(
                     id = tag.id,
                     slug = tag.slug,
                     bookCount = tag.bookCount,
@@ -259,14 +263,10 @@ class BookPuller(
      * next full sync populates them. Runs outside the transaction; the genre catalog is
      * immutable within a pull cycle (no concurrent writer), so this read is race-free.
      */
-    private suspend fun resolveGenreNameToId(
-        booksToUpsert: List<BookEntity>,
-        responseById: Map<String, com.calypsan.listenup.client.data.remote.model.BookResponse>,
-    ): Map<String, String> {
+    private suspend fun resolveGenreNameToId(pairedBooks: List<Pair<BookEntity, BookResponse>>): Map<String, String> {
         val allNames =
-            booksToUpsert
-                .mapNotNull { responseById[it.id.value] }
-                .flatMap { it.genres.orEmpty() }
+            pairedBooks
+                .flatMap { (_, bookResponse) -> bookResponse.genres.orEmpty() }
                 .distinctBy { it.lowercase() }
 
         if (allNames.isEmpty()) return emptyMap()
@@ -275,13 +275,10 @@ class BookPuller(
     }
 
     private fun collectBundles(
-        booksToUpsert: List<BookEntity>,
-        responseById: Map<String, com.calypsan.listenup.client.data.remote.model.BookResponse>,
+        pairedBooks: List<Pair<BookEntity, BookResponse>>,
         genreNameToId: Map<String, String>,
     ): List<BookRelationshipBundle> =
-        booksToUpsert.mapNotNull { book ->
-            val bookResponse = responseById[book.id.value] ?: return@mapNotNull null
-
+        pairedBooks.map { (book, bookResponse) ->
             val contributors =
                 bookResponse.contributors.flatMap { contributor ->
                     contributor.roles.map { role -> contributor.toEntity(book.id, role) }
@@ -291,7 +288,7 @@ class BookPuller(
 
             val tags =
                 bookResponse.tags.map {
-                    com.calypsan.listenup.client.data.local.db.BookTagCrossRef(
+                    BookTagCrossRef(
                         bookId = book.id,
                         tagId = it.id,
                     )

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/pull/BookRelationshipBundle.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/pull/BookRelationshipBundle.kt
@@ -12,11 +12,12 @@ import com.calypsan.listenup.client.data.local.db.BookTagCrossRef
  * to replace the book's existing junction rows with.
  *
  * Built by [BookPuller] during the pure-collection phase (outside the write transaction).
- * Passing a populated list for a relationship type causes a full replace
- * (DELETE existing → INSERT these) for that book. An empty list causes a DELETE-only —
- * the book's prior rows in that table are removed, none are inserted — matching the
- * pre-refactor `BookPuller` behaviour of clearing stale junctions when the server
- * no longer carries entities for that relationship.
+ *
+ * For each relationship field:
+ * - **Non-empty list** → full replace: DELETE existing rows, then INSERT these.
+ * - **Empty list** → DELETE-only: prior rows for this book are removed, none inserted.
+ *   Matches the pre-refactor `BookPuller` behaviour of clearing stale junctions when
+ *   the server no longer carries entities for that relationship.
  */
 data class BookRelationshipBundle(
     val bookId: BookId,

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/pull/BookRelationshipBundle.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/pull/BookRelationshipBundle.kt
@@ -1,0 +1,28 @@
+package com.calypsan.listenup.client.data.sync.pull
+
+import com.calypsan.listenup.client.core.BookId
+import com.calypsan.listenup.client.data.local.db.AudioFileEntity
+import com.calypsan.listenup.client.data.local.db.BookContributorCrossRef
+import com.calypsan.listenup.client.data.local.db.BookGenreCrossRef
+import com.calypsan.listenup.client.data.local.db.BookSeriesCrossRef
+import com.calypsan.listenup.client.data.local.db.BookTagCrossRef
+
+/**
+ * Per-book bundle of pre-collected relationship entities, ready for [BookRelationshipWriter]
+ * to replace the book's existing junction rows with.
+ *
+ * Built by [BookPuller] during the pure-collection phase (outside the write transaction).
+ * Passing a populated list for a relationship type causes a full replace
+ * (DELETE existing → INSERT these) for that book. An empty list causes a DELETE-only —
+ * the book's prior rows in that table are removed, none are inserted — matching the
+ * pre-refactor `BookPuller` behaviour of clearing stale junctions when the server
+ * no longer carries entities for that relationship.
+ */
+data class BookRelationshipBundle(
+    val bookId: BookId,
+    val contributors: List<BookContributorCrossRef>,
+    val series: List<BookSeriesCrossRef>,
+    val tags: List<BookTagCrossRef>,
+    val genres: List<BookGenreCrossRef>,
+    val audioFiles: List<AudioFileEntity>,
+)

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/pull/BookRelationshipWriter.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/pull/BookRelationshipWriter.kt
@@ -1,0 +1,63 @@
+package com.calypsan.listenup.client.data.sync.pull
+
+import com.calypsan.listenup.client.data.local.db.AudioFileDao
+import com.calypsan.listenup.client.data.local.db.BookContributorDao
+import com.calypsan.listenup.client.data.local.db.BookSeriesDao
+import com.calypsan.listenup.client.data.local.db.GenreDao
+import com.calypsan.listenup.client.data.local.db.TagDao
+import com.calypsan.listenup.client.data.local.db.TagEntity
+import io.github.oshai.kotlinlogging.KotlinLogging
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * Writes per-book junction-table rows: contributors, series, tags, genres, audio files.
+ * Also upserts the tag catalog so `BookTagCrossRef` foreign keys are satisfied before
+ * junction inserts.
+ *
+ * Called by [BookPuller] after it has fetched a page, pre-collected entities into
+ * [BookRelationshipBundle]s, and opened the outer write transaction.
+ *
+ * **Transaction contract:** MUST be called inside `TransactionRunner.atomically { ... }`.
+ * This writer contributes no transactional wrapping of its own. Exceptions propagate
+ * unwrapped so the caller's transaction rolls back cleanly.
+ *
+ * Fixes Finding 07 D11: the five per-book relationship syncers previously lived inline
+ * in `BookPuller` as `flatMap`-with-side-effects patterns that entangled pure collection
+ * with mutation. This unit receives already-collected entities and focuses solely on
+ * the paired DELETE+INSERT for each relationship table.
+ */
+class BookRelationshipWriter(
+    private val bookContributorDao: BookContributorDao,
+    private val bookSeriesDao: BookSeriesDao,
+    private val tagDao: TagDao,
+    private val genreDao: GenreDao,
+    private val audioFileDao: AudioFileDao,
+) {
+    suspend fun replaceAll(
+        bundles: List<BookRelationshipBundle>,
+        tagCatalog: List<TagEntity>,
+    ) {
+        if (bundles.isEmpty()) return
+
+        logger.debug {
+            "Replacing relationships for ${bundles.size} books, upserting ${tagCatalog.size} tag catalog entries"
+        }
+
+        if (tagCatalog.isNotEmpty()) tagDao.upsertAll(tagCatalog)
+
+        bundles.forEach { bundle ->
+            bookContributorDao.deleteContributorsForBook(bundle.bookId)
+            bookSeriesDao.deleteSeriesForBook(bundle.bookId)
+            tagDao.deleteTagsForBook(bundle.bookId)
+            genreDao.deleteGenresForBook(bundle.bookId)
+            audioFileDao.deleteForBook(bundle.bookId.value)
+
+            if (bundle.contributors.isNotEmpty()) bookContributorDao.insertAll(bundle.contributors)
+            if (bundle.series.isNotEmpty()) bookSeriesDao.insertAll(bundle.series)
+            if (bundle.tags.isNotEmpty()) tagDao.insertAllBookTags(bundle.tags)
+            if (bundle.genres.isNotEmpty()) genreDao.insertAllBookGenres(bundle.genres)
+            if (bundle.audioFiles.isNotEmpty()) audioFileDao.upsertAll(bundle.audioFiles)
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/pull/BookRelationshipWriter.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/pull/BookRelationshipWriter.kt
@@ -38,13 +38,13 @@ class BookRelationshipWriter(
         bundles: List<BookRelationshipBundle>,
         tagCatalog: List<TagEntity>,
     ) {
+        if (tagCatalog.isNotEmpty()) tagDao.upsertAll(tagCatalog)
+
         if (bundles.isEmpty()) return
 
         logger.debug {
             "Replacing relationships for ${bundles.size} books, upserting ${tagCatalog.size} tag catalog entries"
         }
-
-        if (tagCatalog.isNotEmpty()) tagDao.upsertAll(tagCatalog)
 
         bundles.forEach { bundle ->
             bookContributorDao.deleteContributorsForBook(bundle.bookId)

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/di/Koin.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/di/Koin.kt
@@ -102,6 +102,7 @@ import com.calypsan.listenup.client.data.sync.conflict.ConflictDetectorContract
 import com.calypsan.listenup.client.data.sync.pull.ActiveSessionsPuller
 import com.calypsan.listenup.client.data.sync.pull.BookPuller
 import com.calypsan.listenup.client.data.sync.pull.BookRelationshipDaos
+import com.calypsan.listenup.client.data.sync.pull.BookRelationshipWriter
 import com.calypsan.listenup.client.data.sync.pull.ContributorPuller
 import com.calypsan.listenup.client.data.sync.pull.GenrePuller
 import com.calypsan.listenup.client.data.sync.pull.ShelfPuller
@@ -955,6 +956,18 @@ val syncModule =
                 activityDao = get(),
                 coverDownloadRepository = get(),
                 avatarDownloadRepository = get(),
+            )
+        }
+
+        // BookRelationshipWriter — owns per-book junction-table DELETE+INSERT for BookPuller.
+        // MUST be called inside TransactionRunner.atomically { ... }; contributes no wrapping.
+        single {
+            BookRelationshipWriter(
+                bookContributorDao = get(),
+                bookSeriesDao = get(),
+                tagDao = get(),
+                genreDao = get(),
+                audioFileDao = get(),
             )
         }
 

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/di/Koin.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/di/Koin.kt
@@ -982,14 +982,8 @@ val syncModule =
                 syncApi = get<SyncApiContract>(),
                 bookDao = get(),
                 chapterDao = get(),
-                relationshipDaos =
-                    BookRelationshipDaos(
-                        bookContributorDao = get(),
-                        bookSeriesDao = get(),
-                        tagDao = get(),
-                        genreDao = get(),
-                        audioFileDao = get(),
-                    ),
+                genreDao = get(),
+                bookRelationshipWriter = get(),
                 imageDownloader = get(),
                 conflictDetector = get(),
                 coverDownloadDao = get(),

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/pull/BookPullerTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/pull/BookPullerTest.kt
@@ -167,24 +167,27 @@ class BookPullerTest {
             everySuspend { coverDownloadDao.enqueueAll(any()) } returns Unit
         }
 
-        fun build(): BookPuller =
-            BookPuller(
+        fun build(): BookPuller {
+            val bookRelationshipWriter =
+                BookRelationshipWriter(
+                    bookContributorDao = bookContributorDao,
+                    bookSeriesDao = bookSeriesDao,
+                    tagDao = tagDao,
+                    genreDao = genreDao,
+                    audioFileDao = audioFileDao,
+                )
+            return BookPuller(
                 transactionRunner = transactionRunner,
                 syncApi = syncApi,
                 bookDao = bookDao,
                 chapterDao = chapterDao,
-                relationshipDaos =
-                    BookRelationshipDaos(
-                        bookContributorDao = bookContributorDao,
-                        bookSeriesDao = bookSeriesDao,
-                        tagDao = tagDao,
-                        genreDao = genreDao,
-                        audioFileDao = audioFileDao,
-                    ),
+                genreDao = genreDao,
+                bookRelationshipWriter = bookRelationshipWriter,
                 conflictDetector = conflictDetector,
                 imageDownloader = imageDownloader,
                 coverDownloadDao = coverDownloadDao,
             )
+        }
     }
 
     // ========== Basic Pull Tests ==========

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/pull/BookPullerAtomicityTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/pull/BookPullerAtomicityTest.kt
@@ -135,20 +135,23 @@ class BookPullerAtomicityTest {
                 ),
             )
 
+            val bookRelationshipWriter =
+                BookRelationshipWriter(
+                    bookContributorDao = db.bookContributorDao(),
+                    bookSeriesDao = db.bookSeriesDao(),
+                    tagDao = db.tagDao(),
+                    genreDao = db.genreDao(),
+                    audioFileDao = db.audioFileDao(),
+                )
+
             val puller =
                 BookPuller(
                     transactionRunner = RoomTransactionRunner(db),
                     syncApi = syncApi,
                     bookDao = db.bookDao(),
                     chapterDao = db.chapterDao(),
-                    relationshipDaos =
-                        BookRelationshipDaos(
-                            bookContributorDao = db.bookContributorDao(),
-                            bookSeriesDao = db.bookSeriesDao(),
-                            tagDao = db.tagDao(),
-                            genreDao = db.genreDao(),
-                            audioFileDao = db.audioFileDao(),
-                        ),
+                    genreDao = db.genreDao(),
+                    bookRelationshipWriter = bookRelationshipWriter,
                     conflictDetector = conflictDetector,
                     imageDownloader = imageDownloader,
                     coverDownloadDao = failingCoverDownloadDao,

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/pull/BookRelationshipWriterTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/pull/BookRelationshipWriterTest.kt
@@ -40,11 +40,50 @@ class BookRelationshipWriterTest {
     }
 
     @Test
-    fun `replaceAll with empty bundles is a no-op`() =
+    fun `replaceAll with empty bundles does not mutate pre-existing junction rows`() =
         runTest {
+            val bookId = BookId("book-noop")
+            val contributorId = ContributorId("contrib-noop")
+            val seriesId = SeriesId("series-noop")
+            val now = Timestamp(500_000L)
+
+            // Seed parent rows
+            db.bookDao().upsertAll(listOf(makeBook(bookId, now)))
+            db.contributorDao().upsertAll(listOf(makeContributor(contributorId, now)))
+            db.seriesDao().upsertAll(listOf(makeSeries(seriesId, now)))
+
+            // Seed one row in contributors and audio_files junction tables
+            db.bookContributorDao().insertAll(
+                listOf(BookContributorCrossRef(bookId, contributorId, "author")),
+            )
+            db.audioFileDao().upsertAll(
+                listOf(
+                    AudioFileEntity(
+                        bookId = bookId,
+                        index = 0,
+                        id = "af-noop-1",
+                        filename = "ch1.m4b",
+                        format = "m4b",
+                        codec = "aac",
+                        duration = 1_000L,
+                        size = 1_000L,
+                    ),
+                ),
+            )
+
+            // Call with empty bundles — writer must not touch existing rows
             writer.replaceAll(emptyList(), emptyList())
-            // No exception thrown; nothing written
-            assertEquals(0, db.bookDao().count())
+
+            assertEquals(
+                1,
+                db.bookContributorDao().getByContributorId(contributorId.value).size,
+                "pre-seeded contributor row must still exist after empty-bundle call",
+            )
+            assertEquals(
+                1,
+                db.audioFileDao().getForBook(bookId.value).size,
+                "pre-seeded audio-file row must still exist after empty-bundle call",
+            )
         }
 
     @Test
@@ -172,79 +211,101 @@ class BookRelationshipWriterTest {
         }
 
     @Test
-    fun `replaceAll replaces existing relationships — old rows gone, new rows present`() =
+    fun `replaceAll replaces existing relationships — old rows gone, new rows present in all 5 tables`() =
         runTest {
             val bookId = BookId("book-replace")
-            val oldContrib1 = ContributorId("contrib-old-1")
-            val oldContrib2 = ContributorId("contrib-old-2")
-            val oldContrib3 = ContributorId("contrib-old-3")
-            val newContrib = ContributorId("contrib-new")
             val now = Timestamp(3_000_000L)
 
-            db.bookDao().upsertAll(listOf(makeBook(bookId, now)))
-            db
-                .contributorDao()
-                .upsertAll(
-                    listOf(
-                        makeContributor(oldContrib1, now),
-                        makeContributor(oldContrib2, now),
-                        makeContributor(oldContrib3, now),
-                        makeContributor(newContrib, now),
-                    ),
-                )
+            // Parents for OLD rows
+            val oldContrib = ContributorId("contrib-old")
+            val oldSeries = SeriesId("series-old")
+            val oldTagId = "tag-old"
+            val oldGenreId = "genre-old"
+            val oldAudioFileId = "af-old"
 
-            // Pre-seed 3 old contributor rows
-            db
-                .bookContributorDao()
-                .insertAll(
-                    listOf(
-                        BookContributorCrossRef(bookId, oldContrib1, "author"),
-                        BookContributorCrossRef(bookId, oldContrib2, "narrator"),
-                        BookContributorCrossRef(bookId, oldContrib3, "editor"),
+            // Parents for NEW rows
+            val newContrib = ContributorId("contrib-new")
+            val newSeries = SeriesId("series-new")
+            val newTagId = "tag-new"
+            val newGenreId = "genre-new"
+            val newAudioFileId = "af-new"
+
+            // Seed book
+            db.bookDao().upsertAll(listOf(makeBook(bookId, now)))
+
+            // Seed FK parents for OLD rows
+            db.contributorDao().upsertAll(listOf(makeContributor(oldContrib, now), makeContributor(newContrib, now)))
+            db.seriesDao().upsertAll(listOf(makeSeries(oldSeries, now), makeSeries(newSeries, now)))
+            db.genreDao().upsertAll(listOf(makeGenre(oldGenreId), makeGenre(newGenreId)))
+            // Tag catalog for old tag seeded directly; new tag provided via tagCatalog param
+            db.tagDao().upsertAll(listOf(TagEntity(id = oldTagId, slug = "old-tag", createdAt = now)))
+
+            // Pre-seed OLD junction rows across all 5 tables
+            db.bookContributorDao().insertAll(listOf(BookContributorCrossRef(bookId, oldContrib, "author")))
+            db.bookSeriesDao().insertAll(listOf(BookSeriesCrossRef(bookId, oldSeries, "1")))
+            db.tagDao().insertAllBookTags(listOf(BookTagCrossRef(bookId, oldTagId)))
+            db.genreDao().insertAllBookGenres(listOf(BookGenreCrossRef(bookId, oldGenreId)))
+            db.audioFileDao().upsertAll(
+                listOf(
+                    AudioFileEntity(
+                        bookId = bookId,
+                        index = 0,
+                        id = oldAudioFileId,
+                        filename = "old.m4b",
+                        format = "m4b",
+                        codec = "aac",
+                        duration = 1_000L,
+                        size = 1_000L,
                     ),
-                )
-            assertEquals(
-                3,
-                db.bookContributorDao().getByContributorId(oldContrib1.value).size +
-                    db.bookContributorDao().getByContributorId(oldContrib2.value).size +
-                    db.bookContributorDao().getByContributorId(oldContrib3.value).size,
-                "pre-condition: 3 old rows",
+                ),
             )
 
+            // Verify pre-condition: 1 row in each of the 5 tables
+            assertEquals(1, db.bookContributorDao().getByContributorId(oldContrib.value).size, "pre: contributor")
+            assertEquals(1, db.bookSeriesDao().getSeriesForBook(bookId).size, "pre: series")
+            assertEquals(1, db.tagDao().getTagsForBook(bookId).size, "pre: tags")
+            assertEquals(1, db.genreDao().getGenresForBook(bookId).size, "pre: genres")
+            assertEquals(1, db.audioFileDao().getForBook(bookId.value).size, "pre: audio files")
+
+            // Bundle carries NEW rows for all 5 tables
             val bundle =
                 BookRelationshipBundle(
                     bookId = bookId,
-                    contributors = listOf(BookContributorCrossRef(bookId, newContrib, "author")),
-                    series = emptyList(),
-                    tags = emptyList(),
-                    genres = emptyList(),
-                    audioFiles = emptyList(),
+                    contributors = listOf(BookContributorCrossRef(bookId, newContrib, "narrator")),
+                    series = listOf(BookSeriesCrossRef(bookId, newSeries, "2")),
+                    tags = listOf(BookTagCrossRef(bookId, newTagId)),
+                    genres = listOf(BookGenreCrossRef(bookId, newGenreId)),
+                    audioFiles =
+                        listOf(
+                            AudioFileEntity(
+                                bookId = bookId,
+                                index = 0,
+                                id = newAudioFileId,
+                                filename = "new.m4b",
+                                format = "m4b",
+                                codec = "aac",
+                                duration = 2_000L,
+                                size = 2_000L,
+                            ),
+                        ),
                 )
+            val tagCatalog = listOf(TagEntity(id = newTagId, slug = "new-tag", createdAt = now))
 
-            writer.replaceAll(listOf(bundle), emptyList())
+            writer.replaceAll(listOf(bundle), tagCatalog)
 
             // Old rows gone
-            assertEquals(
-                0,
-                db.bookContributorDao().getByContributorId(oldContrib1.value).size,
-                "old contrib-1 row gone",
-            )
-            assertEquals(
-                0,
-                db.bookContributorDao().getByContributorId(oldContrib2.value).size,
-                "old contrib-2 row gone",
-            )
-            assertEquals(
-                0,
-                db.bookContributorDao().getByContributorId(oldContrib3.value).size,
-                "old contrib-3 row gone",
-            )
-            // New row present
-            assertEquals(
-                1,
-                db.bookContributorDao().getByContributorId(newContrib.value).size,
-                "new contributor row present",
-            )
+            assertEquals(0, db.bookContributorDao().getByContributorId(oldContrib.value).size, "old contributor gone")
+            assertEquals(0, db.bookSeriesDao().getBookSeriesCrossRefs(bookId).count { it.seriesId == oldSeries }, "old series gone")
+            assertEquals(0, db.tagDao().getTagsForBook(bookId).count { it.id == oldTagId }, "old tag gone")
+            assertEquals(0, db.genreDao().getGenresForBook(bookId).count { it.id == oldGenreId }, "old genre gone")
+            assertEquals(0, db.audioFileDao().getForBook(bookId.value).count { it.id == oldAudioFileId }, "old audio file gone")
+
+            // New rows present
+            assertEquals(1, db.bookContributorDao().getByContributorId(newContrib.value).size, "new contributor present")
+            assertEquals(1, db.bookSeriesDao().getBookSeriesCrossRefs(bookId).count { it.seriesId == newSeries }, "new series present")
+            assertEquals(1, db.tagDao().getTagsForBook(bookId).count { it.id == newTagId }, "new tag present")
+            assertEquals(1, db.genreDao().getGenresForBook(bookId).count { it.id == newGenreId }, "new genre present")
+            assertEquals(1, db.audioFileDao().getForBook(bookId.value).count { it.id == newAudioFileId }, "new audio file present")
         }
 
     @Test

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/pull/BookRelationshipWriterTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/pull/BookRelationshipWriterTest.kt
@@ -1,0 +1,340 @@
+package com.calypsan.listenup.client.data.sync.pull
+
+import com.calypsan.listenup.client.core.BookId
+import com.calypsan.listenup.client.core.ContributorId
+import com.calypsan.listenup.client.core.SeriesId
+import com.calypsan.listenup.client.core.Timestamp
+import com.calypsan.listenup.client.data.local.db.AudioFileEntity
+import com.calypsan.listenup.client.data.local.db.BookContributorCrossRef
+import com.calypsan.listenup.client.data.local.db.BookEntity
+import com.calypsan.listenup.client.data.local.db.BookGenreCrossRef
+import com.calypsan.listenup.client.data.local.db.BookSeriesCrossRef
+import com.calypsan.listenup.client.data.local.db.BookTagCrossRef
+import com.calypsan.listenup.client.data.local.db.ContributorEntity
+import com.calypsan.listenup.client.data.local.db.GenreEntity
+import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
+import com.calypsan.listenup.client.data.local.db.SeriesEntity
+import com.calypsan.listenup.client.data.local.db.SyncState
+import com.calypsan.listenup.client.data.local.db.TagEntity
+import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
+import kotlinx.coroutines.test.runTest
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class BookRelationshipWriterTest {
+    private val db: ListenUpDatabase = createInMemoryTestDatabase()
+    private val writer: BookRelationshipWriter =
+        BookRelationshipWriter(
+            bookContributorDao = db.bookContributorDao(),
+            bookSeriesDao = db.bookSeriesDao(),
+            tagDao = db.tagDao(),
+            genreDao = db.genreDao(),
+            audioFileDao = db.audioFileDao(),
+        )
+
+    @AfterTest
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun `replaceAll with empty bundles is a no-op`() =
+        runTest {
+            writer.replaceAll(emptyList(), emptyList())
+            // No exception thrown; nothing written
+            assertEquals(0, db.bookDao().count())
+        }
+
+    @Test
+    fun `replaceAll persists a single-book bundle across all five junction tables`() =
+        runTest {
+            val bookId = BookId("book-1")
+            val contributorId = ContributorId("contrib-1")
+            val seriesId = SeriesId("series-1")
+            val genreId = "genre-1"
+            val tagId = "tag-1"
+            val now = Timestamp(1_000_000L)
+
+            // Seed the book (required by junction FK constraints)
+            db.bookDao().upsertAll(listOf(makeBook(bookId, now)))
+
+            // Seed FK parents: contributor, series, genre
+            db.contributorDao().upsertAll(listOf(makeContributor(contributorId, now)))
+            db.seriesDao().upsertAll(listOf(makeSeries(seriesId, now)))
+            db.genreDao().upsertAll(listOf(makeGenre(genreId)))
+            // Tag catalog is passed via tagCatalog param, seeded by writer
+
+            val bundle =
+                BookRelationshipBundle(
+                    bookId = bookId,
+                    contributors = listOf(BookContributorCrossRef(bookId, contributorId, "author")),
+                    series = listOf(BookSeriesCrossRef(bookId, seriesId, "1")),
+                    tags = listOf(BookTagCrossRef(bookId, tagId)),
+                    genres = listOf(BookGenreCrossRef(bookId, genreId)),
+                    audioFiles =
+                        listOf(
+                            AudioFileEntity(
+                                bookId = bookId,
+                                index = 0,
+                                id = "af-1",
+                                filename = "ch1.m4b",
+                                format = "m4b",
+                                codec = "aac",
+                                duration = 3_600_000L,
+                                size = 45_000_000L,
+                            ),
+                        ),
+                )
+            val tagCatalog = listOf(TagEntity(id = tagId, slug = "fantasy", createdAt = now))
+
+            writer.replaceAll(listOf(bundle), tagCatalog)
+
+            assertEquals(
+                1,
+                db.bookContributorDao().getByContributorId(contributorId.value).size,
+                "contributor cross-ref",
+            )
+            assertEquals(1, db.bookSeriesDao().getSeriesForBook(bookId).size, "series cross-ref")
+            assertEquals(1, db.tagDao().getTagsForBook(bookId).size, "tag cross-ref")
+            assertEquals(1, db.genreDao().getGenresForBook(bookId).size, "genre cross-ref")
+            assertEquals(1, db.audioFileDao().getForBook(bookId.value).size, "audio files")
+        }
+
+    @Test
+    fun `replaceAll handles multi-book bundles with heterogeneous relationships`() =
+        runTest {
+            val bookAId = BookId("book-a")
+            val bookBId = BookId("book-b")
+            val contributorId = ContributorId("contrib-a")
+            val now = Timestamp(2_000_000L)
+
+            db.bookDao().upsertAll(listOf(makeBook(bookAId, now), makeBook(bookBId, now)))
+            db.contributorDao().upsertAll(listOf(makeContributor(contributorId, now)))
+
+            val bundleA =
+                BookRelationshipBundle(
+                    bookId = bookAId,
+                    contributors = listOf(BookContributorCrossRef(bookAId, contributorId, "author")),
+                    series = emptyList(),
+                    tags = emptyList(),
+                    genres = emptyList(),
+                    audioFiles = emptyList(),
+                )
+            val bundleB =
+                BookRelationshipBundle(
+                    bookId = bookBId,
+                    contributors = emptyList(),
+                    series = emptyList(),
+                    tags = emptyList(),
+                    genres = emptyList(),
+                    audioFiles =
+                        listOf(
+                            AudioFileEntity(
+                                bookId = bookBId,
+                                index = 0,
+                                id = "af-b-1",
+                                filename = "ch1.mp3",
+                                format = "mp3",
+                                codec = "mp3",
+                                duration = 1_800_000L,
+                                size = 20_000_000L,
+                            ),
+                        ),
+                )
+
+            writer.replaceAll(listOf(bundleA, bundleB), emptyList())
+
+            // book-a has 1 contributor, 0 audio files
+            assertEquals(
+                1,
+                db.bookContributorDao().getByContributorId(contributorId.value).size,
+                "book-a should have the contributor",
+            )
+            assertEquals(
+                0,
+                db.audioFileDao().getForBook(bookAId.value).size,
+                "book-a should have no audio files",
+            )
+
+            // book-b has 0 contributors, 1 audio file
+            assertEquals(
+                0,
+                db.bookSeriesDao().getSeriesForBook(bookBId).size,
+                "book-b should have no series",
+            )
+            assertEquals(
+                1,
+                db.audioFileDao().getForBook(bookBId.value).size,
+                "book-b should have 1 audio file",
+            )
+        }
+
+    @Test
+    fun `replaceAll replaces existing relationships — old rows gone, new rows present`() =
+        runTest {
+            val bookId = BookId("book-replace")
+            val oldContrib1 = ContributorId("contrib-old-1")
+            val oldContrib2 = ContributorId("contrib-old-2")
+            val oldContrib3 = ContributorId("contrib-old-3")
+            val newContrib = ContributorId("contrib-new")
+            val now = Timestamp(3_000_000L)
+
+            db.bookDao().upsertAll(listOf(makeBook(bookId, now)))
+            db
+                .contributorDao()
+                .upsertAll(
+                    listOf(
+                        makeContributor(oldContrib1, now),
+                        makeContributor(oldContrib2, now),
+                        makeContributor(oldContrib3, now),
+                        makeContributor(newContrib, now),
+                    ),
+                )
+
+            // Pre-seed 3 old contributor rows
+            db
+                .bookContributorDao()
+                .insertAll(
+                    listOf(
+                        BookContributorCrossRef(bookId, oldContrib1, "author"),
+                        BookContributorCrossRef(bookId, oldContrib2, "narrator"),
+                        BookContributorCrossRef(bookId, oldContrib3, "editor"),
+                    ),
+                )
+            assertEquals(
+                3,
+                db.bookContributorDao().getByContributorId(oldContrib1.value).size +
+                    db.bookContributorDao().getByContributorId(oldContrib2.value).size +
+                    db.bookContributorDao().getByContributorId(oldContrib3.value).size,
+                "pre-condition: 3 old rows",
+            )
+
+            val bundle =
+                BookRelationshipBundle(
+                    bookId = bookId,
+                    contributors = listOf(BookContributorCrossRef(bookId, newContrib, "author")),
+                    series = emptyList(),
+                    tags = emptyList(),
+                    genres = emptyList(),
+                    audioFiles = emptyList(),
+                )
+
+            writer.replaceAll(listOf(bundle), emptyList())
+
+            // Old rows gone
+            assertEquals(
+                0,
+                db.bookContributorDao().getByContributorId(oldContrib1.value).size,
+                "old contrib-1 row gone",
+            )
+            assertEquals(
+                0,
+                db.bookContributorDao().getByContributorId(oldContrib2.value).size,
+                "old contrib-2 row gone",
+            )
+            assertEquals(
+                0,
+                db.bookContributorDao().getByContributorId(oldContrib3.value).size,
+                "old contrib-3 row gone",
+            )
+            // New row present
+            assertEquals(
+                1,
+                db.bookContributorDao().getByContributorId(newContrib.value).size,
+                "new contributor row present",
+            )
+        }
+
+    @Test
+    fun `replaceAll upserts tag catalog before inserting junctions (foreign-key ordering)`() =
+        runTest {
+            val bookId = BookId("book-tag-fk")
+            val newTagId = "tag-new"
+            val now = Timestamp(4_000_000L)
+
+            db.bookDao().upsertAll(listOf(makeBook(bookId, now)))
+
+            val bundle =
+                BookRelationshipBundle(
+                    bookId = bookId,
+                    contributors = emptyList(),
+                    series = emptyList(),
+                    tags = listOf(BookTagCrossRef(bookId, newTagId)),
+                    genres = emptyList(),
+                    audioFiles = emptyList(),
+                )
+            val tagCatalog =
+                listOf(
+                    TagEntity(id = newTagId, slug = "tag-new", createdAt = now),
+                )
+
+            // If catalog upsert ran AFTER junction insert, this would fail with an FK violation
+            writer.replaceAll(listOf(bundle), tagCatalog)
+
+            assertEquals(
+                1,
+                db.tagDao().getTagsForBook(bookId).size,
+                "tag junction row written with FK satisfied",
+            )
+            assertTrue(
+                db.tagDao().getById(newTagId) != null,
+                "tag catalog entry persisted",
+            )
+        }
+
+    // ── Fixture helpers ──────────────────────────────────────────────────────
+
+    private fun makeBook(
+        bookId: BookId,
+        now: Timestamp,
+    ) = BookEntity(
+        id = bookId,
+        title = "Test Book ${bookId.value}",
+        coverUrl = null,
+        totalDuration = 3_600_000L,
+        syncState = SyncState.SYNCED,
+        lastModified = now,
+        serverVersion = now,
+        createdAt = now,
+        updatedAt = now,
+    )
+
+    private fun makeContributor(
+        id: ContributorId,
+        now: Timestamp,
+    ) = ContributorEntity(
+        id = id,
+        name = "Contributor ${id.value}",
+        description = null,
+        imagePath = null,
+        syncState = SyncState.SYNCED,
+        lastModified = now,
+        serverVersion = now,
+        createdAt = now,
+        updatedAt = now,
+    )
+
+    private fun makeSeries(
+        id: SeriesId,
+        now: Timestamp,
+    ) = SeriesEntity(
+        id = id,
+        name = "Series ${id.value}",
+        description = null,
+        syncState = SyncState.SYNCED,
+        lastModified = now,
+        serverVersion = now,
+        createdAt = now,
+        updatedAt = now,
+    )
+
+    private fun makeGenre(id: String) =
+        GenreEntity(
+            id = id,
+            name = "Genre $id",
+            slug = id,
+            path = "/$id",
+        )
+}


### PR DESCRIPTION
## Summary

W6 Phase D. Four commits resolving Finding 07 D11 (five per-book relationship syncers in `BookPuller` entangled DELETE with lazy `flatMap` iteration).

- `e6fdd9ae` ✨ add `BookRelationshipWriter` for per-book junction DELETE+INSERT — new single-responsibility collaborator; new `BookRelationshipBundle` data class; 5 isolation tests against real in-memory DB.
- `ba25ff80` 🚨 strengthen `BookRelationshipWriter` tests + unconditional tag-catalog upsert — Task 1 code-quality follow-up (writer body ordering, stronger no-op test, replace-existing test expanded to all 5 tables).
- `97549914` ♻️ rewire `BookPuller` to `BookRelationshipWriter`; drop five sync methods — actually deletes 6 methods (the 5 D11 syncers plus `syncChapters` as incidental cleanup). Pure entity collection moves outside the transaction; the existing page-level `atomically` seam is preserved.
- `07fad255` 🎨 tighten BookPuller collectors — paired map + short imports — Task 2 code-quality follow-up. Consolidated three distinct null-handling idioms into one `requireNotNull`-enforced paired-books pattern; removed fully-qualified type references now that the imports exist.

## Drift log (`docs/architecture/w6-drift-log.md`)

- Row #1 (Random-unstarted siblings) remains Open, Phase-F-bound.
- Rows #2/#3/#4 Closed from Phase C.
- Row #5 (profile-updated avatar gap) remains Open, Phase-F-bound.
- **Row #6 (NEW — `BookRelationshipDaos` package relocation)** — Open, Phase-F-bound. Data class lives in `data.sync.pull` but is now only consumed by `SSEEventProcessor` in `data.sync.sse`. Cheap relocation when Phase F's ownership audit runs.

## Reviewer notes

- `BookRelationshipWriter` contract documented in KDoc: *"MUST be called inside `TransactionRunner.atomically`."* The single caller (`BookPuller.processServerBooks`) honours this. Writer contributes no transactional wrapping of its own — the outer seam stays in one place.
- Atomicity granularity unchanged (page-level). The spec language "per-book atomic DELETE+INSERT" interpreted as "each book's DELETE+INSERT is cleanly paired per book inside the outer transaction" — see spec § Non-goals.
- `BookPuller` constructor: 9 params post-refactor (well under detekt threshold of 12). `BookRelationshipDaos` data class stays defined in `BookPuller.kt` (still used by `SSEEventProcessor` Koin binding — see drift row #6).
- Mandatory §M1 code-reviewer pass: **CLEAR (PASS)**. All 5 rubric rules (EM-R1, SE-R5, C6, P-R1, R-R1) confirmed. CancellationException rethrow compliance via absence. Transaction nesting verified. Test coverage preserved.

## Test plan

- [x] `./gradlew :shared:jvmTest --no-daemon` — green
- [x] `./gradlew spotlessCheck detekt --no-daemon` — green
- [ ] `Build APK` expected red on `AudiobookNotificationProvider` Media3 baseline (W7 territory, accepted per `restoration-roadmap.md` → "Known Baseline Breakage")
- [ ] User approves handoff before Phase E brainstorming opens

## Plan + spec

- Plan (with end-of-phase state): `docs/superpowers/plans/2026-04-20-w6-d-bookpuller-rewrite.md`
- Spec: `docs/superpowers/specs/2026-04-20-w6-d-bookpuller-rewrite-design.md`