### PR TITLE
W6 Phase E — SessionRepository rewrite + BookDetail/BookReaders VM boundary (Bug 1 fix)

### DIFF
--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/BookReadersSummaryDao.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/BookReadersSummaryDao.kt
@@ -1,0 +1,21 @@
+package com.calypsan.listenup.client.data.local.db
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Upsert
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * DAO for [BookReadersSummaryEntity] — per-book aggregate reader counts.
+ *
+ * Consumed only by [com.calypsan.listenup.client.data.repository.SessionRepositoryImpl].
+ * Two methods: `upsert` (write during refresh) and `observeFor` (read during flow emission).
+ */
+@Dao
+interface BookReadersSummaryDao {
+    @Upsert
+    suspend fun upsert(entity: BookReadersSummaryEntity)
+
+    @Query("SELECT * FROM book_readers_summary WHERE bookId = :bookId")
+    fun observeFor(bookId: String): Flow<BookReadersSummaryEntity?>
+}

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/BookReadersSummaryDao.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/BookReadersSummaryDao.kt
@@ -3,6 +3,7 @@ package com.calypsan.listenup.client.data.local.db
 import androidx.room.Dao
 import androidx.room.Query
 import androidx.room.Upsert
+import com.calypsan.listenup.client.core.BookId
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -17,5 +18,5 @@ interface BookReadersSummaryDao {
     suspend fun upsert(entity: BookReadersSummaryEntity)
 
     @Query("SELECT * FROM book_readers_summary WHERE bookId = :bookId")
-    fun observeFor(bookId: String): Flow<BookReadersSummaryEntity?>
+    fun observeFor(bookId: BookId): Flow<BookReadersSummaryEntity?>
 }

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/BookReadersSummaryEntity.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/BookReadersSummaryEntity.kt
@@ -3,6 +3,7 @@ package com.calypsan.listenup.client.data.local.db
 import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.PrimaryKey
+import com.calypsan.listenup.client.core.BookId
 
 /**
  * Per-book aggregate summary persisting the server's authoritative reader counts.
@@ -30,7 +31,7 @@ import androidx.room.PrimaryKey
     ],
 )
 data class BookReadersSummaryEntity(
-    @PrimaryKey val bookId: String,
+    @PrimaryKey val bookId: BookId,
     val totalReaders: Int,
     val totalCompletions: Int,
     val updatedAt: Long,

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/BookReadersSummaryEntity.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/BookReadersSummaryEntity.kt
@@ -1,0 +1,37 @@
+package com.calypsan.listenup.client.data.local.db
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.PrimaryKey
+
+/**
+ * Per-book aggregate summary persisting the server's authoritative reader counts.
+ *
+ * Written by [com.calypsan.listenup.client.data.repository.SessionRepositoryImpl.refreshBookReaders]
+ * inside the same transaction that updates `user_reading_sessions` and `reader_sessions_cache`.
+ * Read by the same repository's `observeBookReaders` flow so the displayed `totalReaders`
+ * matches the server's canonical count rather than being derived from local cache size
+ * (Finding 06 D1 — Bug 1 root cause).
+ *
+ * @property bookId server-assigned book id (primary key; foreign key to `books.id`).
+ * @property totalReaders server's count of all users who have read or are reading this book.
+ * @property totalCompletions server's count of completed reads across all users.
+ * @property updatedAt epoch millis when this row was last written (for staleness diagnostics).
+ */
+@Entity(
+    tableName = "book_readers_summary",
+    foreignKeys = [
+        ForeignKey(
+            entity = BookEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["bookId"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
+)
+data class BookReadersSummaryEntity(
+    @PrimaryKey val bookId: String,
+    val totalReaders: Int,
+    val totalCompletions: Int,
+    val updatedAt: Long,
+)

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/ListenUpDatabase.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/ListenUpDatabase.kt
@@ -24,6 +24,7 @@ import androidx.room.TypeConverters
         UserEntity::class,
         UserProfileEntity::class,
         BookEntity::class,
+        BookReadersSummaryEntity::class, // Phase E
         SyncMetadataEntity::class,
         ChapterEntity::class,
         SeriesEntity::class,
@@ -51,7 +52,7 @@ import androidx.room.TypeConverters
         ReaderSessionCacheEntity::class,
         CoverDownloadTaskEntity::class,
     ],
-    version = 10,
+    version = 11,
     exportSchema = true,
 )
 @TypeConverters(
@@ -119,6 +120,8 @@ abstract class ListenUpDatabase : RoomDatabase() {
     abstract fun readerSessionCacheDao(): ReaderSessionCacheDao
 
     abstract fun coverDownloadDao(): CoverDownloadDao
+
+    abstract fun bookReadersSummaryDao(): BookReadersSummaryDao
 }
 
 /**

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/SessionRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/SessionRepositoryImpl.kt
@@ -3,9 +3,12 @@
 package com.calypsan.listenup.client.data.repository
 
 import com.calypsan.listenup.client.core.AppResult
+import com.calypsan.listenup.client.core.BookId
 import com.calypsan.listenup.client.core.Success
 import com.calypsan.listenup.client.core.currentEpochMilliseconds
 import com.calypsan.listenup.client.core.map
+import com.calypsan.listenup.client.data.local.db.BookReadersSummaryDao
+import com.calypsan.listenup.client.data.local.db.BookReadersSummaryEntity
 import com.calypsan.listenup.client.data.local.db.ReaderSessionCacheDao
 import com.calypsan.listenup.client.data.local.db.ReaderSessionCacheEntity
 import com.calypsan.listenup.client.data.local.db.TransactionRunner
@@ -21,10 +24,11 @@ import com.calypsan.listenup.client.domain.repository.SessionRepository
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlin.time.Instant
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.onStart
 
 private val logger = KotlinLogging.logger {}
 
@@ -40,14 +44,15 @@ private val logger = KotlinLogging.logger {}
  * Writes to [userReadingSessionDao] and [readerSessionCacheDao] are wrapped in a
  * single atomically block so a mid-refresh failure doesn't leave one table stale.
  *
- * Bug 1's fixes (persist API's authoritative totalReaders; drop synthetic-self entirely;
- * ViewModel migration) live in W6 — this implementation still derives totalReaders
- * locally to match W4 scope.
+ * Phase E (Finding 06 D1) persists the API's authoritative `totalReaders` / `totalCompletions`
+ * via [BookReadersSummaryDao]. `observeBookReaders` uses `combine + onStart` — callers
+ * subscribe; the repository handles staleness-on-subscribe internally.
  */
 class SessionRepositoryImpl(
     private val sessionApi: SessionApiContract,
     private val userReadingSessionDao: UserReadingSessionDao,
     private val readerSessionCacheDao: ReaderSessionCacheDao,
+    private val bookReadersSummaryDao: BookReadersSummaryDao,
     private val transactionRunner: TransactionRunner,
     private val authSession: AuthSession,
 ) : SessionRepository {
@@ -79,20 +84,7 @@ class SessionRepositoryImpl(
     // ═══════════════════════════════════════════════════════════════════════════
 
     override fun observeBookReaders(bookId: String): Flow<BookReadersResult> =
-        channelFlow {
-            // Fire-and-forget background refresh on subscription — runs concurrent with collection
-            // so cached data is emitted immediately. W6 will migrate to .onStart { } with an
-            // injected CoroutineScope.
-            launch {
-                try {
-                    refreshBookReaders(bookId)
-                } catch (e: kotlin.coroutines.cancellation.CancellationException) {
-                    throw e
-                } catch (e: Exception) {
-                    logger.warn(e) { "Background refresh of readers for book $bookId failed" }
-                }
-            }
-
+        flow {
             val currentUserId = authSession.getUserId()
             logger.debug { "Observing readers for book $bookId (currentUserId=$currentUserId)" }
 
@@ -105,17 +97,26 @@ class SessionRepositoryImpl(
                     bookId = bookId,
                     excludingUserId = currentUserId ?: "",
                 )
+            val summaryFlow = bookReadersSummaryDao.observeFor(BookId(bookId))
 
-            combine(userFlow, cacheFlow) { userSessions, otherEntries ->
-                BookReadersResult(
-                    yourSessions = userSessions.map { it.toDomain() },
-                    otherReaders = otherEntries.map { it.toDomain() },
-                    totalReaders = otherEntries.size + if (userSessions.isNotEmpty()) 1 else 0,
-                    totalCompletions =
-                        otherEntries.sumOf { it.completionCount } +
-                            userSessions.count { it.isCompleted },
-                )
-            }.collect { send(it) }
+            emitAll(
+                combine(userFlow, cacheFlow, summaryFlow) { userSessions, otherEntries, summary ->
+                    BookReadersResult(
+                        yourSessions = userSessions.map { it.toDomain() },
+                        otherReaders = otherEntries.map { it.toDomain() },
+                        totalReaders = summary?.totalReaders ?: 0,
+                        totalCompletions = summary?.totalCompletions ?: 0,
+                    )
+                }.onStart {
+                    try {
+                        refreshBookReaders(bookId)
+                    } catch (e: kotlin.coroutines.cancellation.CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        logger.warn(e) { "Initial refresh failed for book $bookId; continuing from cache" }
+                    }
+                },
+            )
         }
 
     override suspend fun refreshBookReaders(bookId: String) {
@@ -144,6 +145,14 @@ class SessionRepositoryImpl(
                     if (cacheEntries.isNotEmpty()) {
                         readerSessionCacheDao.upsertAll(cacheEntries)
                     }
+                    bookReadersSummaryDao.upsert(
+                        BookReadersSummaryEntity(
+                            bookId = BookId(bookId),
+                            totalReaders = response.totalReaders,
+                            totalCompletions = response.totalCompletions,
+                            updatedAt = now,
+                        ),
+                    )
                 }
 
                 logger.debug {

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/di/Koin.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/di/Koin.kt
@@ -1514,6 +1514,7 @@ val syncModule =
                 sessionApi = get(),
                 userReadingSessionDao = get(),
                 readerSessionCacheDao = get(),
+                bookReadersSummaryDao = get(),
                 transactionRunner = get(),
                 authSession = get(),
             )

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/di/Koin.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/di/Koin.kt
@@ -378,6 +378,7 @@ val repositoryModule =
         single { get<ListenUpDatabase>().userStatsDao() }
         single { get<ListenUpDatabase>().userReadingSessionDao() }
         single { get<ListenUpDatabase>().readerSessionCacheDao() }
+        single { get<ListenUpDatabase>().bookReadersSummaryDao() }
 
         single<com.calypsan.listenup.client.data.local.db.TransactionRunner> {
             com.calypsan.listenup.client.data.local.db

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/bookdetail/BookDetailViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/bookdetail/BookDetailViewModel.kt
@@ -19,11 +19,17 @@ import com.calypsan.listenup.client.core.Failure
 import com.calypsan.listenup.client.core.Success
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -51,13 +57,25 @@ class BookDetailViewModel(
         field = MutableStateFlow<BookDetailUiState>(BookDetailUiState.Loading)
 
     /**
-     * The currently displayed book ID.
-     * Setting this triggers automatic observer switching via [flatMapLatest].
+     * The currently requested book id. Writing to this flow is the single entry
+     * point for switching books — the main-load flatMapLatest subscribes here
+     * directly, so book-switch cancellation is automatic.
      */
-    private val currentBookId = MutableStateFlow<String?>(null)
+    private val bookIdFlow = MutableStateFlow<String?>(null)
+
+    /**
+     * Derives the active book ID from [state], emitting only when a new [BookDetailUiState.Ready]
+     * state arrives with a different book ID. Genre and tag observers subscribe here rather than
+     * directly to [bookIdFlow] so their [updateReady] calls always land on an already-Ready state.
+     */
+    private val activeBookIdFlow: Flow<String> =
+        state
+            .filterIsInstance<BookDetailUiState.Ready>()
+            .map { it.book.id.value }
+            .distinctUntilChanged()
 
     // Mirrors of book-independent flow-fed fields. Updated inside the init
-    // collectors and read at [loadBook] to seed the Ready state with the
+    // collectors and read at [loadBookFlow] to seed the Ready state with the
     // latest known values, since those collectors may have emitted while
     // state was Loading (and been no-op'd by [updateReady]).
     private var latestIsAdmin: Boolean = false
@@ -72,15 +90,12 @@ class BookDetailViewModel(
             }
         }
 
-        // Reactive genre observer - automatically switches when book changes
+        // Reactive genre observer - automatically switches when book changes.
+        // Subscribes to activeBookIdFlow so updateReady always lands on a Ready state.
         viewModelScope.launch {
-            currentBookId
+            activeBookIdFlow
                 .flatMapLatest { bookId ->
-                    if (bookId != null) {
-                        genreRepository.observeGenresForBook(bookId)
-                    } else {
-                        flowOf(emptyList())
-                    }
+                    genreRepository.observeGenresForBook(bookId)
                 }.collect { genres ->
                     updateReady {
                         it.copy(
@@ -91,15 +106,12 @@ class BookDetailViewModel(
                 }
         }
 
-        // Reactive book-specific tags observer - automatically switches when book changes
+        // Reactive book-specific tags observer - automatically switches when book changes.
+        // Subscribes to activeBookIdFlow so updateReady always lands on a Ready state.
         viewModelScope.launch {
-            currentBookId
+            activeBookIdFlow
                 .flatMapLatest { bookId ->
-                    if (bookId != null) {
-                        tagRepository.observeTagsForBook(bookId)
-                    } else {
-                        flowOf(emptyList())
-                    }
+                    tagRepository.observeTagsForBook(bookId)
                 }.collect { tags ->
                     updateReady {
                         it.copy(
@@ -118,6 +130,15 @@ class BookDetailViewModel(
                     latestAllTags = allTags
                     updateReady { it.copy(allTags = allTags) }
                 }
+        }
+
+        // Main load flow: bookIdFlow changes drive loadBookFlow, which emits
+        // Loading then Ready. flatMapLatest cancels the previous load on switch.
+        viewModelScope.launch {
+            bookIdFlow
+                .filterNotNull()
+                .flatMapLatest { id -> loadBookFlow(id) }
+                .collect { base -> state.value = base }
         }
     }
 
@@ -145,14 +166,34 @@ class BookDetailViewModel(
         }
     }
 
+    /**
+     * Switch the view model to observe [bookId].
+     *
+     * Pushes into [bookIdFlow]; the main-load `flatMapLatest` in init collects
+     * `loadBookFlow(id)` and updates state. Tag + genre observers are downstream
+     * of the same [bookIdFlow] change and auto-switch via their own flatMapLatest.
+     */
     fun loadBook(bookId: String) {
-        viewModelScope.launch {
-            state.value = BookDetailUiState.Loading
+        bookIdFlow.value = bookId
+    }
+
+    /**
+     * Pure flow that drives the main book-load pipeline for [bookId].
+     *
+     * Emits [BookDetailUiState.Loading] immediately, then fetches all required
+     * data and emits [BookDetailUiState.Ready] (or [BookDetailUiState.Error] on
+     * failure). The caller ([init] block) collects into [state] via
+     * `flatMapLatest`, so switching books cancels an in-flight load automatically.
+     */
+    private fun loadBookFlow(bookId: String): Flow<BookDetailUiState> =
+        flow {
+            emit(BookDetailUiState.Loading)
+
             val book = bookRepository.getBook(bookId)
 
             if (book == null) {
-                state.value = BookDetailUiState.Error("Book not found")
-                return@launch
+                emit(BookDetailUiState.Error("Book not found"))
+                return@flow
             }
 
             val chapters =
@@ -201,12 +242,11 @@ class BookDetailViewModel(
             // while state was Loading, so we copy the mirrored latest values
             // into the new Ready state.
             //
-            // IMPORTANT: Assign Ready BEFORE updating currentBookId. Setting
-            // currentBookId triggers the flatMapLatest pipelines for genres
-            // and tags; their collectors call updateReady, which no-ops while
-            // state is still Loading. By writing Ready first we guarantee the
-            // first per-book emissions land on the new Ready state.
-            state.value =
+            // Tags and genres default to empty here — the tag/genre init-block
+            // collectors will patch them via updateReady shortly after this
+            // Ready state lands (driven by the same bookIdFlow change via their
+            // own flatMapLatest).
+            emit(
                 BookDetailUiState.Ready(
                     book = book,
                     isAdmin = latestIsAdmin,
@@ -224,15 +264,9 @@ class BookDetailViewModel(
                     timeRemainingFormatted = timeRemaining,
                     addedAt = book.addedAt.epochMillis,
                     isLoadingTags = true,
-                )
-
-            // Trigger reactive observers for genres and tags via flatMapLatest.
-            // Must happen AFTER state.value = Ready(...) so the first emissions
-            // of those pipelines write into the Ready state (not get no-op'd
-            // while state is still Loading).
-            currentBookId.value = bookId
+                ),
+            )
         }
-    }
 
     /**
      * Show the tag picker sheet.

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/bookdetail/BookDetailViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/bookdetail/BookDetailViewModel.kt
@@ -64,9 +64,17 @@ class BookDetailViewModel(
     private val bookIdFlow = MutableStateFlow<String?>(null)
 
     /**
-     * Derives the active book ID from [state], emitting only when a new [BookDetailUiState.Ready]
-     * state arrives with a different book ID. Genre and tag observers subscribe here rather than
-     * directly to [bookIdFlow] so their [updateReady] calls always land on an already-Ready state.
+     * Gate for book-dependent observers (genre, tag). Emits a distinct book id only once
+     * `state` has reached Ready. Genre / tag observers subscribe here so their
+     * `updateReady` patches always land on a Ready state for the current book; they
+     * cannot fire during the Loading window.
+     *
+     * **Pattern: gated observer via state-derived key.** Two invariants make the
+     * state → derived-flow → updateReady → state loop safe:
+     *   1. `.distinctUntilChanged()` filters on the book-id key, not the Ready state.
+     *      Patches that produce a new Ready for the same book don't re-trigger.
+     *   2. `updateReady` is idempotent w.r.t. the book id — patches never change it.
+     * Before copying this pattern elsewhere, verify both invariants hold.
      */
     private val activeBookIdFlow: Flow<String> =
         state
@@ -74,10 +82,13 @@ class BookDetailViewModel(
             .map { it.book.id.value }
             .distinctUntilChanged()
 
-    // Mirrors of book-independent flow-fed fields. Updated inside the init
-    // collectors and read at [loadBookFlow] to seed the Ready state with the
-    // latest known values, since those collectors may have emitted while
+    // Mirrors of book-INDEPENDENT flow-fed fields (admin status, all-tags). Updated
+    // inside the init collectors and read at [loadBookFlow] to seed the Ready state
+    // with the latest known values, since those collectors may have emitted while
     // state was Loading (and been no-op'd by [updateReady]).
+    //
+    // Book-DEPENDENT observers (genre, tag-for-book) use [activeBookIdFlow] to avoid
+    // the Loading-window race entirely — they only fire post-Ready, so no mirror is needed.
     private var latestIsAdmin: Boolean = false
     private var latestAllTags: List<Tag> = emptyList()
 
@@ -159,6 +170,9 @@ class BookDetailViewModel(
     /**
      * Apply [transform] to state only if it is currently [BookDetailUiState.Ready].
      * No-ops when state is [BookDetailUiState.Loading] or [BookDetailUiState.Error].
+     *
+     * NOTE: [activeBookIdFlow] relies on this no-op-on-non-Ready contract to gate
+     * book-dependent observers so their patches never land during Loading.
      */
     private fun updateReady(transform: (BookDetailUiState.Ready) -> BookDetailUiState.Ready) {
         state.update { current ->

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/bookdetail/BookReadersViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/bookdetail/BookReadersViewModel.kt
@@ -9,14 +9,20 @@ import com.calypsan.listenup.client.domain.repository.EventStreamRepository
 import com.calypsan.listenup.client.domain.repository.SessionRepository
 import com.calypsan.listenup.client.domain.repository.UserRepository
 import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlinx.coroutines.Job
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import kotlin.time.Duration.Companion.seconds
 
 private val logger = KotlinLogging.logger {}
 
@@ -31,77 +37,83 @@ private val logger = KotlinLogging.logger {}
  * - Repository triggers background API refresh automatically
  * - SSE events update the cache for real-time updates
  */
-@OptIn(kotlinx.coroutines.FlowPreview::class)
+@OptIn(ExperimentalCoroutinesApi::class, kotlinx.coroutines.FlowPreview::class)
 class BookReadersViewModel(
     private val sessionRepository: SessionRepository,
     private val eventStreamRepository: EventStreamRepository,
     private val userRepository: UserRepository,
 ) : ViewModel() {
-    val state: StateFlow<BookReadersUiState>
-        field = MutableStateFlow<BookReadersUiState>(BookReadersUiState.Loading)
+    /**
+     * The currently requested book id. Writing to this flow is the single entry
+     * point for switching books — both the state stream and the SSE-trigger
+     * side-effect subscribe via `flatMapLatest`, so book-switch cancellation is
+     * automatic.
+     */
+    private val currentBookId = MutableStateFlow<String?>(null)
 
-    // Track which book we're observing
-    private var currentBookId: String? = null
-    private var observeJob: Job? = null
-    private var sseJob: Job? = null
+    val state: StateFlow<BookReadersUiState> =
+        currentBookId
+            .filterNotNull()
+            .flatMapLatest { id ->
+                sessionRepository
+                    .observeBookReaders(id)
+                    .map { result ->
+                        BookReadersUiState.Ready(
+                            yourSessions = result.yourSessions,
+                            currentUserReaderInfo = buildCurrentUserReaderInfo(result.yourSessions),
+                            otherReaders = result.otherReaders,
+                            totalReaders = result.totalReaders,
+                            totalCompletions = result.totalCompletions,
+                        ) as BookReadersUiState
+                    }.catch { e ->
+                        if (e is kotlin.coroutines.cancellation.CancellationException) throw e
+                        logger.error(e) { "Error observing book readers for $id" }
+                        emit(BookReadersUiState.Error(e.message ?: "Failed to load readers"))
+                    }.onStart { emit(BookReadersUiState.Loading) }
+            }.stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(5_000),
+                initialValue = BookReadersUiState.Loading,
+            )
+
+    init {
+        // SSE-trigger side-effect: when a reading session updates for the current
+        // book, debounce-then-refresh. flatMapLatest cancels the previous book's
+        // SSE subscription on switch, so no manual job management.
+        viewModelScope.launch {
+            currentBookId
+                .filterNotNull()
+                .flatMapLatest { id ->
+                    eventStreamRepository.bookEvents
+                        .mapNotNull { event ->
+                            if (event is BookEvent.ReadingSessionUpdated && event.bookId == id) id else null
+                        }.debounce(2.seconds)
+                }.collect { id ->
+                    try {
+                        logger.debug { "SSE: Reading session updated for book $id, refreshing cache (debounced)" }
+                        sessionRepository.refreshBookReaders(id)
+                    } catch (e: kotlin.coroutines.cancellation.CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        logger.warn(e) { "SSE-triggered refresh failed for $id" }
+                    }
+                }
+        }
+    }
 
     /**
-     * Start observing readers for a specific book.
-     *
-     * Observes the local Room cache via Flow for instant updates.
-     * The repository automatically triggers a background refresh
-     * and SSE events update the cache in real-time.
+     * Start observing readers for a specific book. Idempotent: repeated calls with
+     * the same book-id are no-ops because `MutableStateFlow` doesn't re-emit equal
+     * values.
      *
      * @param bookId Book ID to observe readers for
      */
     fun observeReaders(bookId: String) {
-        // Don't restart if already observing this book
-        if (currentBookId == bookId && observeJob?.isActive == true) {
-            return
-        }
-
-        // Cancel previous observations
-        observeJob?.cancel()
-        sseJob?.cancel()
-
-        currentBookId = bookId
-
-        // Observe local cache (repository triggers background refresh)
-        observeJob =
-            viewModelScope.launch {
-                sessionRepository
-                    .observeBookReaders(bookId)
-                    .onStart {
-                        state.value = BookReadersUiState.Loading
-                    }.catch { e ->
-                        if (e is kotlin.coroutines.cancellation.CancellationException) throw e
-                        logger.error(e) { "Error observing book readers" }
-                        state.value = BookReadersUiState.Error(e.message ?: "Failed to load readers")
-                    }.collect { result ->
-                        // Build current user's ReaderInfo from their sessions and profile
-                        val currentUserReaderInfo = buildCurrentUserReaderInfo(result.yourSessions)
-                        state.value =
-                            BookReadersUiState.Ready(
-                                yourSessions = result.yourSessions,
-                                currentUserReaderInfo = currentUserReaderInfo,
-                                otherReaders = result.otherReaders,
-                                totalReaders = result.totalReaders,
-                                totalCompletions = result.totalCompletions,
-                            )
-                        logger.debug {
-                            "Readers updated: ${result.otherReaders.size} readers, ${result.yourSessions.size} sessions"
-                        }
-                    }
-            }
-
-        // Also observe SSE events to trigger refresh
-        observeSSEEvents(bookId)
+        currentBookId.value = bookId
     }
 
     /**
-     * Load readers for a specific book (legacy method).
-     *
-     * Calls [observeReaders] for backwards compatibility.
+     * Legacy entry point kept for Phase F cleanup (parent spec Phase F Deliverable 6).
      *
      * @param bookId Book ID to load readers for
      */
@@ -110,40 +122,19 @@ class BookReadersViewModel(
     }
 
     /**
-     * Observe book events for reading session updates.
-     *
-     * When another user starts or completes reading the same book,
-     * trigger a cache refresh via the repository.
-     */
-    private fun observeSSEEvents(bookId: String) {
-        sseJob =
-            viewModelScope.launch {
-                eventStreamRepository.bookEvents
-                    .mapNotNull { event ->
-                        when (event) {
-                            is BookEvent.ReadingSessionUpdated -> {
-                                if (event.bookId == bookId) event else null
-                            }
-                        }
-                    }.debounce(2000)
-                    .collect {
-                        logger.debug { "SSE: Reading session updated for book $bookId, refreshing cache (debounced)" }
-                        sessionRepository.refreshBookReaders(bookId)
-                    }
-            }
-    }
-
-    /**
-     * Manually refresh the readers list.
-     *
-     * Triggers a background API fetch to update the local cache.
-     * The Flow observation will automatically emit the updated data.
+     * Manually refresh the readers list — bypasses the debounce.
      *
      * @param bookId Book ID to refresh readers for
      */
     fun refresh(bookId: String) {
         viewModelScope.launch {
-            sessionRepository.refreshBookReaders(bookId)
+            try {
+                sessionRepository.refreshBookReaders(bookId)
+            } catch (e: kotlin.coroutines.cancellation.CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                logger.warn(e) { "Manual refresh failed for $bookId" }
+            }
         }
     }
 

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/bookdetail/BookReadersViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/bookdetail/BookReadersViewModel.kt
@@ -26,6 +26,8 @@ import kotlin.time.Duration.Companion.seconds
 
 private val logger = KotlinLogging.logger {}
 
+private const val SUBSCRIPTION_TIMEOUT_MS = 5_000L
+
 /**
  * ViewModel for the Book Readers screen.
  *
@@ -72,7 +74,7 @@ class BookReadersViewModel(
                     }.onStart { emit(BookReadersUiState.Loading) }
             }.stateIn(
                 scope = viewModelScope,
-                started = SharingStarted.WhileSubscribed(5_000),
+                started = SharingStarted.WhileSubscribed(SUBSCRIPTION_TIMEOUT_MS),
                 initialValue = BookReadersUiState.Loading,
             )
 
@@ -80,6 +82,10 @@ class BookReadersViewModel(
         // SSE-trigger side-effect: when a reading session updates for the current
         // book, debounce-then-refresh. flatMapLatest cancels the previous book's
         // SSE subscription on switch, so no manual job management.
+        //
+        // Intentionally runs for the full viewModelScope lifetime (not gated by
+        // state's WhileSubscribed(5s)): refresh writes to Room so cache stays warm
+        // while the screen is briefly unmounted. Matches pre-rewrite behavior.
         viewModelScope.launch {
             currentBookId
                 .filterNotNull()

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/bookdetail/BookDetailViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/bookdetail/BookDetailViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.calypsan.listenup.client.presentation.bookdetail
 
+import app.cash.turbine.turbineScope
 import com.calypsan.listenup.client.TestData
 import com.calypsan.listenup.client.domain.model.Genre
 import com.calypsan.listenup.client.domain.model.PlaybackPosition
@@ -129,8 +130,14 @@ class BookDetailViewModelTest {
             val fixture = createFixture()
             val viewModel = fixture.build()
 
-            // Then
-            assertIs<BookDetailUiState.Loading>(viewModel.state.value)
+            turbineScope {
+                val states = viewModel.state.testIn(backgroundScope)
+                val initial = states.awaitItem()
+
+                // Then
+                assertIs<BookDetailUiState.Loading>(initial)
+                states.cancel()
+            }
         }
 
     // ========== Load Book Tests ==========
@@ -146,15 +153,21 @@ class BookDetailViewModelTest {
             everySuspend { fixture.bookRepository.getChapters("book-1") } returns chapters
             val viewModel = fixture.build()
 
-            // When
-            viewModel.loadBook("book-1")
-            advanceUntilIdle()
+            turbineScope {
+                val states = viewModel.state.testIn(backgroundScope)
+                states.awaitItem() // initial Loading
 
-            // Then
-            val ready = assertIs<BookDetailUiState.Ready>(viewModel.state.value)
-            assertEquals(book, ready.book)
-            assertEquals("A description", ready.description)
-            assertEquals(2, ready.chapters.size)
+                // When
+                viewModel.loadBook("book-1")
+                advanceUntilIdle()
+
+                // Then
+                val ready = assertIs<BookDetailUiState.Ready>(states.expectMostRecentItem())
+                assertEquals(book, ready.book)
+                assertEquals("A description", ready.description)
+                assertEquals(2, ready.chapters.size)
+                states.cancel()
+            }
         }
 
     @Test
@@ -165,13 +178,19 @@ class BookDetailViewModelTest {
             everySuspend { fixture.bookRepository.getBook("nonexistent") } returns null
             val viewModel = fixture.build()
 
-            // When
-            viewModel.loadBook("nonexistent")
-            advanceUntilIdle()
+            turbineScope {
+                val states = viewModel.state.testIn(backgroundScope)
+                states.awaitItem() // initial Loading
 
-            // Then
-            val error = assertIs<BookDetailUiState.Error>(viewModel.state.value)
-            assertEquals("Book not found", error.message)
+                // When
+                viewModel.loadBook("nonexistent")
+                advanceUntilIdle()
+
+                // Then
+                val error = assertIs<BookDetailUiState.Error>(states.expectMostRecentItem())
+                assertEquals("Book not found", error.message)
+                states.cancel()
+            }
         }
 
     // ========== Subtitle Filtering Tests ==========
@@ -192,13 +211,19 @@ class BookDetailViewModelTest {
             everySuspend { fixture.bookRepository.getChapters(any()) } returns emptyList()
             val viewModel = fixture.build()
 
-            // When
-            viewModel.loadBook("book-1")
-            advanceUntilIdle()
+            turbineScope {
+                val states = viewModel.state.testIn(backgroundScope)
+                states.awaitItem() // initial Loading
 
-            // Then - subtitle should be filtered out (redundant)
-            val ready = assertIs<BookDetailUiState.Ready>(viewModel.state.value)
-            assertNull(ready.subtitle)
+                // When
+                viewModel.loadBook("book-1")
+                advanceUntilIdle()
+
+                // Then - subtitle should be filtered out (redundant)
+                val ready = assertIs<BookDetailUiState.Ready>(states.expectMostRecentItem())
+                assertNull(ready.subtitle)
+                states.cancel()
+            }
         }
 
     @Test
@@ -216,13 +241,19 @@ class BookDetailViewModelTest {
             everySuspend { fixture.bookRepository.getChapters(any()) } returns emptyList()
             val viewModel = fixture.build()
 
-            // When
-            viewModel.loadBook("book-1")
-            advanceUntilIdle()
+            turbineScope {
+                val states = viewModel.state.testIn(backgroundScope)
+                states.awaitItem() // initial Loading
 
-            // Then - subtitle should be kept (not redundant)
-            val ready = assertIs<BookDetailUiState.Ready>(viewModel.state.value)
-            assertEquals("A Novel of Discovery", ready.subtitle)
+                // When
+                viewModel.loadBook("book-1")
+                advanceUntilIdle()
+
+                // Then - subtitle should be kept (not redundant)
+                val ready = assertIs<BookDetailUiState.Ready>(states.expectMostRecentItem())
+                assertEquals("A Novel of Discovery", ready.subtitle)
+                states.cancel()
+            }
         }
 
     @Test
@@ -239,13 +270,19 @@ class BookDetailViewModelTest {
             everySuspend { fixture.bookRepository.getChapters(any()) } returns emptyList()
             val viewModel = fixture.build()
 
-            // When
-            viewModel.loadBook("book-1")
-            advanceUntilIdle()
+            turbineScope {
+                val states = viewModel.state.testIn(backgroundScope)
+                states.awaitItem() // initial Loading
 
-            // Then - subtitle should be kept (no series to be redundant with)
-            val ready = assertIs<BookDetailUiState.Ready>(viewModel.state.value)
-            assertEquals("Part 1", ready.subtitle)
+                // When
+                viewModel.loadBook("book-1")
+                advanceUntilIdle()
+
+                // Then - subtitle should be kept (no series to be redundant with)
+                val ready = assertIs<BookDetailUiState.Ready>(states.expectMostRecentItem())
+                assertEquals("Part 1", ready.subtitle)
+                states.cancel()
+            }
         }
 
     // ========== Genre Loading Tests ==========
@@ -267,17 +304,23 @@ class BookDetailViewModelTest {
             every { fixture.genreRepository.observeGenresForBook(any()) } returns flowOf(bookGenres)
             val viewModel = fixture.build()
 
-            // When
-            viewModel.loadBook("book-1")
-            advanceUntilIdle()
+            turbineScope {
+                val states = viewModel.state.testIn(backgroundScope)
+                states.awaitItem() // initial Loading
 
-            // Then
-            val ready = assertIs<BookDetailUiState.Ready>(viewModel.state.value)
-            val genresList = ready.genresList
-            assertEquals(3, genresList.size)
-            assertEquals("Fiction", genresList[0])
-            assertEquals("Fantasy", genresList[1])
-            assertEquals("Adventure", genresList[2])
+                // When
+                viewModel.loadBook("book-1")
+                advanceUntilIdle()
+
+                // Then
+                val ready = assertIs<BookDetailUiState.Ready>(states.expectMostRecentItem())
+                val genresList = ready.genresList
+                assertEquals(3, genresList.size)
+                assertEquals("Fiction", genresList[0])
+                assertEquals("Fantasy", genresList[1])
+                assertEquals("Adventure", genresList[2])
+                states.cancel()
+            }
         }
 
     @Test
@@ -291,13 +334,19 @@ class BookDetailViewModelTest {
             // genreDao.observeGenresForBook already returns empty list from createFixture()
             val viewModel = fixture.build()
 
-            // When
-            viewModel.loadBook("book-1")
-            advanceUntilIdle()
+            turbineScope {
+                val states = viewModel.state.testIn(backgroundScope)
+                states.awaitItem() // initial Loading
 
-            // Then
-            val ready = assertIs<BookDetailUiState.Ready>(viewModel.state.value)
-            assertTrue(ready.genresList.isEmpty())
+                // When
+                viewModel.loadBook("book-1")
+                advanceUntilIdle()
+
+                // Then
+                val ready = assertIs<BookDetailUiState.Ready>(states.expectMostRecentItem())
+                assertTrue(ready.genresList.isEmpty())
+                states.cancel()
+            }
         }
 
     @Test
@@ -311,14 +360,20 @@ class BookDetailViewModelTest {
             // genreDao.observeGenresForBook already returns empty list from createFixture()
             val viewModel = fixture.build()
 
-            // When
-            viewModel.loadBook("book-1")
-            advanceUntilIdle()
+            turbineScope {
+                val states = viewModel.state.testIn(backgroundScope)
+                states.awaitItem() // initial Loading
 
-            // Then - book loads successfully despite genre failure
-            val ready = assertIs<BookDetailUiState.Ready>(viewModel.state.value)
-            assertEquals(book, ready.book)
-            assertTrue(ready.genresList.isEmpty())
+                // When
+                viewModel.loadBook("book-1")
+                advanceUntilIdle()
+
+                // Then - book loads successfully despite genre failure
+                val ready = assertIs<BookDetailUiState.Ready>(states.expectMostRecentItem())
+                assertEquals(book, ready.book)
+                assertTrue(ready.genresList.isEmpty())
+                states.cancel()
+            }
         }
 
     // ========== Progress Calculation Tests ==========
@@ -335,13 +390,19 @@ class BookDetailViewModelTest {
             everySuspend { fixture.playbackPositionRepository.get(any()) } returns position
             val viewModel = fixture.build()
 
-            // When
-            viewModel.loadBook("book-1")
-            advanceUntilIdle()
+            turbineScope {
+                val states = viewModel.state.testIn(backgroundScope)
+                states.awaitItem() // initial Loading
 
-            // Then - 30 min / 60 min = 0.5
-            val ready = assertIs<BookDetailUiState.Ready>(viewModel.state.value)
-            assertEquals(0.5f, ready.progress)
+                // When
+                viewModel.loadBook("book-1")
+                advanceUntilIdle()
+
+                // Then - 30 min / 60 min = 0.5
+                val ready = assertIs<BookDetailUiState.Ready>(states.expectMostRecentItem())
+                assertEquals(0.5f, ready.progress)
+                states.cancel()
+            }
         }
 
     @Test
@@ -355,13 +416,19 @@ class BookDetailViewModelTest {
             everySuspend { fixture.playbackPositionRepository.get(any()) } returns null
             val viewModel = fixture.build()
 
-            // When
-            viewModel.loadBook("book-1")
-            advanceUntilIdle()
+            turbineScope {
+                val states = viewModel.state.testIn(backgroundScope)
+                states.awaitItem() // initial Loading
 
-            // Then
-            val ready = assertIs<BookDetailUiState.Ready>(viewModel.state.value)
-            assertNull(ready.progress)
+                // When
+                viewModel.loadBook("book-1")
+                advanceUntilIdle()
+
+                // Then
+                val ready = assertIs<BookDetailUiState.Ready>(states.expectMostRecentItem())
+                assertNull(ready.progress)
+                states.cancel()
+            }
         }
 
     @Test
@@ -376,15 +443,21 @@ class BookDetailViewModelTest {
             everySuspend { fixture.playbackPositionRepository.get(any()) } returns position
             val viewModel = fixture.build()
 
-            // When
-            viewModel.loadBook("book-1")
-            advanceUntilIdle()
+            turbineScope {
+                val states = viewModel.state.testIn(backgroundScope)
+                states.awaitItem() // initial Loading
 
-            // Then - progress is shown based on position, hidden only when isFinished=true
-            val ready = assertIs<BookDetailUiState.Ready>(viewModel.state.value)
-            val progress = ready.progress
-            assertNotNull(progress)
-            assertEquals(0.99f, progress, 0.01f)
+                // When
+                viewModel.loadBook("book-1")
+                advanceUntilIdle()
+
+                // Then - progress is shown based on position, hidden only when isFinished=true
+                val ready = assertIs<BookDetailUiState.Ready>(states.expectMostRecentItem())
+                val progress = ready.progress
+                assertNotNull(progress)
+                assertEquals(0.99f, progress, 0.01f)
+                states.cancel()
+            }
         }
 
     // ========== Time Remaining Tests ==========
@@ -401,13 +474,19 @@ class BookDetailViewModelTest {
             everySuspend { fixture.playbackPositionRepository.get(any()) } returns position
             val viewModel = fixture.build()
 
-            // When
-            viewModel.loadBook("book-1")
-            advanceUntilIdle()
+            turbineScope {
+                val states = viewModel.state.testIn(backgroundScope)
+                states.awaitItem() // initial Loading
 
-            // Then - 2h 15m remaining
-            val ready = assertIs<BookDetailUiState.Ready>(viewModel.state.value)
-            assertEquals("2h 15m left", ready.timeRemainingFormatted)
+                // When
+                viewModel.loadBook("book-1")
+                advanceUntilIdle()
+
+                // Then - 2h 15m remaining
+                val ready = assertIs<BookDetailUiState.Ready>(states.expectMostRecentItem())
+                assertEquals("2h 15m left", ready.timeRemainingFormatted)
+                states.cancel()
+            }
         }
 
     @Test
@@ -422,13 +501,19 @@ class BookDetailViewModelTest {
             everySuspend { fixture.playbackPositionRepository.get(any()) } returns position
             val viewModel = fixture.build()
 
-            // When
-            viewModel.loadBook("book-1")
-            advanceUntilIdle()
+            turbineScope {
+                val states = viewModel.state.testIn(backgroundScope)
+                states.awaitItem() // initial Loading
 
-            // Then - 15m remaining
-            val ready = assertIs<BookDetailUiState.Ready>(viewModel.state.value)
-            assertEquals("15m left", ready.timeRemainingFormatted)
+                // When
+                viewModel.loadBook("book-1")
+                advanceUntilIdle()
+
+                // Then - 15m remaining
+                val ready = assertIs<BookDetailUiState.Ready>(states.expectMostRecentItem())
+                assertEquals("15m left", ready.timeRemainingFormatted)
+                states.cancel()
+            }
         }
 
     // ========== Tag Management Tests ==========
@@ -442,16 +527,24 @@ class BookDetailViewModelTest {
             everySuspend { fixture.bookRepository.getBook(any()) } returns book
             everySuspend { fixture.bookRepository.getChapters(any()) } returns emptyList()
             val viewModel = fixture.build()
-            viewModel.loadBook("book-1")
-            advanceUntilIdle()
-            assertFalse(assertIs<BookDetailUiState.Ready>(viewModel.state.value).showTagPicker)
 
-            // When
-            viewModel.showTagPicker()
+            turbineScope {
+                val states = viewModel.state.testIn(backgroundScope)
+                states.awaitItem() // initial Loading
 
-            // Then
-            val ready = assertIs<BookDetailUiState.Ready>(viewModel.state.value)
-            assertTrue(ready.showTagPicker)
+                viewModel.loadBook("book-1")
+                advanceUntilIdle()
+                assertFalse(assertIs<BookDetailUiState.Ready>(states.expectMostRecentItem()).showTagPicker)
+
+                // When
+                viewModel.showTagPicker()
+                advanceUntilIdle()
+
+                // Then
+                val ready = assertIs<BookDetailUiState.Ready>(states.expectMostRecentItem())
+                assertTrue(ready.showTagPicker)
+                states.cancel()
+            }
         }
 
     @Test
@@ -463,17 +556,26 @@ class BookDetailViewModelTest {
             everySuspend { fixture.bookRepository.getBook(any()) } returns book
             everySuspend { fixture.bookRepository.getChapters(any()) } returns emptyList()
             val viewModel = fixture.build()
-            viewModel.loadBook("book-1")
-            advanceUntilIdle()
-            viewModel.showTagPicker()
-            assertTrue(assertIs<BookDetailUiState.Ready>(viewModel.state.value).showTagPicker)
 
-            // When
-            viewModel.hideTagPicker()
+            turbineScope {
+                val states = viewModel.state.testIn(backgroundScope)
+                states.awaitItem() // initial Loading
 
-            // Then
-            val ready = assertIs<BookDetailUiState.Ready>(viewModel.state.value)
-            assertFalse(ready.showTagPicker)
+                viewModel.loadBook("book-1")
+                advanceUntilIdle()
+                viewModel.showTagPicker()
+                advanceUntilIdle()
+                assertTrue(assertIs<BookDetailUiState.Ready>(states.expectMostRecentItem()).showTagPicker)
+
+                // When
+                viewModel.hideTagPicker()
+                advanceUntilIdle()
+
+                // Then
+                val ready = assertIs<BookDetailUiState.Ready>(states.expectMostRecentItem())
+                assertFalse(ready.showTagPicker)
+                states.cancel()
+            }
         }
 
     @Test
@@ -497,15 +599,21 @@ class BookDetailViewModelTest {
             every { fixture.tagRepository.observeAll() } returns flowOf(allTags)
             val viewModel = fixture.build()
 
-            // When
-            viewModel.loadBook("book-1")
-            advanceUntilIdle()
+            turbineScope {
+                val states = viewModel.state.testIn(backgroundScope)
+                states.awaitItem() // initial Loading
 
-            // Then
-            val ready = assertIs<BookDetailUiState.Ready>(viewModel.state.value)
-            assertEquals(1, ready.tags.size)
-            assertEquals("Favorites", ready.tags[0].displayName())
-            assertEquals(2, ready.allTags.size)
+                // When
+                viewModel.loadBook("book-1")
+                advanceUntilIdle()
+
+                // Then
+                val ready = assertIs<BookDetailUiState.Ready>(states.expectMostRecentItem())
+                assertEquals(1, ready.tags.size)
+                assertEquals("Favorites", ready.tags[0].displayName())
+                assertEquals(2, ready.allTags.size)
+                states.cancel()
+            }
         }
 
     @Test
@@ -519,15 +627,23 @@ class BookDetailViewModelTest {
             everySuspend { fixture.bookRepository.getChapters(any()) } returns emptyList()
             everySuspend { fixture.tagRepository.addTagToBook(any(), any()) } returns tag
             val viewModel = fixture.build()
-            viewModel.loadBook("book-1")
-            advanceUntilIdle()
 
-            // When - addTag takes a slug
-            viewModel.addTag("favorites")
-            advanceUntilIdle()
+            turbineScope {
+                val states = viewModel.state.testIn(backgroundScope)
+                states.awaitItem() // initial Loading
 
-            // Then
-            verifySuspend { fixture.tagRepository.addTagToBook("book-1", "favorites") }
+                viewModel.loadBook("book-1")
+                advanceUntilIdle()
+                assertIs<BookDetailUiState.Ready>(states.expectMostRecentItem())
+
+                // When - addTag takes a slug
+                viewModel.addTag("favorites")
+                advanceUntilIdle()
+
+                // Then
+                verifySuspend { fixture.tagRepository.addTagToBook("book-1", "favorites") }
+                states.cancel()
+            }
         }
 
     @Test
@@ -543,15 +659,23 @@ class BookDetailViewModelTest {
             every { fixture.tagRepository.observeTagsForBook(any()) } returns flowOf(bookTags)
             everySuspend { fixture.tagRepository.removeTagFromBook(any(), any(), any()) } returns Unit
             val viewModel = fixture.build()
-            viewModel.loadBook("book-1")
-            advanceUntilIdle()
 
-            // When - removeTag takes a slug and finds tag ID from state
-            viewModel.removeTag("favorites")
-            advanceUntilIdle()
+            turbineScope {
+                val states = viewModel.state.testIn(backgroundScope)
+                states.awaitItem() // initial Loading
 
-            // Then
-            verifySuspend { fixture.tagRepository.removeTagFromBook("book-1", "favorites", "tag-1") }
+                viewModel.loadBook("book-1")
+                advanceUntilIdle()
+                assertIs<BookDetailUiState.Ready>(states.expectMostRecentItem())
+
+                // When - removeTag takes a slug and finds tag ID from state
+                viewModel.removeTag("favorites")
+                advanceUntilIdle()
+
+                // Then
+                verifySuspend { fixture.tagRepository.removeTagFromBook("book-1", "favorites", "tag-1") }
+                states.cancel()
+            }
         }
 
     @Test
@@ -565,18 +689,27 @@ class BookDetailViewModelTest {
             everySuspend { fixture.bookRepository.getChapters(any()) } returns emptyList()
             everySuspend { fixture.tagRepository.addTagToBook(any(), any()) } returns newTag
             val viewModel = fixture.build()
-            viewModel.loadBook("book-1")
-            advanceUntilIdle()
-            viewModel.showTagPicker()
 
-            // When - addNewTag sends raw input, server normalizes to slug
-            viewModel.addNewTag("New Tag")
-            advanceUntilIdle()
+            turbineScope {
+                val states = viewModel.state.testIn(backgroundScope)
+                states.awaitItem() // initial Loading
 
-            // Then
-            verifySuspend { fixture.tagRepository.addTagToBook("book-1", "New Tag") }
-            val ready = assertIs<BookDetailUiState.Ready>(viewModel.state.value)
-            assertFalse(ready.showTagPicker) // Picker should close
+                viewModel.loadBook("book-1")
+                advanceUntilIdle()
+                assertIs<BookDetailUiState.Ready>(states.expectMostRecentItem())
+                viewModel.showTagPicker()
+                advanceUntilIdle()
+
+                // When - addNewTag sends raw input, server normalizes to slug
+                viewModel.addNewTag("New Tag")
+                advanceUntilIdle()
+
+                // Then
+                verifySuspend { fixture.tagRepository.addTagToBook("book-1", "New Tag") }
+                val ready = assertIs<BookDetailUiState.Ready>(states.expectMostRecentItem())
+                assertFalse(ready.showTagPicker) // Picker should close
+                states.cancel()
+            }
         }
 
     @Test
@@ -586,12 +719,18 @@ class BookDetailViewModelTest {
             val fixture = createFixture()
             val viewModel = fixture.build()
 
-            // When - try to add tag without loading book
-            viewModel.addTag("tag-1")
-            advanceUntilIdle()
+            turbineScope {
+                val states = viewModel.state.testIn(backgroundScope)
+                val initial = states.awaitItem() // initial Loading
 
-            // Then - state stays Loading, no API calls made
-            assertIs<BookDetailUiState.Loading>(viewModel.state.value)
+                // When - try to add tag without loading book
+                viewModel.addTag("tag-1")
+                advanceUntilIdle()
+
+                // Then - state stays Loading, no API calls made
+                assertIs<BookDetailUiState.Loading>(initial)
+                states.cancel()
+            }
         }
 
     @Test
@@ -605,12 +744,48 @@ class BookDetailViewModelTest {
             // Tags come from Room via observeTagsForBook (already returns empty in createFixture)
             val viewModel = fixture.build()
 
-            // When
-            viewModel.loadBook("book-1")
-            advanceUntilIdle()
+            turbineScope {
+                val states = viewModel.state.testIn(backgroundScope)
+                states.awaitItem() // initial Loading
 
-            // Then - book loads successfully, tags are empty but no error
-            val ready = assertIs<BookDetailUiState.Ready>(viewModel.state.value)
-            assertEquals(book, ready.book)
+                // When
+                viewModel.loadBook("book-1")
+                advanceUntilIdle()
+
+                // Then - book loads successfully, tags are empty but no error
+                val ready = assertIs<BookDetailUiState.Ready>(states.expectMostRecentItem())
+                assertEquals(book, ready.book)
+                states.cancel()
+            }
+        }
+
+    // ========== Race Condition Tests ==========
+
+    @Test
+    fun `rapid loadBook calls for different bookIds emit one coherent sequence with no cross-book contamination`() =
+        runTest {
+            val fixture = createFixture()
+            val bookX = TestData.book(id = "book-X", title = "Book X")
+            val bookY = TestData.book(id = "book-Y", title = "Book Y")
+            everySuspend { fixture.bookRepository.getBook("book-X") } returns bookX
+            everySuspend { fixture.bookRepository.getBook("book-Y") } returns bookY
+            everySuspend { fixture.bookRepository.getChapters(any()) } returns emptyList()
+            val viewModel = fixture.build()
+
+            turbineScope {
+                val states = viewModel.state.testIn(backgroundScope)
+                states.awaitItem() // initial Loading
+
+                viewModel.loadBook("book-X")
+                viewModel.loadBook("book-Y")
+                advanceUntilIdle()
+
+                val final = states.expectMostRecentItem()
+                // flatMapLatest cancels book-X load when book-Y is requested.
+                // Final state must be Ready for book-Y, not contaminated by book-X.
+                assertTrue(final is BookDetailUiState.Ready)
+                assertEquals("book-Y", final.book.id.value)
+                states.cancel()
+            }
         }
 }

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/bookdetail/BookDetailViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/bookdetail/BookDetailViewModelTest.kt
@@ -13,6 +13,7 @@ import com.calypsan.listenup.client.domain.repository.TagRepository
 import com.calypsan.listenup.client.domain.repository.UserRepository
 import com.calypsan.listenup.client.domain.usecase.shelf.AddBooksToShelfUseCase
 import com.calypsan.listenup.client.domain.usecase.shelf.CreateShelfUseCase
+import dev.mokkery.answering.calls
 import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.everySuspend
@@ -21,6 +22,7 @@ import dev.mokkery.mock
 import dev.mokkery.verifySuspend
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -767,7 +769,15 @@ class BookDetailViewModelTest {
             val fixture = createFixture()
             val bookX = TestData.book(id = "book-X", title = "Book X")
             val bookY = TestData.book(id = "book-Y", title = "Book Y")
-            everySuspend { fixture.bookRepository.getBook("book-X") } returns bookX
+            // Force X-load to suspend so Y can cancel it mid-flight via flatMapLatest.
+            // Without the delay, Mokkery returns synchronously and MutableStateFlow
+            // conflation means the X-load may never start — flatMapLatest cancellation
+            // is not exercised. With delay(1_000) the X-load is in-flight when
+            // loadBook("book-Y") fires; advanceUntilIdle() lets Y win and cancel X.
+            everySuspend { fixture.bookRepository.getBook("book-X") } calls {
+                delay(1_000)
+                bookX
+            }
             everySuspend { fixture.bookRepository.getBook("book-Y") } returns bookY
             everySuspend { fixture.bookRepository.getChapters(any()) } returns emptyList()
             val viewModel = fixture.build()
@@ -781,7 +791,7 @@ class BookDetailViewModelTest {
                 advanceUntilIdle()
 
                 val final = states.expectMostRecentItem()
-                // flatMapLatest cancels book-X load when book-Y is requested.
+                // flatMapLatest cancels the in-flight book-X load when book-Y is requested.
                 // Final state must be Ready for book-Y, not contaminated by book-X.
                 assertTrue(final is BookDetailUiState.Ready)
                 assertEquals("book-Y", final.book.id.value)

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/bookdetail/BookReadersViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/bookdetail/BookReadersViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.calypsan.listenup.client.presentation.bookdetail
 
+import app.cash.turbine.turbineScope
 import com.calypsan.listenup.client.core.UserId
 import com.calypsan.listenup.client.domain.model.BookEvent
 import com.calypsan.listenup.client.domain.model.BookReadersResult
@@ -23,6 +24,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -45,6 +47,9 @@ import kotlin.test.assertTrue
  * - Repository flow throws → Error state with the thrown message
  * - `observeReaders(sameBookId)` is a no-op when already active
  * - `refresh(bookId)` delegates to `SessionRepository.refreshBookReaders`
+ * - Rapid book-switch emits one coherent sequence without cross-contamination
+ * - SSE event for current book triggers debounced refresh
+ * - SSE event for non-current book does not trigger refresh
  *
  * Uses Mokkery for mocking `SessionRepository`, `EventStreamRepository`, and `UserRepository`.
  */
@@ -164,8 +169,14 @@ class BookReadersViewModelTest {
             // When - viewModel created, observeReaders NOT called
             val viewModel = fixture.build()
 
-            // Then - state is Loading
-            assertIs<BookReadersUiState.Loading>(viewModel.state.value)
+            turbineScope {
+                val states = viewModel.state.testIn(backgroundScope)
+                val initial = states.awaitItem()
+
+                // Then - state is Loading
+                assertIs<BookReadersUiState.Loading>(initial)
+                states.cancel()
+            }
         }
 
     // ========== Reactive Observation ==========
@@ -186,22 +197,28 @@ class BookReadersViewModelTest {
                 )
             val viewModel = fixture.build()
 
-            // When
-            viewModel.observeReaders(BOOK_ID)
-            advanceUntilIdle()
+            turbineScope {
+                val states = viewModel.state.testIn(backgroundScope)
+                states.awaitItem() // initial Loading
 
-            // Then
-            val ready = assertIs<BookReadersUiState.Ready>(viewModel.state.value)
-            assertEquals(listOf(session), ready.yourSessions)
-            assertEquals(listOf(other), ready.otherReaders)
-            assertEquals(2, ready.totalReaders)
-            assertEquals(1, ready.totalCompletions)
-            // Current user info built from sessions + profile
-            val currentUserInfo = ready.currentUserReaderInfo
-            assertNotNull(currentUserInfo)
-            assertEquals("user-1", currentUserInfo.userId)
-            assertTrue(ready.hasYourHistory)
-            assertTrue(ready.hasOtherReaders)
+                // When
+                viewModel.observeReaders(BOOK_ID)
+                advanceUntilIdle()
+
+                // Then
+                val ready = assertIs<BookReadersUiState.Ready>(states.expectMostRecentItem())
+                assertEquals(listOf(session), ready.yourSessions)
+                assertEquals(listOf(other), ready.otherReaders)
+                assertEquals(2, ready.totalReaders)
+                assertEquals(1, ready.totalCompletions)
+                // Current user info built from sessions + profile
+                val currentUserInfo = ready.currentUserReaderInfo
+                assertNotNull(currentUserInfo)
+                assertEquals("user-1", currentUserInfo.userId)
+                assertTrue(ready.hasYourHistory)
+                assertTrue(ready.hasOtherReaders)
+                states.cancel()
+            }
         }
 
     @Test
@@ -211,14 +228,20 @@ class BookReadersViewModelTest {
             val fixture = createFixture()
             val viewModel = fixture.build()
 
-            // When
-            viewModel.observeReaders(BOOK_ID)
-            advanceUntilIdle()
+            turbineScope {
+                val states = viewModel.state.testIn(backgroundScope)
+                states.awaitItem() // initial Loading
 
-            // Then
-            val ready = assertIs<BookReadersUiState.Ready>(viewModel.state.value)
-            assertTrue(ready.isEmpty)
-            assertEquals(emptyList(), ready.allReaders)
+                // When
+                viewModel.observeReaders(BOOK_ID)
+                advanceUntilIdle()
+
+                // Then
+                val ready = assertIs<BookReadersUiState.Ready>(states.expectMostRecentItem())
+                assertTrue(ready.isEmpty)
+                assertEquals(emptyList(), ready.allReaders)
+                states.cancel()
+            }
         }
 
     // ========== Error Handling ==========
@@ -238,13 +261,19 @@ class BookReadersViewModelTest {
 
             val viewModel = fixture.build()
 
-            // When
-            viewModel.observeReaders(BOOK_ID)
-            advanceUntilIdle()
+            turbineScope {
+                val states = viewModel.state.testIn(backgroundScope)
+                states.awaitItem() // initial Loading
 
-            // Then
-            val err = assertIs<BookReadersUiState.Error>(viewModel.state.value)
-            assertEquals("boom", err.message)
+                // When
+                viewModel.observeReaders(BOOK_ID)
+                advanceUntilIdle()
+
+                // Then
+                val err = assertIs<BookReadersUiState.Error>(states.expectMostRecentItem())
+                assertEquals("boom", err.message)
+                states.cancel()
+            }
         }
 
     // ========== Observation Gating ==========
@@ -256,14 +285,21 @@ class BookReadersViewModelTest {
             val fixture = createFixture()
             val viewModel = fixture.build()
 
-            // When - call twice with the same book id
-            viewModel.observeReaders(BOOK_ID)
-            advanceUntilIdle()
-            viewModel.observeReaders(BOOK_ID)
-            advanceUntilIdle()
+            turbineScope {
+                val states = viewModel.state.testIn(backgroundScope)
+                states.awaitItem() // initial Loading
 
-            // Then - repository observed only once
-            verify(VerifyMode.exactly(1)) { fixture.sessionRepository.observeBookReaders(BOOK_ID) }
+                // When - call twice with the same book id
+                viewModel.observeReaders(BOOK_ID)
+                advanceUntilIdle()
+                viewModel.observeReaders(BOOK_ID)
+                advanceUntilIdle()
+
+                // Then - repository observed only once (MutableStateFlow idempotency)
+                verify(VerifyMode.exactly(1)) { fixture.sessionRepository.observeBookReaders(BOOK_ID) }
+                states.expectMostRecentItem() // drain emitted Ready before cancel
+                states.cancel()
+            }
         }
 
     // ========== Refresh ==========
@@ -275,11 +311,140 @@ class BookReadersViewModelTest {
             val fixture = createFixture()
             val viewModel = fixture.build()
 
-            // When
-            viewModel.refresh(BOOK_ID)
-            advanceUntilIdle()
+            turbineScope {
+                val states = viewModel.state.testIn(backgroundScope)
+                states.awaitItem() // initial Loading
 
-            // Then
-            verifySuspend { fixture.sessionRepository.refreshBookReaders(BOOK_ID) }
+                // When
+                viewModel.refresh(BOOK_ID)
+                advanceUntilIdle()
+
+                // Then
+                verifySuspend { fixture.sessionRepository.refreshBookReaders(BOOK_ID) }
+                states.cancel()
+            }
+        }
+
+    // ========== Race Condition Tests ==========
+
+    @Test
+    fun `rapid book-switch emits one coherent sequence without cross-contamination`() =
+        runTest {
+            val fixture = createFixture()
+            val resultX =
+                BookReadersResult(
+                    yourSessions = emptyList(),
+                    otherReaders = listOf(createReader(userId = "x-reader")),
+                    totalReaders = 1,
+                    totalCompletions = 0,
+                )
+            val resultY =
+                BookReadersResult(
+                    yourSessions = emptyList(),
+                    otherReaders = listOf(createReader(userId = "y-reader"), createReader(userId = "y-reader-2")),
+                    totalReaders = 2,
+                    totalCompletions = 0,
+                )
+            val flowX = MutableStateFlow(resultX)
+            val flowY = MutableStateFlow(resultY)
+            every { fixture.sessionRepository.observeBookReaders("book-X") } returns flowX
+            every { fixture.sessionRepository.observeBookReaders("book-Y") } returns flowY
+
+            val vm = fixture.build()
+
+            turbineScope {
+                val states = vm.state.testIn(backgroundScope)
+                states.awaitItem() // initial Loading
+
+                vm.observeReaders("book-X")
+                advanceUntilIdle()
+                val xState = states.expectMostRecentItem()
+                assertTrue(xState is BookReadersUiState.Ready)
+                assertEquals(1, xState.totalReaders)
+
+                vm.observeReaders("book-Y")
+                advanceUntilIdle()
+                val yState = states.expectMostRecentItem()
+                assertTrue(yState is BookReadersUiState.Ready)
+                // Y-specific assertion: 2 readers, not 1 from X
+                assertEquals(2, yState.totalReaders)
+
+                states.cancel()
+            }
+        }
+
+    // ========== SSE Tests ==========
+
+    @Test
+    fun `SSE event for current book triggers debounced refresh`() =
+        runTest {
+            val fixture = createFixture()
+            val vm = fixture.build()
+
+            turbineScope {
+                val states = vm.state.testIn(backgroundScope)
+                states.awaitItem() // initial Loading
+
+                vm.observeReaders("book-X")
+                advanceUntilIdle()
+                states.expectMostRecentItem() // consume Ready
+
+                // Emit an SSE event for book-X
+                fixture.bookEvents.emit(
+                    BookEvent.ReadingSessionUpdated(
+                        sessionId = "session-1",
+                        bookId = "book-X",
+                        isCompleted = false,
+                        listenTimeMs = 0L,
+                        finishedAt = null,
+                    ),
+                )
+
+                // Advance past the 2-second debounce
+                advanceTimeBy(2_500)
+                advanceUntilIdle()
+
+                verifySuspend(mode = VerifyMode.atLeast(1)) {
+                    fixture.sessionRepository.refreshBookReaders("book-X")
+                }
+
+                states.cancel()
+            }
+        }
+
+    @Test
+    fun `SSE event for non-current book does not trigger refresh`() =
+        runTest {
+            val fixture = createFixture()
+            val vm = fixture.build()
+
+            turbineScope {
+                val states = vm.state.testIn(backgroundScope)
+                states.awaitItem() // initial Loading
+
+                vm.observeReaders("book-X")
+                advanceUntilIdle()
+                states.expectMostRecentItem() // consume Ready
+
+                // Emit an SSE event for a DIFFERENT book (book-Y) while VM is observing book-X
+                fixture.bookEvents.emit(
+                    BookEvent.ReadingSessionUpdated(
+                        sessionId = "session-2",
+                        bookId = "book-Y",
+                        isCompleted = false,
+                        listenTimeMs = 0L,
+                        finishedAt = null,
+                    ),
+                )
+
+                advanceTimeBy(3_000)
+                advanceUntilIdle()
+
+                verifySuspend(mode = VerifyMode.not) {
+                    fixture.sessionRepository.refreshBookReaders("book-Y")
+                }
+
+                states.cancel()
+            }
         }
 }

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/SessionRepositoryImplTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/SessionRepositoryImplTest.kt
@@ -1,0 +1,314 @@
+package com.calypsan.listenup.client.data.repository
+
+import app.cash.turbine.turbineScope
+import com.calypsan.listenup.client.core.BookId
+import com.calypsan.listenup.client.core.Success
+import com.calypsan.listenup.client.core.Timestamp
+import com.calypsan.listenup.client.data.local.db.BookEntity
+import com.calypsan.listenup.client.data.local.db.BookReadersSummaryDao
+import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
+import com.calypsan.listenup.client.data.local.db.RoomTransactionRunner
+import com.calypsan.listenup.client.data.local.db.SyncState
+import com.calypsan.listenup.client.data.local.db.TransactionRunner
+import com.calypsan.listenup.client.data.remote.BookReadersResponse
+import com.calypsan.listenup.client.data.remote.ReaderSummary
+import com.calypsan.listenup.client.data.remote.SessionApiContract
+import com.calypsan.listenup.client.data.remote.SessionSummary as RemoteSessionSummary
+import com.calypsan.listenup.client.domain.repository.AuthSession
+import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
+import dev.mokkery.answering.returns
+import dev.mokkery.answering.throws
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.test.runTest
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * Seam-level tests for [SessionRepositoryImpl]. Uses real in-memory [ListenUpDatabase]
+ * with real DAOs; mocks [SessionApiContract] and [AuthSession] so the repository's
+ * transaction and flow-composition behaviour is exercised end-to-end.
+ *
+ * Covers Bug 1's fix (authoritative totalReaders from the summary DAO) + the
+ * refactored `observeBookReaders` shape (combine + onStart, no channelFlow).
+ */
+class SessionRepositoryImplTest {
+    private val db: ListenUpDatabase = createInMemoryTestDatabase()
+    private val transactionRunner = RoomTransactionRunner(db)
+    private val sessionApi: SessionApiContract = mock()
+    private val authSession: AuthSession = mock()
+
+    private val repo =
+        SessionRepositoryImpl(
+            sessionApi = sessionApi,
+            userReadingSessionDao = db.userReadingSessionDao(),
+            readerSessionCacheDao = db.readerSessionCacheDao(),
+            bookReadersSummaryDao = db.bookReadersSummaryDao(),
+            transactionRunner = transactionRunner,
+            authSession = authSession,
+        )
+
+    private val userId = "user-1"
+    private val bookId = "book-1"
+
+    @AfterTest
+    fun tearDown() {
+        db.close()
+    }
+
+    private suspend fun seedBook() {
+        db.bookDao().upsertAll(
+            listOf(
+                BookEntity(
+                    id = BookId(bookId),
+                    title = "Test Book",
+                    subtitle = null,
+                    coverUrl = null,
+                    totalDuration = 3_600_000L,
+                    description = null,
+                    publishYear = null,
+                    dominantColor = null,
+                    darkMutedColor = null,
+                    vibrantColor = null,
+                    createdAt = Timestamp(1_700_000_000_000L),
+                    updatedAt = Timestamp(1_700_000_000_000L),
+                    syncState = SyncState.SYNCED,
+                    lastModified = Timestamp(1_700_000_000_000L),
+                    serverVersion = Timestamp(1_700_000_000_000L),
+                ),
+            ),
+        )
+    }
+
+    private fun mockApiResponse(
+        totalReaders: Int,
+        totalCompletions: Int,
+        yourSessions: List<RemoteSessionSummary> = emptyList(),
+        otherReaders: List<ReaderSummary> = emptyList(),
+    ) {
+        everySuspend { sessionApi.getBookReaders(bookId) } returns
+            Success(
+                BookReadersResponse(
+                    yourSessions = yourSessions,
+                    otherReaders = otherReaders,
+                    totalReaders = totalReaders,
+                    totalCompletions = totalCompletions,
+                ),
+            )
+    }
+
+    @Test
+    fun `observeBookReaders emits empty-cache Result on first subscription before refresh lands`() =
+        runTest {
+            seedBook()
+            everySuspend { authSession.getUserId() } returns userId
+            mockApiResponse(totalReaders = 0, totalCompletions = 0)
+
+            turbineScope {
+                val turbine = repo.observeBookReaders(bookId).testIn(backgroundScope)
+                val first = turbine.awaitItem()
+                assertEquals(0, first.totalReaders)
+                assertEquals(0, first.totalCompletions)
+                assertTrue(first.yourSessions.isEmpty())
+                assertTrue(first.otherReaders.isEmpty())
+                turbine.cancel()
+            }
+        }
+
+    @Test
+    fun `onStart triggers refresh which populates all three tables`() =
+        runTest {
+            seedBook()
+            everySuspend { authSession.getUserId() } returns userId
+            mockApiResponse(totalReaders = 42, totalCompletions = 7)
+
+            turbineScope {
+                val turbine = repo.observeBookReaders(bookId).testIn(backgroundScope)
+                var result = turbine.awaitItem()
+                while (result.totalReaders == 0) {
+                    result = turbine.awaitItem()
+                }
+                assertEquals(42, result.totalReaders)
+                assertEquals(7, result.totalCompletions)
+                turbine.cancel()
+            }
+        }
+
+    @Test
+    fun `refresh network failure logs and continues emitting from cache`() =
+        runTest {
+            seedBook()
+            everySuspend { authSession.getUserId() } returns userId
+            everySuspend { sessionApi.getBookReaders(bookId) } throws RuntimeException("network boom")
+
+            turbineScope {
+                val turbine = repo.observeBookReaders(bookId).testIn(backgroundScope)
+                val first = turbine.awaitItem()
+                assertEquals(0, first.totalReaders)
+                turbine.cancel()
+            }
+        }
+
+    @Test
+    fun `totalReaders reflects API response value not derived cache count`() =
+        runTest {
+            // Canonical Bug 1 regression test.
+            seedBook()
+            everySuspend { authSession.getUserId() } returns userId
+            // API says totalReaders=42 but only 1 other reader in the response payload.
+            // Result must show 42, not 2 (derived = 1 cache + 1 user).
+            val otherReader =
+                ReaderSummary(
+                    userId = "other-1",
+                    displayName = "Other 1",
+                    avatarType = "initials",
+                    avatarValue = "O1",
+                    avatarColor = "#fff",
+                    isCurrentlyReading = true,
+                    currentProgress = 0.5,
+                    startedAt = "2026-04-01T00:00:00Z",
+                    finishedAt = null,
+                    lastActivityAt = "2026-04-20T00:00:00Z",
+                    completionCount = 0,
+                )
+            mockApiResponse(totalReaders = 42, totalCompletions = 15, otherReaders = listOf(otherReader))
+
+            turbineScope {
+                val turbine = repo.observeBookReaders(bookId).testIn(backgroundScope)
+                var result = turbine.awaitItem()
+                while (result.totalReaders == 0) {
+                    result = turbine.awaitItem()
+                }
+                assertEquals(42, result.totalReaders, "must use API's authoritative count, not derived from cache")
+                assertEquals(15, result.totalCompletions)
+                turbine.cancel()
+            }
+        }
+
+    @Test
+    fun `self-emission path reads from user_reading_sessions not from cache`() =
+        runTest {
+            // The API returns one yourSessions entry. After onStart refresh, the
+            // user_reading_sessions table is populated from the API response and
+            // combine emits it via the userFlow path (not via readerSessionCacheDao).
+            seedBook()
+            everySuspend { authSession.getUserId() } returns userId
+
+            val apiSession =
+                RemoteSessionSummary(
+                    id = "user-session-marker",
+                    startedAt = "2026-04-01T00:00:00Z",
+                    finishedAt = null,
+                    isCompleted = false,
+                    listenTimeMs = 300_000L,
+                )
+            mockApiResponse(
+                totalReaders = 1,
+                totalCompletions = 0,
+                yourSessions = listOf(apiSession),
+            )
+
+            turbineScope {
+                val turbine = repo.observeBookReaders(bookId).testIn(backgroundScope)
+                var result = turbine.awaitItem()
+                while (result.yourSessions.isEmpty()) {
+                    result = turbine.awaitItem()
+                }
+                assertEquals(1, result.yourSessions.size)
+                assertEquals("user-session-marker", result.yourSessions.first().id)
+                turbine.cancel()
+            }
+        }
+
+    @Test
+    fun `refresh DB transaction rollback on late-step throw`() =
+        runTest {
+            seedBook()
+            everySuspend { authSession.getUserId() } returns userId
+            mockApiResponse(totalReaders = 5, totalCompletions = 2)
+
+            val failingSummaryDao: BookReadersSummaryDao = mock()
+            everySuspend { failingSummaryDao.upsert(any()) } throws RuntimeException("simulated mid-transaction failure")
+
+            val repoWithFailingDao =
+                SessionRepositoryImpl(
+                    sessionApi = sessionApi,
+                    userReadingSessionDao = db.userReadingSessionDao(),
+                    readerSessionCacheDao = db.readerSessionCacheDao(),
+                    bookReadersSummaryDao = failingSummaryDao,
+                    transactionRunner = transactionRunner,
+                    authSession = authSession,
+                )
+
+            assertFailsWith<RuntimeException> {
+                repoWithFailingDao.refreshBookReaders(bookId)
+            }
+
+            assertTrue(db.userReadingSessionDao().getForBook(bookId, userId).isEmpty(), "user-session rows must roll back")
+            assertTrue(
+                db.readerSessionCacheDao().getForBook(bookId, excludingUserId = userId).isEmpty(),
+                "reader-cache rows must roll back",
+            )
+        }
+
+    @Test
+    fun `10 concurrent refreshBookReaders calls complete without deadlock and final state matches last response`() =
+        runTest {
+            seedBook()
+            everySuspend { authSession.getUserId() } returns userId
+            mockApiResponse(totalReaders = 99, totalCompletions = 42)
+
+            (1..10)
+                .map {
+                    async { repo.refreshBookReaders(bookId) }
+                }.awaitAll()
+
+            val summaryFlow = db.bookReadersSummaryDao().observeFor(BookId(bookId))
+            turbineScope {
+                val t = summaryFlow.testIn(backgroundScope)
+                var summary = t.awaitItem()
+                while (summary == null) {
+                    summary = t.awaitItem()
+                }
+                assertEquals(99, summary.totalReaders)
+                t.cancel()
+            }
+        }
+
+    @Test
+    fun `refresh writes all three tables in one transaction`() =
+        runTest {
+            seedBook()
+            everySuspend { authSession.getUserId() } returns userId
+            mockApiResponse(totalReaders = 3, totalCompletions = 1)
+
+            var atomicallyCallCount = 0
+            val countingRunner =
+                object : TransactionRunner {
+                    override suspend fun <R> atomically(block: suspend () -> R): R {
+                        atomicallyCallCount++
+                        return transactionRunner.atomically(block)
+                    }
+                }
+
+            val repoWithCounter =
+                SessionRepositoryImpl(
+                    sessionApi = sessionApi,
+                    userReadingSessionDao = db.userReadingSessionDao(),
+                    readerSessionCacheDao = db.readerSessionCacheDao(),
+                    bookReadersSummaryDao = db.bookReadersSummaryDao(),
+                    transactionRunner = countingRunner,
+                    authSession = authSession,
+                )
+
+            repoWithCounter.refreshBookReaders(bookId)
+
+            assertEquals(1, atomicallyCallCount, "refreshBookReaders must use exactly one atomically block")
+        }
+}

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/SessionRepositoryImplTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/SessionRepositoryImplTest.kt
@@ -1,9 +1,12 @@
 package com.calypsan.listenup.client.data.repository
 
+import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.turbineScope
 import com.calypsan.listenup.client.core.BookId
+import com.calypsan.listenup.client.core.Failure
 import com.calypsan.listenup.client.core.Success
 import com.calypsan.listenup.client.core.Timestamp
+import com.calypsan.listenup.client.core.error.NetworkError
 import com.calypsan.listenup.client.data.local.db.BookEntity
 import com.calypsan.listenup.client.data.local.db.BookReadersSummaryDao
 import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
@@ -21,14 +24,33 @@ import dev.mokkery.answering.throws
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
+
+/**
+ * Awaits emissions from this turbine until [predicate] returns true, or fails after [maxAttempts].
+ * Protects against indefinite hangs when Room invalidation timing diverges from expectations.
+ */
+private suspend fun <T> ReceiveTurbine<T>.awaitUntil(
+    maxAttempts: Int = 10,
+    predicate: (T) -> Boolean,
+): T {
+    repeat(maxAttempts) {
+        val item = awaitItem()
+        if (predicate(item)) return item
+    }
+    error("Predicate never satisfied within $maxAttempts emissions")
+}
 
 /**
  * Seam-level tests for [SessionRepositoryImpl]. Uses real in-memory [ListenUpDatabase]
@@ -130,10 +152,7 @@ class SessionRepositoryImplTest {
 
             turbineScope {
                 val turbine = repo.observeBookReaders(bookId).testIn(backgroundScope)
-                var result = turbine.awaitItem()
-                while (result.totalReaders == 0) {
-                    result = turbine.awaitItem()
-                }
+                val result = turbine.awaitUntil { it.totalReaders > 0 }
                 assertEquals(42, result.totalReaders)
                 assertEquals(7, result.totalCompletions)
                 turbine.cancel()
@@ -153,6 +172,33 @@ class SessionRepositoryImplTest {
                 assertEquals(0, first.totalReaders)
                 turbine.cancel()
             }
+        }
+
+    @Test
+    fun `refresh returning AppResult Failure logs and continues emitting from cache`() =
+        runTest {
+            seedBook()
+            everySuspend { authSession.getUserId() } returns userId
+            // API returns a typed Failure instead of throwing — exercises the `is Failure ->` branch
+            // at lines 163-165 of SessionRepositoryImpl (logs, returns without writing to DB).
+            everySuspend { sessionApi.getBookReaders(bookId) } returns
+                Failure(NetworkError(message = "simulated failure"))
+
+            turbineScope {
+                val turbine = repo.observeBookReaders(bookId).testIn(backgroundScope)
+                val first = turbine.awaitItem()
+                assertEquals(0, first.totalReaders)
+                // No exception surfaces; no summary row created
+                turbine.cancel()
+            }
+
+            // Assert no summary row was written
+            val summary =
+                db
+                    .bookReadersSummaryDao()
+                    .observeFor(BookId(bookId))
+                    .first()
+            assertNull(summary, "Failure branch must not write a summary row")
         }
 
     @Test
@@ -181,10 +227,7 @@ class SessionRepositoryImplTest {
 
             turbineScope {
                 val turbine = repo.observeBookReaders(bookId).testIn(backgroundScope)
-                var result = turbine.awaitItem()
-                while (result.totalReaders == 0) {
-                    result = turbine.awaitItem()
-                }
+                val result = turbine.awaitUntil { it.totalReaders > 0 }
                 assertEquals(42, result.totalReaders, "must use API's authoritative count, not derived from cache")
                 assertEquals(15, result.totalCompletions)
                 turbine.cancel()
@@ -216,10 +259,7 @@ class SessionRepositoryImplTest {
 
             turbineScope {
                 val turbine = repo.observeBookReaders(bookId).testIn(backgroundScope)
-                var result = turbine.awaitItem()
-                while (result.yourSessions.isEmpty()) {
-                    result = turbine.awaitItem()
-                }
+                val result = turbine.awaitUntil { it.yourSessions.isNotEmpty() }
                 assertEquals(1, result.yourSessions.size)
                 assertEquals("user-session-marker", result.yourSessions.first().id)
                 turbine.cancel()
@@ -269,13 +309,14 @@ class SessionRepositoryImplTest {
                     async { repo.refreshBookReaders(bookId) }
                 }.awaitAll()
 
+            verifySuspend(VerifyMode.exactly(10)) {
+                sessionApi.getBookReaders(bookId)
+            }
+
             val summaryFlow = db.bookReadersSummaryDao().observeFor(BookId(bookId))
             turbineScope {
                 val t = summaryFlow.testIn(backgroundScope)
-                var summary = t.awaitItem()
-                while (summary == null) {
-                    summary = t.awaitItem()
-                }
+                val summary = t.awaitUntil { it != null }!!
                 assertEquals(99, summary.totalReaders)
                 t.cancel()
             }


### PR DESCRIPTION
## Summary

W6 Phase E. Eight commits resolving Finding 06 D1 (Bug 1 root cause — derived `totalReaders` + fire-and-forget refresh + imperative VM observe pattern).

**Canonical commits (4):**
- `495fe518` ✨ add `book_readers_summary` table for authoritative reader counts — additive schema (Room v10→v11).
- `31c5377b` ♻️ rewire `SessionRepositoryImpl` onto `combine + onStart`; persist authoritative `totalReaders` — main Bug 1 fix. New 9-test seam-level test file closes Finding 03 D2 gap.
- `82212583` ♻️ serialize `BookDetailViewModel.loadBook` via `bookIdFlow + flatMapLatest` — closes concurrent-load race; 22 tests migrated to T-R3 harness + 1 new race test.
- `e98e757b` ♻️ canonicalize `BookReadersViewModel` onto `flatMapLatest + stateIn` — manual `observeJob`/`sseJob` deleted; 6 tests migrated + 3 new (rapid book-switch, SSE trigger, SSE-not-for-non-current-book).

**Code-review follow-ups (4):**
- `dee595ef` 🎨 use `BookId` value class for `book_readers_summary` PK — type safety.
- `44a65676` 🚨 strengthen `SessionRepositoryImplTest` assertions — `awaitUntil` helper, `verifySuspend(exactly 10)`, `AppResult.Failure` branch test.
- `d843c755` 🎨 strengthen `BookDetailViewModel` race test + document `activeBookIdFlow` pattern — `delay(1_000)` in race-test forces `flatMapLatest` cancellation; 8-line pattern KDoc.
- `b1641473` 🎨 extract `SUBSCRIPTION_TIMEOUT_MS` const + document SSE `init` lifetime.

## Bug 1 on-device verification

**Status:** PENDING. Per parent spec Phase E handoff, open a book that has been read by multiple users, confirm the displayed `totalReaders` count matches the server-side count. If the count is off, Phase E has not closed — investigate before merging.

## Drift log (\`docs/architecture/w6-drift-log.md\`)

- Rows #1, #5, #6 remain Open, Phase-F-bound.
- **Row #7 (NEW — \`BookDetailViewModel.activeBookIdFlow\` pattern invariants)** — Open, Phase F-bound. Novel state-derived-flow-feeding-back-into-state pattern. Two loop-safety invariants are code-enforced but not type-enforced. Phase F VM-boundary audit should re-evaluate.
- **Row #8 (NEW — \`SessionRepositoryImpl.kt:1\` \`@file:Suppress(\"SwallowedException\")\`)** — Open, Phase F-bound. Main swallower removed in Phase E; legacy \`getBookReaders\` silent-\`emptyList()\` remains. Phase F component-ownership audit.
- Rows #2/#3/#4 Closed from prior phases.

## Reviewer notes

- **Bug 1 root-cause chain (Finding 06 D1):** all four drifts addressed. Derived-\`totalReaders\` deleted, \`channelFlow { launch }\` deleted, imperative VM observe gone, \`BookDetailViewModel.loadBook\` race closed.
- **Plan audit A11 deviation (\`activeBookIdFlow\`):** accepted as strict improvement — plan's simpler rewire would have silently introduced a tag/genre race. Documented with 8-line pattern KDoc + race-test strengthened to actually exercise \`flatMapLatest\` cancellation via \`delay(1_000)\` in the X-mock. Phase F may re-evaluate as part of full VM consolidation.
- **Transaction atomicity preserved:** summary upsert inside existing \`atomically { }\` block — pinned by counting-TransactionRunner test.
- **Android bump (\`c3efa6d9\`):** target 37, AGP 9.2, Gradle 9.4.1 landed on \`main\` before Phase E. Task 0 audit confirmed 5 Phase-E-relevant canonicals unchanged. Separate commit from Phase E work.
- Mandatory §M1 code-reviewer pass: **CLEAR (PASS)**. All 6 rubric rules (EM-R1, SE-R5, C6, P-R1, R-R1, T-R3) confirmed.

## Test plan

- [x] \`./gradlew :shared:jvmTest --no-daemon\` — green (9 new \`SessionRepositoryImplTest\` + 23 \`BookDetailViewModelTest\` + 9 \`BookReadersViewModelTest\`)
- [x] \`./gradlew spotlessCheck detekt --no-daemon\` — green
- [ ] **Bug 1 on-device verification** — pending (open multi-reader book, confirm displayed count matches server)
- [ ] \`Build APK\` expected red on \`AudiobookNotificationProvider\` Media3 baseline (W7 territory, accepted per \`restoration-roadmap.md\` → "Known Baseline Breakage")
- [ ] User approves handoff before Phase F brainstorming opens

## Plan + spec

- Plan (with end-of-phase state): \`docs/superpowers/plans/2026-04-21-w6-e-session-repo-vm-boundary.md\`
- Spec: \`docs/superpowers/specs/2026-04-21-w6-e-session-repo-vm-boundary-design.md\`