### PR TITLE
W6 Phase F — SSoT + mapper test + N+1 + ownership triage + dead code + Shelf pending-op

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/MainActivity.kt
@@ -66,7 +66,6 @@ import com.calypsan.listenup.client.core.Failure
  * - Auto-reconnects on app resume
  *
  * Handles deep links for invite URLs:
- * - https://server.com/join/{code} (App Links)
  * - listenup://join?server=...&code=... (custom scheme)
  *
  * This ensures real-time updates when actively using the app
@@ -108,7 +107,7 @@ class MainActivity : ComponentActivity() {
      * Parses and stores deep link or shortcut action for navigation layer to consume.
      *
      * Handles:
-     * - Invite deep links (listenup://join, https://.../join/...)
+     * - Invite deep links (listenup://join)
      * - App shortcut actions (RESUME, PLAY_BOOK, SEARCH, SLEEP_TIMER)
      */
     private fun handleIntent(intent: Intent?) {

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/deeplink/DeepLinkParser.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/deeplink/DeepLinkParser.kt
@@ -16,23 +16,13 @@ data class BookDeepLink(
 /**
  * Parses deep link intents into structured data.
  *
- * Handles two types of invite URLs:
- *
- * 1. HTTPS App Links (verified domain):
- *    https://audiobooks.example.com/join/ABC123
- *    - Requires assetlinks.json verification
- *    - Opens directly in app if verified
- *
- * 2. Custom scheme (fallback):
- *    listenup://join?server=https://audiobooks.example.com&code=ABC123
- *    - Always opens in app
- *    - Used as fallback when App Links don't work
+ * Handles custom scheme deep links:
+ * listenup://join?server=https://audiobooks.example.com&code=ABC123
  */
 object DeepLinkParser {
     private const val CUSTOM_SCHEME = "listenup"
     private const val JOIN_HOST = "join"
     private const val BOOK_HOST = "book"
-    private const val JOIN_PATH_PREFIX = "/join/"
 
     /**
      * Parses an intent into an InviteDeepLink if it contains a valid invite URL.
@@ -63,20 +53,13 @@ object DeepLinkParser {
     /**
      * Parses a URI into an InviteDeepLink.
      *
-     * Handles:
-     * - https://server.com/join/CODE
-     * - http://server.com/join/CODE (for local dev)
-     * - listenup://join?server=URL&code=CODE
+     * Handles: listenup://join?server=URL&code=CODE
      *
      * @param uri The deep link URI
      * @return Parsed invite data, or null if not a valid invite URL
      */
     fun parseUri(uri: Uri): InviteDeepLink? =
-        when (uri.scheme?.lowercase()) {
-            CUSTOM_SCHEME -> parseCustomScheme(uri)
-            "https", "http" -> parseHttpsScheme(uri)
-            else -> null
-        }
+        if (uri.scheme?.lowercase() == CUSTOM_SCHEME) parseCustomScheme(uri) else null
 
     /**
      * Parses custom scheme: listenup://join?server=URL&code=CODE
@@ -94,62 +77,4 @@ object DeepLinkParser {
             code = code,
         )
     }
-
-    /**
-     * Parses HTTPS scheme: https://server.com/join/CODE
-     *
-     * Extracts:
-     * - Server URL from scheme + host + port
-     * - Invite code from path after /join/
-     */
-    private fun parseHttpsScheme(uri: Uri): InviteDeepLink? {
-        val path = uri.path ?: return null
-
-        // Must start with /join/
-        if (!path.startsWith(JOIN_PATH_PREFIX)) return null
-
-        // Extract code from path
-        val code = path.removePrefix(JOIN_PATH_PREFIX).takeIf { it.isNotBlank() } ?: return null
-
-        // Build server URL (scheme + host + optional port)
-        val serverUrl = buildServerUrl(uri) ?: return null
-
-        return InviteDeepLink(
-            serverUrl = serverUrl,
-            code = code,
-        )
-    }
-
-    /**
-     * Builds the server base URL from a URI.
-     * Includes scheme, host, and port (if non-standard).
-     */
-    private fun buildServerUrl(uri: Uri): String? {
-        val scheme = uri.scheme ?: return null
-        val host = uri.host ?: return null
-        val port = uri.port
-
-        return buildString {
-            append(scheme)
-            append("://")
-            append(host)
-            if (port != -1 && !isStandardPort(scheme, port)) {
-                append(":")
-                append(port)
-            }
-        }
-    }
-
-    /**
-     * Checks if the port is the standard port for the scheme.
-     */
-    private fun isStandardPort(
-        scheme: String,
-        port: Int,
-    ): Boolean =
-        when (scheme.lowercase()) {
-            "https" -> port == 443
-            "http" -> port == 80
-            else -> false
-        }
 }

--- a/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/components/BookReadersSection.kt
+++ b/composeApp/src/commonMain/kotlin/com/calypsan/listenup/client/features/bookdetail/components/BookReadersSection.kt
@@ -49,7 +49,7 @@ fun BookReadersSection(
     viewModel: BookReadersViewModel = koinViewModel(),
 ) {
     LaunchedEffect(bookId) {
-        viewModel.loadReaders(bookId)
+        viewModel.observeReaders(bookId)
     }
 
     val state by viewModel.state.collectAsStateWithLifecycle()

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/BookDao.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/BookDao.kt
@@ -339,15 +339,16 @@ interface BookDao {
     fun observeRecentlyAdded(limit: Int = 10): Flow<List<BookEntity>>
 
     /**
-     * Observe random books the user hasn't started.
-     * Excludes books with playback position > 0.
-     * Used for "Discover Something New" section.
+     * Observe random unstarted books that are either standalone or the first entry
+     * of a series.
      *
-     * Note: Uses SQLite RANDOM() which produces a new random set each query.
-     * Flow re-emits when books table changes, triggering new random selection.
+     * Applies a product-level filter: a book is included only if it has no
+     * `book_series` rows, or at least one of its rows has
+     * `sequence IN ('1', '0', '0.5')`. Mid-series entries are silently excluded —
+     * use [observeRandomUnstartedBooks] when you want the unfiltered set.
      *
      * @param limit Maximum number of books to return
-     * @return Flow emitting list of random unstarted books
+     * @return Flow emitting list of random unstarted standalone/first-in-series books
      */
     @Query(
         """
@@ -365,14 +366,38 @@ interface BookDao {
         LIMIT :limit
     """,
     )
+    fun observeRandomUnstartedBooksFirstInSeriesOnly(limit: Int = 10): Flow<List<BookEntity>>
+
+    /**
+     * Observe random unstarted books with no series-sequence filter.
+     *
+     * Neutral query: returns every unstarted book regardless of series position.
+     * Callers that specifically want the "first-in-series or standalone" product
+     * filter should use [observeRandomUnstartedBooksFirstInSeriesOnly] instead.
+     *
+     * @param limit Maximum number of books to return
+     * @return Flow emitting list of random unstarted books
+     */
+    @Query(
+        """
+        SELECT b.* FROM books b
+        LEFT JOIN playback_positions p ON b.id = p.bookId
+        WHERE (p.bookId IS NULL OR p.positionMs = 0)
+        ORDER BY RANDOM()
+        LIMIT :limit
+    """,
+    )
     fun observeRandomUnstartedBooks(limit: Int = 10): Flow<List<BookEntity>>
 
     /**
-     * Get a snapshot of random unstarted books (non-reactive).
-     * Useful for manual refresh without reactive updates.
+     * Get a snapshot of random unstarted books that are either standalone or the first
+     * entry of a series (non-reactive).
+     *
+     * Applies a product-level filter: only standalone or first-in-series books are
+     * returned. Use [getRandomUnstartedBooks] for the unfiltered set.
      *
      * @param limit Maximum number of books to return
-     * @return List of random unstarted books
+     * @return List of random unstarted standalone/first-in-series books
      */
     @Query(
         """
@@ -386,6 +411,27 @@ interface BookDao {
                 AND bs.sequence IN ('1', '0', '0.5')
             )
         )
+        ORDER BY RANDOM()
+        LIMIT :limit
+    """,
+    )
+    suspend fun getRandomUnstartedBooksFirstInSeriesOnly(limit: Int = 10): List<BookEntity>
+
+    /**
+     * Get a snapshot of random unstarted books with no series-sequence filter (non-reactive).
+     *
+     * Neutral query: returns every unstarted book regardless of series position.
+     * Callers that specifically want the "first-in-series or standalone" product
+     * filter should use [getRandomUnstartedBooksFirstInSeriesOnly] instead.
+     *
+     * @param limit Maximum number of books to return
+     * @return List of random unstarted books
+     */
+    @Query(
+        """
+        SELECT b.* FROM books b
+        LEFT JOIN playback_positions p ON b.id = p.bookId
+        WHERE (p.bookId IS NULL OR p.positionMs = 0)
         ORDER BY RANDOM()
         LIMIT :limit
     """,
@@ -459,11 +505,16 @@ interface BookDao {
     fun observeRecentlyAddedFirstInSeriesWithAuthor(limit: Int = 10): Flow<List<DiscoveryBookWithAuthor>>
 
     /**
-     * Observe random unstarted books with primary author.
-     * Used for "Discover Something New" section.
+     * Observe random unstarted books with primary author, restricted to standalone or
+     * first-in-series books.
+     *
+     * Applies a product-level filter: only books with no `book_series` rows, or at
+     * least one row with `sequence IN ('1', '0', '0.5')`, are included. Mid-series
+     * entries are silently excluded — use [observeRandomUnstartedBooksWithAuthor] for
+     * the unfiltered set.
      *
      * @param limit Maximum number of books to return
-     * @return Flow emitting list of random unstarted books with author
+     * @return Flow emitting list of random unstarted standalone/first-in-series books with author
      */
     @Query(
         """
@@ -485,6 +536,35 @@ interface BookDao {
                 AND bs.sequence IN ('1', '0', '0.5')
             )
         )
+        ORDER BY RANDOM()
+        LIMIT :limit
+    """,
+    )
+    fun observeRandomUnstartedBooksFirstInSeriesWithAuthor(limit: Int = 10): Flow<List<DiscoveryBookWithAuthor>>
+
+    /**
+     * Observe random unstarted books with primary author, with no series-sequence filter.
+     *
+     * Neutral query: returns every unstarted book regardless of series position.
+     * Callers that specifically want the "first-in-series or standalone" product
+     * filter should use [observeRandomUnstartedBooksFirstInSeriesWithAuthor] instead.
+     *
+     * @param limit Maximum number of books to return
+     * @return Flow emitting list of random unstarted books with author
+     */
+    @Query(
+        """
+        SELECT
+            b.id, b.title, b.coverBlurHash, b.createdAt,
+            (
+                SELECT c.name FROM book_contributors bc
+                INNER JOIN contributors c ON bc.contributorId = c.id
+                WHERE bc.bookId = b.id AND bc.role = 'author'
+                LIMIT 1
+            ) as authorName
+        FROM books b
+        LEFT JOIN playback_positions p ON b.id = p.bookId
+        WHERE (p.bookId IS NULL OR p.positionMs = 0)
         ORDER BY RANDOM()
         LIMIT :limit
     """,

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/PendingOperationEntity.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/local/db/PendingOperationEntity.kt
@@ -77,6 +77,13 @@ enum class OperationType {
 
     // Mark book as complete (retry on failure)
     MARK_COMPLETE,
+
+    // Shelf mutations (never coalesce - each is a discrete intent)
+    CREATE_SHELF,
+    UPDATE_SHELF,
+    DELETE_SHELF,
+    ADD_BOOKS_TO_SHELF,
+    REMOVE_BOOK_FROM_SHELF,
 }
 
 /**

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/AvatarDownloadRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/AvatarDownloadRepositoryImpl.kt
@@ -34,4 +34,28 @@ class AvatarDownloadRepositoryImpl(
             }
         }
     }
+
+    override fun queueAvatarForceRefresh(userId: String) {
+        scope.launch {
+            try {
+                imageDownloader.downloadUserAvatar(userId, forceRefresh = true)
+                logger.debug { "Force-refreshed avatar for user $userId" }
+            } catch (e: kotlin.coroutines.cancellation.CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                logger.warn(e) { "Failed to force-refresh avatar for user $userId" }
+            }
+        }
+    }
+
+    override suspend fun deleteAvatar(userId: String) {
+        try {
+            imageDownloader.deleteUserAvatar(userId)
+            logger.debug { "Deleted avatar for user $userId" }
+        } catch (e: kotlin.coroutines.cancellation.CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.warn(e) { "Failed to delete avatar for user $userId" }
+        }
+    }
 }

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/HomeRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/HomeRepositoryImpl.kt
@@ -72,11 +72,14 @@ class HomeRepositoryImpl(
         var booksNotFound = 0
         var booksFiltered = 0
 
+        val bookIds = positions.map { it.bookId.value }
+        val bookMap = bookRepository.getBooks(bookIds).associateBy { it.id.value }
+
         val books =
             positions.mapNotNull { position ->
                 val bookIdStr = position.bookId.value
                 val book =
-                    bookRepository.getBook(bookIdStr) ?: run {
+                    bookMap[bookIdStr] ?: run {
                         booksNotFound++
                         logger.warn { "Local fallback: book not found - id=$bookIdStr" }
                         return@mapNotNull null
@@ -157,9 +160,10 @@ class HomeRepositoryImpl(
                 }
             }.mapLatest { positions ->
                 val result = mutableListOf<ContinueListeningBook>()
+                val bookMap = bookRepository.getBooks(positions.map { it.bookId.value }).associateBy { it.id.value }
                 for (position in positions) {
                     val bookIdStr = position.bookId.value
-                    val book = bookRepository.getBook(bookIdStr) ?: continue
+                    val book = bookMap[bookIdStr] ?: continue
 
                     val effectivelyFinished =
                         book.duration > 0 && (

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/PendingOperationRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/PendingOperationRepositoryImpl.kt
@@ -75,6 +75,11 @@ private fun OperationType.toDomain(): PendingOperationType =
         OperationType.PROFILE_UPDATE -> PendingOperationType.PROFILE_UPDATE
         OperationType.PROFILE_AVATAR -> PendingOperationType.PROFILE_AVATAR
         OperationType.MARK_COMPLETE -> PendingOperationType.MARK_COMPLETE
+        OperationType.CREATE_SHELF -> PendingOperationType.CREATE_SHELF
+        OperationType.UPDATE_SHELF -> PendingOperationType.UPDATE_SHELF
+        OperationType.DELETE_SHELF -> PendingOperationType.DELETE_SHELF
+        OperationType.ADD_BOOKS_TO_SHELF -> PendingOperationType.ADD_BOOKS_TO_SHELF
+        OperationType.REMOVE_BOOK_FROM_SHELF -> PendingOperationType.REMOVE_BOOK_FROM_SHELF
     }
 
 /**

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/SessionRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/SessionRepositoryImpl.kt
@@ -1,8 +1,5 @@
-@file:Suppress("SwallowedException")
-
 package com.calypsan.listenup.client.data.repository
 
-import com.calypsan.listenup.client.core.AppResult
 import com.calypsan.listenup.client.core.BookId
 import com.calypsan.listenup.client.core.Success
 import com.calypsan.listenup.client.core.currentEpochMilliseconds
@@ -56,29 +53,6 @@ class SessionRepositoryImpl(
     private val transactionRunner: TransactionRunner,
     private val authSession: AuthSession,
 ) : SessionRepository {
-    // ═══════════════════════════════════════════════════════════════════════════
-    // LEGACY ONE-SHOT METHODS (kept for backwards compatibility)
-    // ═══════════════════════════════════════════════════════════════════════════
-
-    override suspend fun getBookReaders(bookId: String): List<ReaderInfo> {
-        val result = sessionApi.getBookReaders(bookId)
-        return if (result is Success) {
-            result.data.otherReaders.map { it.toDomain() }
-        } else {
-            emptyList()
-        }
-    }
-
-    override suspend fun getBookReadersResult(bookId: String): AppResult<BookReadersResult> =
-        sessionApi.getBookReaders(bookId).map { response ->
-            BookReadersResult(
-                yourSessions = response.yourSessions.map { it.toDomain() },
-                otherReaders = response.otherReaders.map { it.toDomain() },
-                totalReaders = response.totalReaders,
-                totalCompletions = response.totalCompletions,
-            )
-        }
-
     // ═══════════════════════════════════════════════════════════════════════════
     // OFFLINE-FIRST REACTIVE METHODS
     // ═══════════════════════════════════════════════════════════════════════════

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/SessionRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/SessionRepositoryImpl.kt
@@ -240,7 +240,9 @@ private fun com.calypsan.listenup.client.data.remote.SessionSummary.toUserSessio
     )
 
 /**
- * Parse ISO timestamp string to epoch milliseconds.
+ * Parse an ISO timestamp string to epoch millis. On parse failure, logs and falls
+ * back to the current epoch — best-effort semantics appropriate for cache entries
+ * that will be reconciled on next sync.
  */
 private fun parseTimestampToEpoch(iso: String): Long =
     try {
@@ -248,6 +250,7 @@ private fun parseTimestampToEpoch(iso: String): Long =
     } catch (e: kotlin.coroutines.cancellation.CancellationException) {
         throw e
     } catch (e: Exception) {
+        logger.warn(e) { "Failed to parse timestamp '$iso'; falling back to current time" }
         currentEpochMilliseconds()
     }
 

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/ShelfRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/ShelfRepositoryImpl.kt
@@ -1,19 +1,36 @@
-@file:Suppress("SwallowedException")
-
 package com.calypsan.listenup.client.data.repository
 
 import com.calypsan.listenup.client.core.Timestamp
 import com.calypsan.listenup.client.core.currentEpochMilliseconds
+import com.calypsan.listenup.client.data.local.db.EntityType
+import com.calypsan.listenup.client.data.local.db.OperationType
+import com.calypsan.listenup.client.data.local.db.ShelfBookCrossRef
+import com.calypsan.listenup.client.data.local.db.ShelfBookDao
 import com.calypsan.listenup.client.data.local.db.ShelfDao
 import com.calypsan.listenup.client.data.local.db.ShelfEntity
+import com.calypsan.listenup.client.data.local.db.SyncState
+import com.calypsan.listenup.client.data.local.db.TransactionRunner
+import com.calypsan.listenup.client.data.local.db.UserDao
 import com.calypsan.listenup.client.data.remote.ShelfApiContract
 import com.calypsan.listenup.client.data.remote.ShelfDetailResponse
 import com.calypsan.listenup.client.data.remote.ShelfResponse
+import com.calypsan.listenup.client.data.sync.push.AddBooksToShelfPayload
+import com.calypsan.listenup.client.data.sync.push.CreateShelfHandler
+import com.calypsan.listenup.client.data.sync.push.CreateShelfPayload
+import com.calypsan.listenup.client.data.sync.push.DeleteShelfHandler
+import com.calypsan.listenup.client.data.sync.push.DeleteShelfPayload
+import com.calypsan.listenup.client.data.sync.push.AddBooksToShelfHandler
+import com.calypsan.listenup.client.data.sync.push.RemoveBookFromShelfHandler
+import com.calypsan.listenup.client.data.sync.push.RemoveBookFromShelfPayload
+import com.calypsan.listenup.client.data.sync.push.PendingOperationRepositoryContract
+import com.calypsan.listenup.client.data.sync.push.UpdateShelfHandler
+import com.calypsan.listenup.client.data.sync.push.UpdateShelfPayload
 import com.calypsan.listenup.client.domain.model.Shelf
 import com.calypsan.listenup.client.domain.model.ShelfBook
 import com.calypsan.listenup.client.domain.model.ShelfDetail
 import com.calypsan.listenup.client.domain.model.ShelfOwner
 import com.calypsan.listenup.client.domain.repository.ShelfRepository
+import com.calypsan.listenup.client.util.NanoId
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -22,17 +39,37 @@ import kotlin.time.Instant
 private val logger = KotlinLogging.logger {}
 
 /**
- * Implementation of ShelfRepository using Room.
+ * Implementation of ShelfRepository using Room-first + pending-op pattern.
  *
- * Wraps ShelfDao and converts entities to domain models.
- * Also handles fetching shelves from API and caching locally.
+ * Command methods (create, update, delete, addBooks, removeBook) write to Room
+ * atomically and enqueue a PendingOperation for server sync. The API boundary
+ * moves entirely to the operation handlers (Task 11). Read-side methods and
+ * fetch/cache methods retain direct API access for pull-side behaviour.
  *
  * @property dao Room DAO for shelf operations
- * @property shelfApi API client for fetching shelves from server
+ * @property shelfBookDao Room DAO for shelf-book junction operations
+ * @property userDao Room DAO for current user lookup (needed for owner fields on create)
+ * @property shelfApi API client for read-side fetches (getShelfDetail, fetchAndCache*)
+ * @property pendingOperationRepository Repository for queuing push-sync operations
+ * @property transactionRunner Runs multi-DAO writes atomically
+ * @property createShelfHandler Handler for CREATE_SHELF operations
+ * @property updateShelfHandler Handler for UPDATE_SHELF operations
+ * @property deleteShelfHandler Handler for DELETE_SHELF operations
+ * @property addBooksToShelfHandler Handler for ADD_BOOKS_TO_SHELF operations
+ * @property removeBookFromShelfHandler Handler for REMOVE_BOOK_FROM_SHELF operations
  */
 class ShelfRepositoryImpl(
     private val dao: ShelfDao,
+    private val shelfBookDao: ShelfBookDao,
+    private val userDao: UserDao,
     private val shelfApi: ShelfApiContract,
+    private val pendingOperationRepository: PendingOperationRepositoryContract,
+    private val transactionRunner: TransactionRunner,
+    private val createShelfHandler: CreateShelfHandler,
+    private val updateShelfHandler: UpdateShelfHandler,
+    private val deleteShelfHandler: DeleteShelfHandler,
+    private val addBooksToShelfHandler: AddBooksToShelfHandler,
+    private val removeBookFromShelfHandler: RemoveBookFromShelfHandler,
 ) : ShelfRepository {
     override fun observeMyShelves(userId: String): Flow<List<Shelf>> =
         dao.observeMyShelves(userId).map { entities ->
@@ -97,57 +134,169 @@ class ShelfRepositoryImpl(
         return response.toDomain()
     }
 
-    override suspend fun removeBookFromShelf(
-        shelfId: String,
-        bookId: String,
-    ) {
-        logger.info { "Removing book $bookId from shelf $shelfId" }
-        shelfApi.removeBook(shelfId, bookId)
-    }
-
-    override suspend fun addBooksToShelf(
-        shelfId: String,
-        bookIds: List<String>,
-    ) {
-        logger.info { "Adding ${bookIds.size} books to shelf $shelfId" }
-        shelfApi.addBooks(shelfId, bookIds)
-    }
-
+    /**
+     * Room-first: writes the new shelf locally then enqueues a CREATE_SHELF operation.
+     *
+     * A client-side NanoId is assigned immediately. The handler will create it on the
+     * server; ShelfPuller will later remap the local id to the server-assigned id via
+     * [ShelfDao.updateIdAndSyncState].
+     */
     override suspend fun createShelf(
         name: String,
         description: String?,
     ): Shelf {
-        logger.info { "Creating shelf: $name" }
-        val response = shelfApi.createShelf(name, description)
-        // Cache the new shelf locally
-        dao.upsert(response.toEntity())
-        return response.toDomain()
+        logger.info { "Creating shelf (offline-first): $name" }
+        val localId = NanoId.generate("shelf")
+        val now = currentEpochMilliseconds()
+
+        val currentUser = userDao.getCurrentUser()
+        val ownerId = currentUser?.id?.value ?: ""
+        val ownerDisplayName = currentUser?.displayName ?: ""
+        val ownerAvatarColor = currentUser?.avatarColor ?: "#6B7280"
+
+        val entity =
+            ShelfEntity(
+                id = localId,
+                name = name,
+                description = description,
+                ownerId = ownerId,
+                ownerDisplayName = ownerDisplayName,
+                ownerAvatarColor = ownerAvatarColor,
+                bookCount = 0,
+                totalDurationSeconds = 0L,
+                createdAt = Timestamp(now),
+                updatedAt = Timestamp(now),
+                syncState = SyncState.NOT_SYNCED,
+            )
+
+        val payload = CreateShelfPayload(localId = localId, name = name, description = description)
+        transactionRunner.atomically {
+            dao.upsert(entity)
+            pendingOperationRepository.queue(
+                type = OperationType.CREATE_SHELF,
+                entityType = EntityType.SHELF,
+                entityId = localId,
+                payload = payload,
+                handler = createShelfHandler,
+            )
+        }
+
+        logger.info { "Shelf create queued: $localId" }
+        return entity.toDomain()
     }
 
+    /**
+     * Room-first: applies the update locally then enqueues an UPDATE_SHELF operation.
+     */
     override suspend fun updateShelf(
         shelfId: String,
         name: String,
         description: String?,
     ): Shelf {
-        logger.info { "Updating shelf $shelfId: $name" }
-        val response = shelfApi.updateShelf(shelfId, name, description)
-        // Update local cache
-        dao.getById(shelfId)?.let { cached ->
-            dao.upsert(
-                cached.copy(
-                    name = response.name,
-                    description = response.description.ifEmpty { null },
-                ),
+        logger.info { "Updating shelf (offline-first): $shelfId" }
+        val existing =
+            requireNotNull(dao.getById(shelfId)) {
+                "Shelf not found: $shelfId"
+            }
+        val updated =
+            existing.copy(
+                name = name,
+                description = description,
+                updatedAt = Timestamp(currentEpochMilliseconds()),
+                syncState = SyncState.NOT_SYNCED,
+            )
+
+        val payload = UpdateShelfPayload(shelfId = shelfId, name = name, description = description)
+        transactionRunner.atomically {
+            dao.upsert(updated)
+            pendingOperationRepository.queue(
+                type = OperationType.UPDATE_SHELF,
+                entityType = EntityType.SHELF,
+                entityId = shelfId,
+                payload = payload,
+                handler = updateShelfHandler,
             )
         }
-        return response.toDomain()
+
+        logger.info { "Shelf update queued: $shelfId" }
+        return updated.toDomain()
     }
 
+    /**
+     * Room-first: removes the shelf locally then enqueues a DELETE_SHELF operation.
+     *
+     * The shelf_books junction rows are cascade-deleted by the foreign key constraint.
+     */
     override suspend fun deleteShelf(shelfId: String) {
-        logger.info { "Deleting shelf $shelfId" }
-        shelfApi.deleteShelf(shelfId)
-        // Remove from local cache
-        dao.deleteById(shelfId)
+        logger.info { "Deleting shelf (offline-first): $shelfId" }
+        val payload = DeleteShelfPayload(shelfId = shelfId)
+        transactionRunner.atomically {
+            dao.deleteById(shelfId)
+            pendingOperationRepository.queue(
+                type = OperationType.DELETE_SHELF,
+                entityType = EntityType.SHELF,
+                entityId = shelfId,
+                payload = payload,
+                handler = deleteShelfHandler,
+            )
+        }
+        logger.info { "Shelf delete queued: $shelfId" }
+    }
+
+    /**
+     * Room-first: inserts junction rows for each book then enqueues an ADD_BOOKS_TO_SHELF
+     * operation.
+     */
+    override suspend fun addBooksToShelf(
+        shelfId: String,
+        bookIds: List<String>,
+    ) {
+        logger.info { "Adding ${bookIds.size} books to shelf $shelfId (offline-first)" }
+        val now = currentEpochMilliseconds()
+        val crossRefs =
+            bookIds.mapIndexed { index, bookId ->
+                ShelfBookCrossRef(
+                    shelfId = shelfId,
+                    bookId = bookId,
+                    // Offset each entry so ordering by addedAt DESC remains stable
+                    addedAt = now - index,
+                )
+            }
+
+        val payload = AddBooksToShelfPayload(shelfId = shelfId, bookIds = bookIds)
+        transactionRunner.atomically {
+            shelfBookDao.upsertAll(crossRefs)
+            pendingOperationRepository.queue(
+                type = OperationType.ADD_BOOKS_TO_SHELF,
+                entityType = EntityType.SHELF,
+                entityId = shelfId,
+                payload = payload,
+                handler = addBooksToShelfHandler,
+            )
+        }
+        logger.info { "AddBooksToShelf queued: $shelfId (${bookIds.size} books)" }
+    }
+
+    /**
+     * Room-first: deletes the junction row then enqueues a REMOVE_BOOK_FROM_SHELF operation.
+     */
+    override suspend fun removeBookFromShelf(
+        shelfId: String,
+        bookId: String,
+    ) {
+        logger.info { "Removing book $bookId from shelf $shelfId (offline-first)" }
+        val payload = RemoveBookFromShelfPayload(shelfId = shelfId, bookId = bookId)
+        transactionRunner.atomically {
+            shelfBookDao.deleteShelfBook(shelfId, bookId)
+            pendingOperationRepository.queue(
+                type = OperationType.REMOVE_BOOK_FROM_SHELF,
+                entityType = EntityType.SHELF,
+                entityId = shelfId,
+                payload = payload,
+                handler = removeBookFromShelfHandler,
+            )
+        }
+        logger.info { "RemoveBookFromShelf queued: shelfId=$shelfId, bookId=$bookId" }
     }
 }
 
@@ -161,6 +310,7 @@ fun ShelfResponse.toDomain(): Shelf {
         } catch (e: kotlin.coroutines.cancellation.CancellationException) {
             throw e
         } catch (e: Exception) {
+            logger.warn(e) { "Failed to parse createdAt '$createdAt' for shelf $id; using current time" }
             currentEpochMilliseconds()
         }
     val updatedAtMs =
@@ -169,6 +319,7 @@ fun ShelfResponse.toDomain(): Shelf {
         } catch (e: kotlin.coroutines.cancellation.CancellationException) {
             throw e
         } catch (e: Exception) {
+            logger.warn(e) { "Failed to parse updatedAt '$updatedAt' for shelf $id; using current time" }
             currentEpochMilliseconds()
         }
 
@@ -196,6 +347,7 @@ private fun ShelfResponse.toEntity(): ShelfEntity {
         } catch (e: kotlin.coroutines.cancellation.CancellationException) {
             throw e
         } catch (e: Exception) {
+            logger.warn(e) { "Failed to parse createdAt '$createdAt' for shelf $id; using current time" }
             currentEpochMilliseconds()
         }
     val updatedAtMs =
@@ -204,6 +356,7 @@ private fun ShelfResponse.toEntity(): ShelfEntity {
         } catch (e: kotlin.coroutines.cancellation.CancellationException) {
             throw e
         } catch (e: Exception) {
+            logger.warn(e) { "Failed to parse updatedAt '$updatedAt' for shelf $id; using current time" }
             currentEpochMilliseconds()
         }
 

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/pull/BookPuller.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/pull/BookPuller.kt
@@ -2,18 +2,14 @@ package com.calypsan.listenup.client.data.sync.pull
 
 import com.calypsan.listenup.client.core.BookId
 import com.calypsan.listenup.client.core.Timestamp
-import com.calypsan.listenup.client.data.local.db.AudioFileDao
 import com.calypsan.listenup.client.data.local.db.AudioFileEntity
-import com.calypsan.listenup.client.data.local.db.BookContributorDao
 import com.calypsan.listenup.client.data.local.db.BookDao
 import com.calypsan.listenup.client.data.local.db.BookEntity
 import com.calypsan.listenup.client.data.local.db.BookGenreCrossRef
-import com.calypsan.listenup.client.data.local.db.BookSeriesDao
 import com.calypsan.listenup.client.data.local.db.BookTagCrossRef
 import com.calypsan.listenup.client.data.local.db.ChapterDao
 import com.calypsan.listenup.client.data.local.db.ChapterEntity
 import com.calypsan.listenup.client.data.local.db.GenreDao
-import com.calypsan.listenup.client.data.local.db.TagDao
 import com.calypsan.listenup.client.data.local.db.TagEntity
 import com.calypsan.listenup.client.data.local.db.TransactionRunner
 import com.calypsan.listenup.client.data.remote.SyncApiContract
@@ -30,19 +26,6 @@ import com.calypsan.listenup.client.core.Success
 import com.calypsan.listenup.client.core.Failure
 
 private val logger = KotlinLogging.logger {}
-
-/**
- * Bundle of junction-table DAOs BookPuller writes to when replacing a book's
- * relationships on each sync. Grouped to keep the puller's constructor focused
- * on distinct collaborators rather than individual relationship tables.
- */
-data class BookRelationshipDaos(
-    val bookContributorDao: BookContributorDao,
-    val bookSeriesDao: BookSeriesDao,
-    val tagDao: TagDao,
-    val genreDao: GenreDao,
-    val audioFileDao: AudioFileDao,
-)
 
 /**
  * Handles paginated book fetching, processing, and relationship syncing.

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/push/OperationExecutor.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/push/OperationExecutor.kt
@@ -110,6 +110,11 @@ class OperationExecutor(
             profileUpdateHandler: ProfileUpdateHandler,
             profileAvatarHandler: ProfileAvatarHandler,
             markCompleteHandler: MarkCompleteHandler,
+            createShelfHandler: CreateShelfHandler,
+            updateShelfHandler: UpdateShelfHandler,
+            deleteShelfHandler: DeleteShelfHandler,
+            addBooksToShelfHandler: AddBooksToShelfHandler,
+            removeBookFromShelfHandler: RemoveBookFromShelfHandler,
         ): OperationExecutor =
             OperationExecutor(
                 mapOf(
@@ -126,6 +131,11 @@ class OperationExecutor(
                     OperationType.PROFILE_UPDATE to profileUpdateHandler,
                     OperationType.PROFILE_AVATAR to profileAvatarHandler,
                     OperationType.MARK_COMPLETE to markCompleteHandler,
+                    OperationType.CREATE_SHELF to createShelfHandler,
+                    OperationType.UPDATE_SHELF to updateShelfHandler,
+                    OperationType.DELETE_SHELF to deleteShelfHandler,
+                    OperationType.ADD_BOOKS_TO_SHELF to addBooksToShelfHandler,
+                    OperationType.REMOVE_BOOK_FROM_SHELF to removeBookFromShelfHandler,
                 ),
             )
     }

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/push/OperationHandlers.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/push/OperationHandlers.kt
@@ -11,6 +11,7 @@ import com.calypsan.listenup.client.data.local.db.PendingOperationEntity
 import com.calypsan.listenup.client.data.local.db.PlaybackPositionDao
 import com.calypsan.listenup.client.data.local.db.UserDao
 import com.calypsan.listenup.client.data.remote.BookApiContract
+import com.calypsan.listenup.client.data.remote.ShelfApiContract
 import com.calypsan.listenup.client.data.remote.BookUpdateRequest
 import com.calypsan.listenup.client.data.remote.ContributorApiContract
 import com.calypsan.listenup.client.data.remote.ListeningEventRequest
@@ -699,5 +700,177 @@ class MarkCompleteHandler(
         ) {
             is Success -> Success(Unit)
             is Failure -> result
+        }
+}
+
+/**
+ * Handler for CREATE_SHELF operations.
+ * Never coalesces — each create is a discrete intent.
+ */
+class CreateShelfHandler(
+    private val api: ShelfApiContract,
+) : OperationHandler<CreateShelfPayload> {
+    override val operationType = OperationType.CREATE_SHELF
+
+    override fun parsePayload(json: String): CreateShelfPayload = appJson.decodeFromString(json)
+
+    override fun serializePayload(payload: CreateShelfPayload): String = appJson.encodeToString(payload)
+
+    override fun tryCoalesce(
+        existing: PendingOperationEntity,
+        existingPayload: CreateShelfPayload,
+        newPayload: CreateShelfPayload,
+    ): CreateShelfPayload? = null // Create operations never coalesce
+
+    override suspend fun execute(
+        operation: PendingOperationEntity,
+        payload: CreateShelfPayload,
+    ): AppResult<Unit> =
+        try {
+            api.createShelf(payload.name, payload.description)
+            Success(Unit)
+        } catch (e: kotlin.coroutines.cancellation.CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.warn(e) { "CreateShelfHandler failed for localId=${payload.localId}" }
+            Failure(e)
+        }
+}
+
+/**
+ * Handler for UPDATE_SHELF operations.
+ * Never coalesces — each update carries the full desired state.
+ */
+class UpdateShelfHandler(
+    private val api: ShelfApiContract,
+) : OperationHandler<UpdateShelfPayload> {
+    override val operationType = OperationType.UPDATE_SHELF
+
+    override fun parsePayload(json: String): UpdateShelfPayload = appJson.decodeFromString(json)
+
+    override fun serializePayload(payload: UpdateShelfPayload): String = appJson.encodeToString(payload)
+
+    override fun tryCoalesce(
+        existing: PendingOperationEntity,
+        existingPayload: UpdateShelfPayload,
+        newPayload: UpdateShelfPayload,
+    ): UpdateShelfPayload? = null // Update operations never coalesce
+
+    override suspend fun execute(
+        operation: PendingOperationEntity,
+        payload: UpdateShelfPayload,
+    ): AppResult<Unit> =
+        try {
+            api.updateShelf(payload.shelfId, payload.name, payload.description)
+            Success(Unit)
+        } catch (e: kotlin.coroutines.cancellation.CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.warn(e) { "UpdateShelfHandler failed for shelfId=${payload.shelfId}" }
+            Failure(e)
+        }
+}
+
+/**
+ * Handler for DELETE_SHELF operations.
+ * Never coalesces — each delete is a discrete intent.
+ */
+class DeleteShelfHandler(
+    private val api: ShelfApiContract,
+) : OperationHandler<DeleteShelfPayload> {
+    override val operationType = OperationType.DELETE_SHELF
+
+    override fun parsePayload(json: String): DeleteShelfPayload = appJson.decodeFromString(json)
+
+    override fun serializePayload(payload: DeleteShelfPayload): String = appJson.encodeToString(payload)
+
+    override fun tryCoalesce(
+        existing: PendingOperationEntity,
+        existingPayload: DeleteShelfPayload,
+        newPayload: DeleteShelfPayload,
+    ): DeleteShelfPayload? = null // Delete operations never coalesce
+
+    override suspend fun execute(
+        operation: PendingOperationEntity,
+        payload: DeleteShelfPayload,
+    ): AppResult<Unit> =
+        try {
+            api.deleteShelf(payload.shelfId)
+            Success(Unit)
+        } catch (e: kotlin.coroutines.cancellation.CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.warn(e) { "DeleteShelfHandler failed for shelfId=${payload.shelfId}" }
+            Failure(e)
+        }
+}
+
+/**
+ * Handler for ADD_BOOKS_TO_SHELF operations.
+ * Never coalesces — each call is a discrete add intent.
+ */
+class AddBooksToShelfHandler(
+    private val api: ShelfApiContract,
+) : OperationHandler<AddBooksToShelfPayload> {
+    override val operationType = OperationType.ADD_BOOKS_TO_SHELF
+
+    override fun parsePayload(json: String): AddBooksToShelfPayload = appJson.decodeFromString(json)
+
+    override fun serializePayload(payload: AddBooksToShelfPayload): String = appJson.encodeToString(payload)
+
+    override fun tryCoalesce(
+        existing: PendingOperationEntity,
+        existingPayload: AddBooksToShelfPayload,
+        newPayload: AddBooksToShelfPayload,
+    ): AddBooksToShelfPayload? = null // Add operations never coalesce
+
+    override suspend fun execute(
+        operation: PendingOperationEntity,
+        payload: AddBooksToShelfPayload,
+    ): AppResult<Unit> =
+        try {
+            api.addBooks(payload.shelfId, payload.bookIds)
+            Success(Unit)
+        } catch (e: kotlin.coroutines.cancellation.CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.warn(e) { "AddBooksToShelfHandler failed for shelfId=${payload.shelfId}" }
+            Failure(e)
+        }
+}
+
+/**
+ * Handler for REMOVE_BOOK_FROM_SHELF operations.
+ * Never coalesces — each remove is a discrete intent.
+ */
+class RemoveBookFromShelfHandler(
+    private val api: ShelfApiContract,
+) : OperationHandler<RemoveBookFromShelfPayload> {
+    override val operationType = OperationType.REMOVE_BOOK_FROM_SHELF
+
+    override fun parsePayload(json: String): RemoveBookFromShelfPayload = appJson.decodeFromString(json)
+
+    override fun serializePayload(payload: RemoveBookFromShelfPayload): String = appJson.encodeToString(payload)
+
+    override fun tryCoalesce(
+        existing: PendingOperationEntity,
+        existingPayload: RemoveBookFromShelfPayload,
+        newPayload: RemoveBookFromShelfPayload,
+    ): RemoveBookFromShelfPayload? = null // Remove operations never coalesce
+
+    override suspend fun execute(
+        operation: PendingOperationEntity,
+        payload: RemoveBookFromShelfPayload,
+    ): AppResult<Unit> =
+        try {
+            api.removeBook(payload.shelfId, payload.bookId)
+            Success(Unit)
+        } catch (e: kotlin.coroutines.cancellation.CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.warn(
+                e,
+            ) { "RemoveBookFromShelfHandler failed for shelfId=${payload.shelfId}, bookId=${payload.bookId}" }
+            Failure(e)
         }
 }

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/push/ShelfPayloads.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/push/ShelfPayloads.kt
@@ -1,0 +1,47 @@
+package com.calypsan.listenup.client.data.sync.push
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/** Payload for the `CREATE_SHELF` pending operation. */
+@Serializable
+data class CreateShelfPayload(
+    @SerialName("local_id")
+    val localId: String,
+    val name: String,
+    val description: String?,
+)
+
+/** Payload for the `UPDATE_SHELF` pending operation. */
+@Serializable
+data class UpdateShelfPayload(
+    @SerialName("shelf_id")
+    val shelfId: String,
+    val name: String,
+    val description: String?,
+)
+
+/** Payload for the `DELETE_SHELF` pending operation. */
+@Serializable
+data class DeleteShelfPayload(
+    @SerialName("shelf_id")
+    val shelfId: String,
+)
+
+/** Payload for the `ADD_BOOKS_TO_SHELF` pending operation. */
+@Serializable
+data class AddBooksToShelfPayload(
+    @SerialName("shelf_id")
+    val shelfId: String,
+    @SerialName("book_ids")
+    val bookIds: List<String>,
+)
+
+/** Payload for the `REMOVE_BOOK_FROM_SHELF` pending operation. */
+@Serializable
+data class RemoveBookFromShelfPayload(
+    @SerialName("shelf_id")
+    val shelfId: String,
+    @SerialName("book_id")
+    val bookId: String,
+)

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/sse/BookRelationshipDaos.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/sse/BookRelationshipDaos.kt
@@ -1,0 +1,20 @@
+package com.calypsan.listenup.client.data.sync.sse
+
+import com.calypsan.listenup.client.data.local.db.AudioFileDao
+import com.calypsan.listenup.client.data.local.db.BookContributorDao
+import com.calypsan.listenup.client.data.local.db.BookSeriesDao
+import com.calypsan.listenup.client.data.local.db.GenreDao
+import com.calypsan.listenup.client.data.local.db.TagDao
+
+/**
+ * Bundle of junction-table DAOs BookPuller writes to when replacing a book's
+ * relationships on each sync. Grouped to keep the puller's constructor focused
+ * on distinct collaborators rather than individual relationship tables.
+ */
+data class BookRelationshipDaos(
+    val bookContributorDao: BookContributorDao,
+    val bookSeriesDao: BookSeriesDao,
+    val tagDao: TagDao,
+    val genreDao: GenreDao,
+    val audioFileDao: AudioFileDao,
+)

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/sse/SSEEventProcessor.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/sse/SSEEventProcessor.kt
@@ -30,7 +30,6 @@ import com.calypsan.listenup.client.data.sync.SSEChannelMessage
 import com.calypsan.listenup.client.data.sync.SSEEvent
 import com.calypsan.listenup.client.data.sync.SessionDaos
 import com.calypsan.listenup.client.data.sync.UserDaos
-import com.calypsan.listenup.client.data.sync.pull.BookRelationshipDaos
 import com.calypsan.listenup.client.domain.repository.AvatarDownloadRepository
 import com.calypsan.listenup.client.domain.repository.CoverDownloadRepository
 import io.github.oshai.kotlinlogging.KotlinLogging

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/sse/SSEEventProcessor.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/sse/SSEEventProcessor.kt
@@ -1127,24 +1127,12 @@ class SSEEventProcessor(
         // This ensures the local file exists when the UI Flow emits after userDao update.
         // If we update userDao first, the UI checks for the file before it's downloaded.
         if (payload.avatarType == "image" && payload.avatarValue != null) {
-            try {
-                imageDownloader.downloadUserAvatar(payload.userId, forceRefresh = true)
-                logger.info { "SSE: Downloaded avatar image for user ${payload.userId}" }
-            } catch (e: kotlin.coroutines.cancellation.CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                logger.warn(e) { "SSE: Failed to download avatar for user ${payload.userId}" }
-            }
+            avatarDownloadRepository.queueAvatarForceRefresh(payload.userId)
+            logger.info { "SSE: Queued force-refresh avatar for user ${payload.userId}" }
         } else if (payload.avatarType == "auto") {
             // User reverted to auto avatar, delete the local image file
-            try {
-                imageDownloader.deleteUserAvatar(payload.userId)
-                logger.info { "SSE: Deleted local avatar for user ${payload.userId} (reverted to auto)" }
-            } catch (e: kotlin.coroutines.cancellation.CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                logger.warn(e) { "SSS: Failed to delete avatar for user ${payload.userId}" }
-            }
+            avatarDownloadRepository.deleteAvatar(payload.userId)
+            logger.info { "SSE: Deleted local avatar for user ${payload.userId} (reverted to auto)" }
         }
 
         // Cache user profile for offline display (for ALL users, not just current)

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/di/Koin.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/di/Koin.kt
@@ -101,7 +101,7 @@ import com.calypsan.listenup.client.data.sync.conflict.ConflictDetector
 import com.calypsan.listenup.client.data.sync.conflict.ConflictDetectorContract
 import com.calypsan.listenup.client.data.sync.pull.ActiveSessionsPuller
 import com.calypsan.listenup.client.data.sync.pull.BookPuller
-import com.calypsan.listenup.client.data.sync.pull.BookRelationshipDaos
+import com.calypsan.listenup.client.data.sync.sse.BookRelationshipDaos
 import com.calypsan.listenup.client.data.sync.pull.BookRelationshipWriter
 import com.calypsan.listenup.client.data.sync.pull.ContributorPuller
 import com.calypsan.listenup.client.data.sync.pull.GenrePuller

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/di/Koin.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/di/Koin.kt
@@ -114,8 +114,11 @@ import com.calypsan.listenup.client.data.sync.pull.PullSyncOrchestrator
 import com.calypsan.listenup.client.data.sync.pull.Puller
 import com.calypsan.listenup.client.data.sync.pull.SeriesPuller
 import com.calypsan.listenup.client.data.sync.pull.TagPuller
+import com.calypsan.listenup.client.data.sync.push.AddBooksToShelfHandler
 import com.calypsan.listenup.client.data.sync.push.BookUpdateHandler
 import com.calypsan.listenup.client.data.sync.push.ContributorUpdateHandler
+import com.calypsan.listenup.client.data.sync.push.CreateShelfHandler
+import com.calypsan.listenup.client.data.sync.push.DeleteShelfHandler
 import com.calypsan.listenup.client.data.sync.push.ListeningEventHandler
 import com.calypsan.listenup.client.data.sync.push.MergeContributorHandler
 import com.calypsan.listenup.client.data.sync.push.OperationExecutor
@@ -129,10 +132,12 @@ import com.calypsan.listenup.client.data.sync.push.ProfileAvatarHandler
 import com.calypsan.listenup.client.data.sync.push.ProfileUpdateHandler
 import com.calypsan.listenup.client.data.sync.push.PushSyncOrchestrator
 import com.calypsan.listenup.client.data.sync.push.PushSyncOrchestratorContract
+import com.calypsan.listenup.client.data.sync.push.RemoveBookFromShelfHandler
 import com.calypsan.listenup.client.data.sync.push.SeriesUpdateHandler
 import com.calypsan.listenup.client.data.sync.push.SetBookContributorsHandler
 import com.calypsan.listenup.client.data.sync.push.SetBookSeriesHandler
 import com.calypsan.listenup.client.data.sync.push.UnmergeContributorHandler
+import com.calypsan.listenup.client.data.sync.push.UpdateShelfHandler
 import com.calypsan.listenup.client.data.sync.push.UserPreferencesHandler
 import com.calypsan.listenup.client.data.sync.SessionDaos
 import com.calypsan.listenup.client.data.sync.UserDaos
@@ -1201,6 +1206,11 @@ val syncModule =
         single { ProfileUpdateHandler(transactionRunner = get(), api = get(), userDao = get()) }
         single { ProfileAvatarHandler(api = get(), userDao = get(), imageDownloader = get()) }
         single { MarkCompleteHandler(api = get()) }
+        single { CreateShelfHandler(api = get()) }
+        single { UpdateShelfHandler(api = get()) }
+        single { DeleteShelfHandler(api = get()) }
+        single { AddBooksToShelfHandler(api = get()) }
+        single { RemoveBookFromShelfHandler(api = get()) }
 
         // PreferencesSyncObserver - observes SettingsRepository.preferenceChanges and queues sync operations.
         // This breaks the circular dependency between SettingsRepository and the sync layer.
@@ -1238,6 +1248,11 @@ val syncModule =
                 profileUpdateHandler = get(),
                 profileAvatarHandler = get(),
                 markCompleteHandler = get(),
+                createShelfHandler = get(),
+                updateShelfHandler = get(),
+                deleteShelfHandler = get(),
+                addBooksToShelfHandler = get(),
+                removeBookFromShelfHandler = get(),
             )
         } bind OperationExecutorContract::class
 

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/di/Koin.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/di/Koin.kt
@@ -1487,7 +1487,19 @@ val syncModule =
 
         // ShelfRepository for personal curation shelves (SOLID: interface in domain, impl in data)
         single<ShelfRepository> {
-            ShelfRepositoryImpl(dao = get(), shelfApi = get())
+            ShelfRepositoryImpl(
+                dao = get(),
+                shelfBookDao = get(),
+                userDao = get(),
+                shelfApi = get(),
+                pendingOperationRepository = get(),
+                transactionRunner = get(),
+                createShelfHandler = get(),
+                updateShelfHandler = get(),
+                deleteShelfHandler = get(),
+                addBooksToShelfHandler = get(),
+                removeBookFromShelfHandler = get(),
+            )
         }
 
         // CollectionRepository for admin collections (SOLID: interface in domain, impl in data)

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/domain/model/PendingOperation.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/domain/model/PendingOperation.kt
@@ -41,6 +41,11 @@ enum class PendingOperationType {
     PROFILE_UPDATE,
     PROFILE_AVATAR,
     MARK_COMPLETE,
+    CREATE_SHELF,
+    UPDATE_SHELF,
+    DELETE_SHELF,
+    ADD_BOOKS_TO_SHELF,
+    REMOVE_BOOK_FROM_SHELF,
 }
 
 /**

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/AvatarDownloadRepository.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/AvatarDownloadRepository.kt
@@ -21,4 +21,27 @@ interface AvatarDownloadRepository {
      * @param userId the user whose avatar should be fetched.
      */
     fun queueAvatarDownload(userId: String)
+
+    /**
+     * Queue a force-refresh download for [userId], bypassing the file-exists skip.
+     *
+     * Returns immediately; the download happens on the repository's internal scope.
+     * Used by the SSE profile-updated handler when avatar bytes have changed server-side
+     * but the URL/path is unchanged — so the normal existence check would incorrectly skip it.
+     * On failure, the error is logged and dropped.
+     *
+     * @param userId the user whose avatar should be force-refreshed.
+     */
+    fun queueAvatarForceRefresh(userId: String)
+
+    /**
+     * Delete the locally-cached avatar for [userId].
+     *
+     * Suspends until the filesystem operation completes so callers know the file is gone
+     * before proceeding (e.g. before updating the local DB, to avoid a TOCTOU race where
+     * the UI reads the profile and finds no file). On failure, the error is logged and dropped.
+     *
+     * @param userId the user whose local avatar file should be removed.
+     */
+    suspend fun deleteAvatar(userId: String)
 }

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/SessionRepository.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/SessionRepository.kt
@@ -1,8 +1,6 @@
 package com.calypsan.listenup.client.domain.repository
 
-import com.calypsan.listenup.client.core.AppResult
 import com.calypsan.listenup.client.domain.model.BookReadersResult
-import com.calypsan.listenup.client.domain.model.ReaderInfo
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -16,23 +14,6 @@ import kotlinx.coroutines.flow.Flow
  * Part of the domain layer - implementations live in the data layer.
  */
 interface SessionRepository {
-    /**
-     * Get all users currently reading a specific book.
-     *
-     * @param bookId The book ID to check
-     * @return List of readers currently listening to this book
-     */
-    suspend fun getBookReaders(bookId: String): List<ReaderInfo>
-
-    /**
-     * Get comprehensive book readers information including the current user's
-     * reading history and other readers.
-     *
-     * @param bookId The book ID to get readers for
-     * @return Result containing readers information or error
-     */
-    suspend fun getBookReadersResult(bookId: String): AppResult<BookReadersResult>
-
     /**
      * Observe book readers reactively from local cache.
      *

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/ProgressTracker.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/ProgressTracker.kt
@@ -539,7 +539,7 @@ class ProgressTracker(
      * Clear progress for a book (reset to beginning).
      */
     suspend fun clearProgress(bookId: BookId) {
-        positionDao.delete(bookId)
+        positionRepository.delete(bookId.value)
         logger.info { "Progress cleared for book: ${bookId.value}" }
     }
 

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/bookdetail/BookDetailViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/bookdetail/BookDetailViewModel.kt
@@ -23,13 +23,14 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -63,32 +64,13 @@ class BookDetailViewModel(
      */
     private val bookIdFlow = MutableStateFlow<String?>(null)
 
-    /**
-     * Gate for book-dependent observers (genre, tag). Emits a distinct book id only once
-     * `state` has reached Ready. Genre / tag observers subscribe here so their
-     * `updateReady` patches always land on a Ready state for the current book; they
-     * cannot fire during the Loading window.
-     *
-     * **Pattern: gated observer via state-derived key.** Two invariants make the
-     * state → derived-flow → updateReady → state loop safe:
-     *   1. `.distinctUntilChanged()` filters on the book-id key, not the Ready state.
-     *      Patches that produce a new Ready for the same book don't re-trigger.
-     *   2. `updateReady` is idempotent w.r.t. the book id — patches never change it.
-     * Before copying this pattern elsewhere, verify both invariants hold.
-     */
-    private val activeBookIdFlow: Flow<String> =
-        state
-            .filterIsInstance<BookDetailUiState.Ready>()
-            .map { it.book.id.value }
-            .distinctUntilChanged()
-
     // Mirrors of book-INDEPENDENT flow-fed fields (admin status, all-tags). Updated
     // inside the init collectors and read at [loadBookFlow] to seed the Ready state
     // with the latest known values, since those collectors may have emitted while
     // state was Loading (and been no-op'd by [updateReady]).
     //
-    // Book-DEPENDENT observers (genre, tag-for-book) use [activeBookIdFlow] to avoid
-    // the Loading-window race entirely — they only fire post-Ready, so no mirror is needed.
+    // Per-book observers (genre, tag-for-book) are folded into [loadBookFlow] via
+    // combine, so they are naturally scoped to one book and need no mirror.
     private var latestIsAdmin: Boolean = false
     private var latestAllTags: List<Tag> = emptyList()
 
@@ -99,38 +81,6 @@ class BookDetailViewModel(
                 latestIsAdmin = isAdmin
                 updateReady { it.copy(isAdmin = isAdmin) }
             }
-        }
-
-        // Reactive genre observer - automatically switches when book changes.
-        // Subscribes to activeBookIdFlow so updateReady always lands on a Ready state.
-        viewModelScope.launch {
-            activeBookIdFlow
-                .flatMapLatest { bookId ->
-                    genreRepository.observeGenresForBook(bookId)
-                }.collect { genres ->
-                    updateReady {
-                        it.copy(
-                            genres = genres,
-                            genresList = genres.map { g -> g.name },
-                        )
-                    }
-                }
-        }
-
-        // Reactive book-specific tags observer - automatically switches when book changes.
-        // Subscribes to activeBookIdFlow so updateReady always lands on a Ready state.
-        viewModelScope.launch {
-            activeBookIdFlow
-                .flatMapLatest { bookId ->
-                    tagRepository.observeTagsForBook(bookId)
-                }.collect { tags ->
-                    updateReady {
-                        it.copy(
-                            tags = tags,
-                            isLoadingTags = false,
-                        )
-                    }
-                }
         }
 
         // All tags observer (doesn't depend on current book - for tag picker)
@@ -144,12 +94,13 @@ class BookDetailViewModel(
         }
 
         // Main load flow: bookIdFlow changes drive loadBookFlow, which emits
-        // Loading then Ready. flatMapLatest cancels the previous load on switch.
+        // Loading then a combine of Ready + per-book genres + per-book tags.
+        // flatMapLatest cancels the previous load (and its inner combine) on switch.
         viewModelScope.launch {
             bookIdFlow
                 .filterNotNull()
                 .flatMapLatest { id -> loadBookFlow(id) }
-                .collect { base -> state.value = base }
+                .collect { state.value = it }
         }
     }
 
@@ -170,9 +121,6 @@ class BookDetailViewModel(
     /**
      * Apply [transform] to state only if it is currently [BookDetailUiState.Ready].
      * No-ops when state is [BookDetailUiState.Loading] or [BookDetailUiState.Error].
-     *
-     * NOTE: [activeBookIdFlow] relies on this no-op-on-non-Ready contract to gate
-     * book-dependent observers so their patches never land during Loading.
      */
     private fun updateReady(transform: (BookDetailUiState.Ready) -> BookDetailUiState.Ready) {
         state.update { current ->
@@ -184,8 +132,9 @@ class BookDetailViewModel(
      * Switch the view model to observe [bookId].
      *
      * Pushes into [bookIdFlow]; the main-load `flatMapLatest` in init collects
-     * `loadBookFlow(id)` and updates state. Tag + genre observers are downstream
-     * of the same [bookIdFlow] change and auto-switch via their own flatMapLatest.
+     * `loadBookFlow(id)`, which combines per-book genres + tags into the Ready
+     * state, and updates [state]. Switching books cancels the in-flight load
+     * (and its inner combine) automatically.
      */
     fun loadBook(bookId: String) {
         bookIdFlow.value = bookId
@@ -195,9 +144,10 @@ class BookDetailViewModel(
      * Pure flow that drives the main book-load pipeline for [bookId].
      *
      * Emits [BookDetailUiState.Loading] immediately, then fetches all required
-     * data and emits [BookDetailUiState.Ready] (or [BookDetailUiState.Error] on
-     * failure). The caller ([init] block) collects into [state] via
-     * `flatMapLatest`, so switching books cancels an in-flight load automatically.
+     * data and emits a [combine] of base [BookDetailUiState.Ready] with live
+     * per-book genres and tags streams (or [BookDetailUiState.Error] on failure).
+     * The caller ([init] block) collects into [state] via `flatMapLatest`, so
+     * switching books cancels the in-flight load and the inner combine automatically.
      */
     private fun loadBookFlow(bookId: String): Flow<BookDetailUiState> =
         flow {
@@ -255,12 +205,7 @@ class BookDetailViewModel(
             // allTags). Their emissions may have been no-op'd by updateReady
             // while state was Loading, so we copy the mirrored latest values
             // into the new Ready state.
-            //
-            // Tags and genres default to empty here — the tag/genre init-block
-            // collectors will patch them via updateReady shortly after this
-            // Ready state lands (driven by the same bookIdFlow change via their
-            // own flatMapLatest).
-            emit(
+            val baseReady =
                 BookDetailUiState.Ready(
                     book = book,
                     isAdmin = latestIsAdmin,
@@ -277,8 +222,24 @@ class BookDetailViewModel(
                     progress = if (progress != null && progress > 0f && !isComplete) progress else null,
                     timeRemainingFormatted = timeRemaining,
                     addedAt = book.addedAt.epochMillis,
-                    isLoadingTags = true,
-                ),
+                )
+
+            // Combine base Ready with live per-book genre and tag streams.
+            // onStart ensures the combine emits immediately with empty lists before
+            // any repository data arrives. flatMapLatest in the caller cancels this
+            // combine when the book switches, preventing cross-book contamination.
+            emitAll(
+                combine(
+                    flowOf(baseReady),
+                    genreRepository.observeGenresForBook(bookId).onStart { emit(emptyList()) },
+                    tagRepository.observeTagsForBook(bookId).onStart { emit(emptyList()) },
+                ) { base, genres, tags ->
+                    base.copy(
+                        genres = genres,
+                        genresList = genres.map { it.name },
+                        tags = tags,
+                    )
+                },
             )
         }
 

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/bookdetail/BookReadersViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/bookdetail/BookReadersViewModel.kt
@@ -119,15 +119,6 @@ class BookReadersViewModel(
     }
 
     /**
-     * Legacy entry point kept for Phase F cleanup (parent spec Phase F Deliverable 6).
-     *
-     * @param bookId Book ID to load readers for
-     */
-    fun loadReaders(bookId: String) {
-        observeReaders(bookId)
-    }
-
-    /**
      * Manually refresh the readers list — bypasses the debounce.
      *
      * @param bookId Book ID to refresh readers for

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/sync/SyncIndicatorViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/sync/SyncIndicatorViewModel.kt
@@ -198,20 +198,28 @@ class SyncIndicatorViewModel(
      */
     private fun describeOperation(operation: PendingOperation): String {
         val entityName = operation.entityId?.take(8) ?: "item"
-        return when (operation.operationType) {
-            PendingOperationType.BOOK_UPDATE -> "Updating book $entityName"
-            PendingOperationType.CONTRIBUTOR_UPDATE -> "Updating contributor $entityName"
-            PendingOperationType.SERIES_UPDATE -> "Updating series $entityName"
-            PendingOperationType.SET_BOOK_CONTRIBUTORS -> "Setting contributors for book $entityName"
-            PendingOperationType.SET_BOOK_SERIES -> "Setting series for book $entityName"
-            PendingOperationType.MERGE_CONTRIBUTOR -> "Merging contributors"
-            PendingOperationType.UNMERGE_CONTRIBUTOR -> "Unmerging contributor"
-            PendingOperationType.LISTENING_EVENT -> "Syncing listening data"
-            PendingOperationType.PLAYBACK_POSITION -> "Syncing playback position"
-            PendingOperationType.USER_PREFERENCES -> "Syncing preferences"
-            PendingOperationType.PROFILE_UPDATE -> "Updating profile"
-            PendingOperationType.PROFILE_AVATAR -> "Uploading avatar"
-            PendingOperationType.MARK_COMPLETE -> "Marking book complete"
-        }
+        return operation.operationType.describe(entityName)
     }
 }
+
+private fun PendingOperationType.describe(entityName: String): String =
+    when (this) {
+        PendingOperationType.BOOK_UPDATE -> "Updating book $entityName"
+        PendingOperationType.CONTRIBUTOR_UPDATE -> "Updating contributor $entityName"
+        PendingOperationType.SERIES_UPDATE -> "Updating series $entityName"
+        PendingOperationType.SET_BOOK_CONTRIBUTORS -> "Setting contributors for book $entityName"
+        PendingOperationType.SET_BOOK_SERIES -> "Setting series for book $entityName"
+        PendingOperationType.MERGE_CONTRIBUTOR -> "Merging contributors"
+        PendingOperationType.UNMERGE_CONTRIBUTOR -> "Unmerging contributor"
+        PendingOperationType.LISTENING_EVENT -> "Syncing listening data"
+        PendingOperationType.PLAYBACK_POSITION -> "Syncing playback position"
+        PendingOperationType.USER_PREFERENCES -> "Syncing preferences"
+        PendingOperationType.PROFILE_UPDATE -> "Updating profile"
+        PendingOperationType.PROFILE_AVATAR -> "Uploading avatar"
+        PendingOperationType.MARK_COMPLETE -> "Marking book complete"
+        PendingOperationType.CREATE_SHELF -> "Creating shelf"
+        PendingOperationType.UPDATE_SHELF -> "Updating shelf"
+        PendingOperationType.DELETE_SHELF -> "Deleting shelf"
+        PendingOperationType.ADD_BOOKS_TO_SHELF -> "Adding books to shelf"
+        PendingOperationType.REMOVE_BOOK_FROM_SHELF -> "Removing book from shelf"
+    }

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/tagdetail/TagDetailViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/tagdetail/TagDetailViewModel.kt
@@ -24,8 +24,6 @@ import kotlinx.coroutines.flow.stateIn
  * via [loadTag]; the flow pipeline uses `flatMapLatest` to swap upstream
  * sources when the id changes, and `.stateIn(WhileSubscribed)` so the
  * pipeline is only hot while the screen is observing.
- *
- * Known N+1 query on per-book fetch — tracked for W6; do not fix here.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class TagDetailViewModel(
@@ -48,8 +46,8 @@ class TagDetailViewModel(
                             TagDetailUiState.Error("Tag not found")
                         } else {
                             val books =
-                                bookIds
-                                    .mapNotNull { bookRepository.getBook(it) }
+                                bookRepository
+                                    .getBooks(bookIds)
                                     .sortedBy { it.title }
                             TagDetailUiState.Ready(
                                 tagId = tagId,

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/AvatarDownloadRepositoryImplTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/AvatarDownloadRepositoryImplTest.kt
@@ -1,0 +1,60 @@
+package com.calypsan.listenup.client.data.repository
+
+import com.calypsan.listenup.client.core.Success
+import com.calypsan.listenup.client.data.sync.ImageDownloaderContract
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+/**
+ * Tests for AvatarDownloadRepositoryImpl.
+ *
+ * Verifies that each repository method delegates to [ImageDownloaderContract] with the
+ * correct arguments and that async work fires on the provided scope.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class AvatarDownloadRepositoryImplTest {
+    @Test
+    fun `queueAvatarDownload triggers download with forceRefresh=false`() =
+        runTest {
+            val imageDownloader: ImageDownloaderContract = mock()
+            everySuspend { imageDownloader.downloadUserAvatar(any(), any()) } returns Success(false)
+            val repo = AvatarDownloadRepositoryImpl(imageDownloader, this)
+
+            repo.queueAvatarDownload("user-1")
+            advanceUntilIdle()
+
+            verifySuspend { imageDownloader.downloadUserAvatar("user-1", forceRefresh = false) }
+        }
+
+    @Test
+    fun `queueAvatarForceRefresh triggers download with forceRefresh=true`() =
+        runTest {
+            val imageDownloader: ImageDownloaderContract = mock()
+            everySuspend { imageDownloader.downloadUserAvatar(any(), any()) } returns Success(true)
+            val repo = AvatarDownloadRepositoryImpl(imageDownloader, this)
+
+            repo.queueAvatarForceRefresh("user-1")
+            advanceUntilIdle()
+
+            verifySuspend { imageDownloader.downloadUserAvatar("user-1", forceRefresh = true) }
+        }
+
+    @Test
+    fun `deleteAvatar delegates to imageDownloader deleteUserAvatar`() =
+        runTest {
+            val imageDownloader: ImageDownloaderContract = mock()
+            everySuspend { imageDownloader.deleteUserAvatar(any()) } returns Success(Unit)
+            val repo = AvatarDownloadRepositoryImpl(imageDownloader, this)
+
+            repo.deleteAvatar("user-1")
+
+            verifySuspend { imageDownloader.deleteUserAvatar("user-1") }
+        }
+}

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/HomeRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/HomeRepositoryTest.kt
@@ -13,6 +13,10 @@ import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -53,9 +57,11 @@ class HomeRepositoryTest {
 
         // Default stubs
         everySuspend { fixture.playbackPositionDao.getRecentPositions(any()) } returns emptyList()
+        every { fixture.playbackPositionDao.observeRecentPositions(any()) } returns flowOf(emptyList())
         everySuspend { fixture.playbackPositionDao.get(any()) } returns null
         everySuspend { fixture.playbackPositionDao.save(any()) } returns Unit
         everySuspend { fixture.bookRepository.getBook(any()) } returns null
+        everySuspend { fixture.bookRepository.getBooks(any()) } returns emptyList()
 
         return fixture
     }
@@ -122,7 +128,7 @@ class HomeRepositoryTest {
             val book = createBook(id = "book-1", title = "Test Book", duration = 10_000L)
 
             everySuspend { fixture.playbackPositionDao.getRecentPositions(10) } returns listOf(position)
-            everySuspend { fixture.bookRepository.getBook("book-1") } returns book
+            everySuspend { fixture.bookRepository.getBooks(any()) } returns listOf(book)
             val repository = fixture.build()
 
             // When
@@ -150,8 +156,8 @@ class HomeRepositoryTest {
             val book1 = createBook(id = "book-1", title = "Book One", duration = 10_000L)
 
             everySuspend { fixture.playbackPositionDao.getRecentPositions(10) } returns listOf(position1, position2)
-            everySuspend { fixture.bookRepository.getBook("book-1") } returns book1
-            everySuspend { fixture.bookRepository.getBook("book-2") } returns null // Not found
+            // getBooks returns only book1 — book2 is absent (simulates "not found")
+            everySuspend { fixture.bookRepository.getBooks(any()) } returns listOf(book1)
             val repository = fixture.build()
 
             // When
@@ -172,7 +178,7 @@ class HomeRepositoryTest {
             val book = createBook(id = "book-1", duration = 10_000L)
 
             everySuspend { fixture.playbackPositionDao.getRecentPositions(10) } returns listOf(finishedPosition)
-            everySuspend { fixture.bookRepository.getBook("book-1") } returns book
+            everySuspend { fixture.bookRepository.getBooks(any()) } returns listOf(book)
             val repository = fixture.build()
 
             // When
@@ -194,7 +200,7 @@ class HomeRepositoryTest {
             val book = createBook(id = "book-1", duration = 10_000L)
 
             everySuspend { fixture.playbackPositionDao.getRecentPositions(10) } returns listOf(almostDone)
-            everySuspend { fixture.bookRepository.getBook("book-1") } returns book
+            everySuspend { fixture.bookRepository.getBooks(any()) } returns listOf(book)
             val repository = fixture.build()
 
             // When
@@ -215,7 +221,7 @@ class HomeRepositoryTest {
             val book = createBook(id = "book-1", duration = 10_000L)
 
             everySuspend { fixture.playbackPositionDao.getRecentPositions(10) } returns listOf(position)
-            everySuspend { fixture.bookRepository.getBook("book-1") } returns book
+            everySuspend { fixture.bookRepository.getBooks(any()) } returns listOf(book)
             val repository = fixture.build()
 
             // When
@@ -236,7 +242,7 @@ class HomeRepositoryTest {
             val book = createBook(id = "book-1", duration = 0L) // Zero duration
 
             everySuspend { fixture.playbackPositionDao.getRecentPositions(10) } returns listOf(position)
-            everySuspend { fixture.bookRepository.getBook("book-1") } returns book
+            everySuspend { fixture.bookRepository.getBooks(any()) } returns listOf(book)
             val repository = fixture.build()
 
             // When
@@ -259,7 +265,7 @@ class HomeRepositoryTest {
             val book = createBook(id = "book-1", duration = 10_000L, authorNames = "Stephen King")
 
             everySuspend { fixture.playbackPositionDao.getRecentPositions(10) } returns listOf(position)
-            everySuspend { fixture.bookRepository.getBook("book-1") } returns book
+            everySuspend { fixture.bookRepository.getBooks(any()) } returns listOf(book)
             val repository = fixture.build()
 
             // When
@@ -281,7 +287,7 @@ class HomeRepositoryTest {
             val book = createBook(id = "book-1", duration = 10_000L, coverPath = "/path/to/cover.jpg")
 
             everySuspend { fixture.playbackPositionDao.getRecentPositions(10) } returns listOf(position)
-            everySuspend { fixture.bookRepository.getBook("book-1") } returns book
+            everySuspend { fixture.bookRepository.getBooks(any()) } returns listOf(book)
             val repository = fixture.build()
 
             // When
@@ -303,9 +309,7 @@ class HomeRepositoryTest {
             val books = (1..20).map { createBook(id = "book-$it", duration = 10_000L) }
 
             everySuspend { fixture.playbackPositionDao.getRecentPositions(5) } returns positions.take(5)
-            positions.take(5).forEachIndexed { index, _ ->
-                everySuspend { fixture.bookRepository.getBook("book-${index + 1}") } returns books[index]
-            }
+            everySuspend { fixture.bookRepository.getBooks(any()) } returns books.take(5)
             val repository = fixture.build()
 
             // When
@@ -339,7 +343,7 @@ class HomeRepositoryTest {
             val book = createBook(id = "book-1", duration = 10_000L)
 
             everySuspend { fixture.playbackPositionDao.getRecentPositions(10) } returns listOf(position)
-            everySuspend { fixture.bookRepository.getBook("book-1") } returns book
+            everySuspend { fixture.bookRepository.getBooks(any()) } returns listOf(book)
             val repository = fixture.build()
 
             // When
@@ -378,7 +382,7 @@ class HomeRepositoryTest {
             val book = createBook(id = "book-1", duration = 10_000L)
 
             everySuspend { fixture.playbackPositionDao.getRecentPositions(10) } returns listOf(position)
-            everySuspend { fixture.bookRepository.getBook("book-1") } returns book
+            everySuspend { fixture.bookRepository.getBooks(any()) } returns listOf(book)
             val repository = fixture.build()
 
             // When
@@ -392,5 +396,67 @@ class HomeRepositoryTest {
                 continueBook.lastPlayedAt.contains("2024-01-01"),
                 "Expected ISO 8601 from updatedAt fallback, got: ${continueBook.lastPlayedAt}",
             )
+        }
+
+    // ========== Regression Tests: N+1 fix — getBooks called once, not per book ==========
+
+    @Test
+    fun `getContinueListening calls getBooks once for multiple positions, not per book`() =
+        runTest {
+            // Given: Three positions — verifies a single batched call replaces N per-book calls
+            val fixture = createFixture()
+            val positions =
+                listOf(
+                    createPlaybackPosition("book-1", positionMs = 1000L),
+                    createPlaybackPosition("book-2", positionMs = 2000L),
+                    createPlaybackPosition("book-3", positionMs = 3000L),
+                )
+            val books =
+                listOf(
+                    createBook(id = "book-1", duration = 10_000L),
+                    createBook(id = "book-2", duration = 10_000L),
+                    createBook(id = "book-3", duration = 10_000L),
+                )
+
+            everySuspend { fixture.playbackPositionDao.getRecentPositions(any()) } returns positions
+            everySuspend { fixture.bookRepository.getBooks(any()) } returns books
+            val repository = fixture.build()
+
+            // When
+            repository.getContinueListening(10)
+
+            // Then: getBooks called exactly once (batched), never the per-book getBook
+            verifySuspend(VerifyMode.exactly(1)) { fixture.bookRepository.getBooks(any()) }
+            verifySuspend(VerifyMode.exactly(0)) { fixture.bookRepository.getBook(any()) }
+        }
+
+    @Test
+    fun `observeContinueListening calls getBooks once per emission, not per book`() =
+        runTest {
+            // Given: Three positions emitted as a single list
+            val fixture = createFixture()
+            val positions =
+                listOf(
+                    createPlaybackPosition("book-1", positionMs = 1000L),
+                    createPlaybackPosition("book-2", positionMs = 2000L),
+                    createPlaybackPosition("book-3", positionMs = 3000L),
+                )
+            val books =
+                listOf(
+                    createBook(id = "book-1", duration = 10_000L),
+                    createBook(id = "book-2", duration = 10_000L),
+                    createBook(id = "book-3", duration = 10_000L),
+                )
+
+            every { fixture.playbackPositionDao.observeRecentPositions(any()) } returns flowOf(positions)
+            everySuspend { fixture.bookRepository.getBooks(any()) } returns books
+            val repository = fixture.build()
+
+            // When: collect one emission
+            repository.observeContinueListening(10).first()
+
+            // Then: getBooks called exactly once (batched), never the per-book getBook
+            verifySuspend(VerifyMode.exactly(1)) { fixture.bookRepository.getBooks(any()) }
+            verifySuspend(VerifyMode.exactly(0)) { fixture.bookRepository.getBook(any()) }
         }
 }

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/ShelfRepositoryImplTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/ShelfRepositoryImplTest.kt
@@ -1,9 +1,18 @@
 package com.calypsan.listenup.client.data.repository
 
 import com.calypsan.listenup.client.core.Timestamp
+import com.calypsan.listenup.client.data.local.db.ShelfBookDao
 import com.calypsan.listenup.client.data.local.db.ShelfDao
 import com.calypsan.listenup.client.data.local.db.ShelfEntity
+import com.calypsan.listenup.client.data.local.db.TransactionRunner
+import com.calypsan.listenup.client.data.local.db.UserDao
 import com.calypsan.listenup.client.data.remote.ShelfApiContract
+import com.calypsan.listenup.client.data.sync.push.AddBooksToShelfHandler
+import com.calypsan.listenup.client.data.sync.push.CreateShelfHandler
+import com.calypsan.listenup.client.data.sync.push.DeleteShelfHandler
+import com.calypsan.listenup.client.data.sync.push.PendingOperationRepositoryContract
+import com.calypsan.listenup.client.data.sync.push.RemoveBookFromShelfHandler
+import com.calypsan.listenup.client.data.sync.push.UpdateShelfHandler
 import com.calypsan.listenup.client.domain.model.Shelf
 import dev.mokkery.answering.returns
 import dev.mokkery.every
@@ -42,7 +51,20 @@ class ShelfRepositoryImplTest {
     private fun createRepository(
         dao: ShelfDao = createMockShelfDao(),
         shelfApi: ShelfApiContract = createMockShelfApi(),
-    ): ShelfRepositoryImpl = ShelfRepositoryImpl(dao, shelfApi)
+    ): ShelfRepositoryImpl =
+        ShelfRepositoryImpl(
+            dao = dao,
+            shelfBookDao = mock(),
+            userDao = mock(),
+            shelfApi = shelfApi,
+            pendingOperationRepository = mock(),
+            transactionRunner = mock(),
+            createShelfHandler = CreateShelfHandler(api = shelfApi),
+            updateShelfHandler = UpdateShelfHandler(api = shelfApi),
+            deleteShelfHandler = DeleteShelfHandler(api = shelfApi),
+            addBooksToShelfHandler = AddBooksToShelfHandler(api = shelfApi),
+            removeBookFromShelfHandler = RemoveBookFromShelfHandler(api = shelfApi),
+        )
 
     // ========== Test Data Factories ==========
 

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/push/ShelfHandlersTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/push/ShelfHandlersTest.kt
@@ -1,0 +1,204 @@
+package com.calypsan.listenup.client.data.sync.push
+
+import com.calypsan.listenup.client.core.Success
+import com.calypsan.listenup.client.core.Failure
+import com.calypsan.listenup.client.data.local.db.OperationStatus
+import com.calypsan.listenup.client.data.local.db.OperationType
+import com.calypsan.listenup.client.data.local.db.PendingOperationEntity
+import com.calypsan.listenup.client.data.remote.ShelfApiContract
+import com.calypsan.listenup.client.data.remote.ShelfOwnerResponse
+import com.calypsan.listenup.client.data.remote.ShelfResponse
+import dev.mokkery.answering.returns
+import dev.mokkery.answering.throws
+import dev.mokkery.everySuspend
+import dev.mokkery.mock
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertIs
+
+/**
+ * Tests for the 5 Shelf OperationHandlers.
+ *
+ * Each handler:
+ * - Success path: verifies the correct API method is called and Success(Unit) is returned.
+ * - Failure path: verifies that a thrown exception is converted to Failure.
+ */
+class ShelfHandlersTest {
+    private val owner =
+        ShelfOwnerResponse(id = "user-1", displayName = "Alice", avatarColor = "#abc")
+
+    private val shelfResponse =
+        ShelfResponse(
+            id = "shelf-1",
+            name = "My Shelf",
+            description = "",
+            owner = owner,
+            bookCount = 0,
+            totalDuration = 0L,
+            createdAt = "2024-01-01T00:00:00Z",
+            updatedAt = "2024-01-01T00:00:00Z",
+        )
+
+    private fun pendingOp(type: OperationType): PendingOperationEntity =
+        PendingOperationEntity(
+            id = "op-1",
+            operationType = type,
+            entityType = null,
+            entityId = null,
+            payload = "{}",
+            batchKey = null,
+            status = OperationStatus.PENDING,
+            createdAt = 1000L,
+            updatedAt = 1000L,
+            attemptCount = 0,
+            lastError = null,
+        )
+
+    // ========== CreateShelfHandler ==========
+
+    @Test
+    fun `CreateShelfHandler execute - success - calls createShelf and returns Success`() =
+        runTest {
+            val api: ShelfApiContract = mock()
+            everySuspend { api.createShelf("My Shelf", "A description") } returns shelfResponse
+
+            val handler = CreateShelfHandler(api)
+            val payload = CreateShelfPayload(localId = "local-1", name = "My Shelf", description = "A description")
+            val result = handler.execute(pendingOp(OperationType.CREATE_SHELF), payload)
+
+            assertIs<Success<Unit>>(result)
+            verifySuspend { api.createShelf("My Shelf", "A description") }
+        }
+
+    @Test
+    fun `CreateShelfHandler execute - failure - returns Failure`() =
+        runTest {
+            val api: ShelfApiContract = mock()
+            everySuspend { api.createShelf("My Shelf", null) } throws RuntimeException("network error")
+
+            val handler = CreateShelfHandler(api)
+            val payload = CreateShelfPayload(localId = "local-1", name = "My Shelf", description = null)
+            val result = handler.execute(pendingOp(OperationType.CREATE_SHELF), payload)
+
+            assertIs<Failure>(result)
+        }
+
+    // ========== UpdateShelfHandler ==========
+
+    @Test
+    fun `UpdateShelfHandler execute - success - calls updateShelf and returns Success`() =
+        runTest {
+            val api: ShelfApiContract = mock()
+            everySuspend { api.updateShelf("shelf-1", "Renamed", null) } returns shelfResponse
+
+            val handler = UpdateShelfHandler(api)
+            val payload = UpdateShelfPayload(shelfId = "shelf-1", name = "Renamed", description = null)
+            val result = handler.execute(pendingOp(OperationType.UPDATE_SHELF), payload)
+
+            assertIs<Success<Unit>>(result)
+            verifySuspend { api.updateShelf("shelf-1", "Renamed", null) }
+        }
+
+    @Test
+    fun `UpdateShelfHandler execute - failure - returns Failure`() =
+        runTest {
+            val api: ShelfApiContract = mock()
+            everySuspend { api.updateShelf("shelf-1", "Renamed", null) } throws RuntimeException("network error")
+
+            val handler = UpdateShelfHandler(api)
+            val payload = UpdateShelfPayload(shelfId = "shelf-1", name = "Renamed", description = null)
+            val result = handler.execute(pendingOp(OperationType.UPDATE_SHELF), payload)
+
+            assertIs<Failure>(result)
+        }
+
+    // ========== DeleteShelfHandler ==========
+
+    @Test
+    fun `DeleteShelfHandler execute - success - calls deleteShelf and returns Success`() =
+        runTest {
+            val api: ShelfApiContract = mock()
+            everySuspend { api.deleteShelf("shelf-1") } returns Unit
+
+            val handler = DeleteShelfHandler(api)
+            val payload = DeleteShelfPayload(shelfId = "shelf-1")
+            val result = handler.execute(pendingOp(OperationType.DELETE_SHELF), payload)
+
+            assertIs<Success<Unit>>(result)
+            verifySuspend { api.deleteShelf("shelf-1") }
+        }
+
+    @Test
+    fun `DeleteShelfHandler execute - failure - returns Failure`() =
+        runTest {
+            val api: ShelfApiContract = mock()
+            everySuspend { api.deleteShelf("shelf-1") } throws RuntimeException("network error")
+
+            val handler = DeleteShelfHandler(api)
+            val payload = DeleteShelfPayload(shelfId = "shelf-1")
+            val result = handler.execute(pendingOp(OperationType.DELETE_SHELF), payload)
+
+            assertIs<Failure>(result)
+        }
+
+    // ========== AddBooksToShelfHandler ==========
+
+    @Test
+    fun `AddBooksToShelfHandler execute - success - calls addBooks and returns Success`() =
+        runTest {
+            val api: ShelfApiContract = mock()
+            val bookIds = listOf("book-1", "book-2")
+            everySuspend { api.addBooks("shelf-1", bookIds) } returns Unit
+
+            val handler = AddBooksToShelfHandler(api)
+            val payload = AddBooksToShelfPayload(shelfId = "shelf-1", bookIds = bookIds)
+            val result = handler.execute(pendingOp(OperationType.ADD_BOOKS_TO_SHELF), payload)
+
+            assertIs<Success<Unit>>(result)
+            verifySuspend { api.addBooks("shelf-1", bookIds) }
+        }
+
+    @Test
+    fun `AddBooksToShelfHandler execute - failure - returns Failure`() =
+        runTest {
+            val api: ShelfApiContract = mock()
+            val bookIds = listOf("book-1")
+            everySuspend { api.addBooks("shelf-1", bookIds) } throws RuntimeException("network error")
+
+            val handler = AddBooksToShelfHandler(api)
+            val payload = AddBooksToShelfPayload(shelfId = "shelf-1", bookIds = bookIds)
+            val result = handler.execute(pendingOp(OperationType.ADD_BOOKS_TO_SHELF), payload)
+
+            assertIs<Failure>(result)
+        }
+
+    // ========== RemoveBookFromShelfHandler ==========
+
+    @Test
+    fun `RemoveBookFromShelfHandler execute - success - calls removeBook and returns Success`() =
+        runTest {
+            val api: ShelfApiContract = mock()
+            everySuspend { api.removeBook("shelf-1", "book-1") } returns Unit
+
+            val handler = RemoveBookFromShelfHandler(api)
+            val payload = RemoveBookFromShelfPayload(shelfId = "shelf-1", bookId = "book-1")
+            val result = handler.execute(pendingOp(OperationType.REMOVE_BOOK_FROM_SHELF), payload)
+
+            assertIs<Success<Unit>>(result)
+            verifySuspend { api.removeBook("shelf-1", "book-1") }
+        }
+
+    @Test
+    fun `RemoveBookFromShelfHandler execute - failure - returns Failure`() =
+        runTest {
+            val api: ShelfApiContract = mock()
+            everySuspend { api.removeBook("shelf-1", "book-1") } throws RuntimeException("network error")
+
+            val handler = RemoveBookFromShelfHandler(api)
+            val payload = RemoveBookFromShelfPayload(shelfId = "shelf-1", bookId = "book-1")
+            val result = handler.execute(pendingOp(OperationType.REMOVE_BOOK_FROM_SHELF), payload)
+
+            assertIs<Failure>(result)
+        }
+}

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/sse/SSEEventProcessorTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/sse/SSEEventProcessorTest.kt
@@ -48,6 +48,7 @@ import com.calypsan.listenup.client.data.sync.BookPayload
 import com.calypsan.listenup.client.data.sync.BookDeletedPayload
 import com.calypsan.listenup.client.data.sync.SSEChannelMessage
 import com.calypsan.listenup.client.data.sync.SSEEvent
+import com.calypsan.listenup.client.data.sync.ProfilePayload
 import com.calypsan.listenup.client.data.sync.ScanCompletedPayload
 import com.calypsan.listenup.client.data.sync.ScanStartedPayload
 import com.calypsan.listenup.client.data.sync.SessionStartedPayload
@@ -208,6 +209,8 @@ class SSEEventProcessorTest {
 
             // AvatarDownloadRepository stubs
             every { avatarDownloadRepository.queueAvatarDownload(any()) } returns Unit
+            every { avatarDownloadRepository.queueAvatarForceRefresh(any()) } returns Unit
+            everySuspend { avatarDownloadRepository.deleteAvatar(any()) } returns Unit
 
             // PlaybackStateProvider stubs
             every { playbackStateProvider.currentBookId } returns currentBookIdFlow
@@ -905,6 +908,39 @@ class SSEEventProcessorTest {
             advanceUntilIdle()
 
             verify { fixture.avatarDownloadRepository.queueAvatarDownload(testUserId) }
+        }
+
+    // ========== ProfileUpdated Avatar Routing Tests ==========
+
+    @Test
+    fun `handleProfileUpdated routes force-refresh through avatarDownloadRepository not imageDownloader`() =
+        runTest {
+            val testUserId = "user-profile-updated"
+            val fixture = TestFixture(this)
+            val processor = fixture.build()
+
+            val event =
+                SSEEvent.ProfileUpdated(
+                    timestamp = "2026-04-19T10:00:00Z",
+                    data =
+                        ProfilePayload(
+                            userId = testUserId,
+                            firstName = "Test",
+                            lastName = "User",
+                            avatarType = "image",
+                            avatarValue = "/avatars/$testUserId.jpg",
+                            avatarColor = "#6B7280",
+                        ),
+                )
+            processor.process(SSEChannelMessage.Wire(event))
+            advanceUntilIdle()
+
+            // Must route through repository
+            verify { fixture.avatarDownloadRepository.queueAvatarForceRefresh(testUserId) }
+            // Must NOT call imageDownloader directly
+            verifySuspend(VerifyMode.not) {
+                fixture.imageDownloader.downloadUserAvatar(testUserId, forceRefresh = true)
+            }
         }
 
     companion object {

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/sse/SSEEventProcessorTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/sse/SSEEventProcessorTest.kt
@@ -41,7 +41,7 @@ import com.calypsan.listenup.client.data.repository.CoverDownloadRepositoryImpl
 import com.calypsan.listenup.client.data.sync.ImageDownloaderContract
 import com.calypsan.listenup.client.data.sync.SessionDaos
 import com.calypsan.listenup.client.data.sync.UserDaos
-import com.calypsan.listenup.client.data.sync.pull.BookRelationshipDaos
+import com.calypsan.listenup.client.data.sync.sse.BookRelationshipDaos
 import com.calypsan.listenup.client.domain.repository.AvatarDownloadRepository
 import com.calypsan.listenup.client.domain.repository.SessionRepository
 import com.calypsan.listenup.client.data.sync.BookPayload

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/playback/ProgressTrackerTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/playback/ProgressTrackerTest.kt
@@ -414,4 +414,22 @@ class ProgressTrackerTest {
             // Then - verify save was called (position captured)
             verifySuspend { fixture.positionDao.save(any()) }
         }
+
+    // ========== clearProgress Tests ==========
+
+    @Test
+    fun `clearProgress delegates to positionRepository not positionDao`() =
+        runTest {
+            // Verifies Finding 07 Rule 5: DAO writes in /playback/ routed through repository.
+            // positionRepository.delete is the correct domain-layer entry point.
+            val fixture = createFixture()
+            val bookId = BookId("book-clear")
+            everySuspend { fixture.positionRepository.delete(bookId.value) } returns Unit
+
+            val tracker = fixture.build()
+
+            tracker.clearProgress(bookId)
+
+            verifySuspend { fixture.positionRepository.delete(bookId.value) }
+        }
 }

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/tagdetail/TagDetailViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/tagdetail/TagDetailViewModelTest.kt
@@ -1,0 +1,135 @@
+package com.calypsan.listenup.client.presentation.tagdetail
+
+import com.calypsan.listenup.client.TestData
+import com.calypsan.listenup.client.domain.model.Tag
+import com.calypsan.listenup.client.domain.repository.BookRepository
+import com.calypsan.listenup.client.domain.repository.TagRepository
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertIs
+
+/**
+ * Tests for TagDetailViewModel.
+ *
+ * Tests cover:
+ * - Initial state (Idle)
+ * - Books loaded for a tag
+ * - N+1 regression: getBooks called once with full list, not per-book getBook
+ *
+ * Uses Mokkery for mocking domain repositories.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class TagDetailViewModelTest {
+    private val testDispatcher = StandardTestDispatcher()
+
+    // ========== Test Fixtures ==========
+
+    private class TestFixture {
+        val tagRepository: TagRepository = mock()
+        val bookRepository: BookRepository = mock()
+
+        fun build(): TagDetailViewModel =
+            TagDetailViewModel(
+                tagRepository = tagRepository,
+                bookRepository = bookRepository,
+            )
+    }
+
+    private fun createFixture(): TestFixture {
+        val fixture = TestFixture()
+
+        every { fixture.tagRepository.observeById(any()) } returns flowOf(null)
+        every { fixture.tagRepository.observeBookIdsForTag(any()) } returns flowOf(emptyList())
+        everySuspend { fixture.bookRepository.getBooks(any()) } returns emptyList()
+
+        return fixture
+    }
+
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterTest
+    fun teardown() {
+        Dispatchers.resetMain()
+    }
+
+    // ========== Basic State Tests ==========
+
+    @Test
+    fun `initial state is Idle`() =
+        runTest {
+            val fixture = createFixture()
+            val viewModel = fixture.build()
+
+            assertIs<TagDetailUiState.Idle>(viewModel.state.value)
+        }
+
+    @Test
+    fun `loadTag transitions to Ready when tag and books are found`() =
+        runTest {
+            // Given
+            val fixture = createFixture()
+            val tag = Tag(id = "tag-1", slug = "found-family", bookCount = 2)
+            val books = listOf(TestData.book(id = "book-1"), TestData.book(id = "book-2"))
+
+            every { fixture.tagRepository.observeById("tag-1") } returns flowOf(tag)
+            every { fixture.tagRepository.observeBookIdsForTag("tag-1") } returns flowOf(listOf("book-1", "book-2"))
+            everySuspend { fixture.bookRepository.getBooks(any()) } returns books
+
+            val viewModel = fixture.build()
+            backgroundScope.launch { viewModel.state.collect { } }
+
+            // When
+            viewModel.loadTag("tag-1")
+            advanceUntilIdle()
+
+            // Then
+            assertIs<TagDetailUiState.Ready>(viewModel.state.value)
+        }
+
+    // ========== Regression Test: N+1 fix — getBooks called once with full list ==========
+
+    @Test
+    fun `observeBooksForTag calls getBooks once with full list, not per-book getBook`() =
+        runTest {
+            // Given: tag with three book IDs — verifies batched call replaces per-book loop
+            val fixture = createFixture()
+            val tag = Tag(id = "tag-1", slug = "mystery", bookCount = 3)
+            val bookIds = listOf("book-1", "book-2", "book-3")
+            val books = bookIds.map { TestData.book(id = it) }
+
+            every { fixture.tagRepository.observeById("tag-1") } returns flowOf(tag)
+            every { fixture.tagRepository.observeBookIdsForTag("tag-1") } returns flowOf(bookIds)
+            everySuspend { fixture.bookRepository.getBooks(any()) } returns books
+
+            val viewModel = fixture.build()
+            backgroundScope.launch { viewModel.state.collect { } }
+
+            // When
+            viewModel.loadTag("tag-1")
+            advanceUntilIdle()
+
+            // Then: getBooks called exactly once (batched), never the per-book getBook
+            verifySuspend(VerifyMode.exactly(1)) { fixture.bookRepository.getBooks(any()) }
+            verifySuspend(VerifyMode.exactly(0)) { fixture.bookRepository.getBook(any()) }
+        }
+}

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/test/fake/FakeSessionRepository.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/test/fake/FakeSessionRepository.kt
@@ -29,11 +29,6 @@ class FakeSessionRepository(
     /** Map of bookId → number of times [refreshBookReaders] was called. */
     val refreshCounts: Map<String, Int> get() = _refreshCounts.toMap()
 
-    override suspend fun getBookReaders(bookId: String): List<ReaderInfo> = state.value[bookId]?.otherReaders.orEmpty()
-
-    override suspend fun getBookReadersResult(bookId: String): AppResult<BookReadersResult> =
-        Success(state.value[bookId] ?: empty)
-
     override fun observeBookReaders(bookId: String): Flow<BookReadersResult> =
         state.asStateFlow().map { it[bookId] ?: empty }
 

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/test/fake/FakeSessionRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/test/fake/FakeSessionRepositoryTest.kt
@@ -23,27 +23,6 @@ class FakeSessionRepositoryTest {
         )
 
     @Test
-    fun seededReadersAreReturnedByGetBookReaders() =
-        runTest {
-            val seed =
-                mapOf(
-                    "book-1" to
-                        BookReadersResult(
-                            yourSessions = emptyList(),
-                            otherReaders = listOf(reader("alice"), reader("bob")),
-                            totalReaders = 2,
-                            totalCompletions = 0,
-                        ),
-                )
-            val repo = FakeSessionRepository(initialReaders = seed)
-
-            val readers = repo.getBookReaders("book-1")
-
-            assertEquals(2, readers.size)
-            assertTrue(readers.any { it.userId == "alice" })
-        }
-
-    @Test
     fun setReadersUpdatesObservers() =
         runTest {
             val repo = FakeSessionRepository()
@@ -77,25 +56,5 @@ class FakeSessionRepositoryTest {
             repo.refreshBookReaders("book-1")
 
             assertEquals(2, repo.refreshCounts["book-1"])
-        }
-
-    @Test
-    fun getBookReadersResultReturnsSuccess() =
-        runTest {
-            val seed =
-                mapOf(
-                    "book-1" to
-                        BookReadersResult(
-                            yourSessions = emptyList(),
-                            otherReaders = emptyList(),
-                            totalReaders = 0,
-                            totalCompletions = 0,
-                        ),
-                )
-            val repo = FakeSessionRepository(initialReaders = seed)
-
-            val result = repo.getBookReadersResult("book-1")
-
-            assertTrue(result is Success)
         }
 }

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/BookDaoRandomUnstartedTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/BookDaoRandomUnstartedTest.kt
@@ -1,0 +1,213 @@
+package com.calypsan.listenup.client.data.local.db
+
+import app.cash.turbine.test
+import com.calypsan.listenup.client.core.BookId
+import com.calypsan.listenup.client.core.SeriesId
+import com.calypsan.listenup.client.core.Timestamp
+import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
+import kotlinx.coroutines.test.runTest
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Regression coverage for the Discover "Random Unstarted" silent-filter bug (W6 Phase F, Drift #1).
+ *
+ * Prior to this test suite three DAO methods silently applied a
+ * `bs.sequence IN ('1', '0', '0.5')` filter, hiding every mid-series book from
+ * Discover. The method names did not advertise this filter.
+ *
+ * The fix (per the rubric rule "Query-shaping lives in the repository, not the DAO;
+ * DAO methods are named for exactly what they return"):
+ *  - [BookDao.observeRandomUnstartedBooks], [BookDao.getRandomUnstartedBooks], and
+ *    [BookDao.observeRandomUnstartedBooksWithAuthor] are now neutral queries (no series filter).
+ *  - [BookDao.observeRandomUnstartedBooksFirstInSeriesOnly],
+ *    [BookDao.getRandomUnstartedBooksFirstInSeriesOnly], and
+ *    [BookDao.observeRandomUnstartedBooksFirstInSeriesWithAuthor] carry the original
+ *    filter under names that tell the truth.
+ *
+ * These tests seed a mid-series book (sequence "3") alongside a standalone and a
+ * first-in-series book, then assert:
+ *  - neutral methods include the mid-series book
+ *  - filtered methods exclude the mid-series book
+ */
+class BookDaoRandomUnstartedTest {
+    private val db: ListenUpDatabase = createInMemoryTestDatabase()
+    private val bookDao = db.bookDao()
+    private val seriesDao = db.seriesDao()
+    private val bookSeriesDao = db.bookSeriesDao()
+
+    @AfterTest
+    fun tearDown() {
+        db.close()
+    }
+
+    private suspend fun seedBook(id: String) {
+        bookDao.upsert(
+            BookEntity(
+                id = BookId(id),
+                title = "Book $id",
+                sortTitle = "Book $id",
+                subtitle = null,
+                coverUrl = null,
+                coverBlurHash = null,
+                dominantColor = null,
+                darkMutedColor = null,
+                vibrantColor = null,
+                totalDuration = 0L,
+                description = null,
+                publishYear = null,
+                publisher = null,
+                language = null,
+                isbn = null,
+                asin = null,
+                abridged = false,
+                syncState = SyncState.SYNCED,
+                lastModified = Timestamp(1L),
+                serverVersion = Timestamp(1L),
+                createdAt = Timestamp(1L),
+                updatedAt = Timestamp(1L),
+            ),
+        )
+    }
+
+    private suspend fun seedSeries(
+        id: String,
+        name: String,
+    ) {
+        seriesDao.upsert(
+            SeriesEntity(
+                id = SeriesId(id),
+                name = name,
+                description = null,
+                syncState = SyncState.SYNCED,
+                lastModified = Timestamp(1L),
+                serverVersion = Timestamp(1L),
+                createdAt = Timestamp(1L),
+                updatedAt = Timestamp(1L),
+            ),
+        )
+    }
+
+    private suspend fun linkBookToSeries(
+        bookId: String,
+        seriesId: String,
+        sequence: String?,
+    ) {
+        bookSeriesDao.insertAll(
+            listOf(
+                BookSeriesCrossRef(
+                    bookId = BookId(bookId),
+                    seriesId = SeriesId(seriesId),
+                    sequence = sequence,
+                ),
+            ),
+        )
+    }
+
+    /** Seeds: standalone, first-in-series (sequence "1"), mid-series (sequence "3"). */
+    private suspend fun seedThreeBooks() {
+        seedBook(id = "standalone")
+        seedBook(id = "first-in-series")
+        seedBook(id = "mid-series")
+
+        seedSeries(id = "s1", name = "Test Series")
+        linkBookToSeries(bookId = "first-in-series", seriesId = "s1", sequence = "1")
+        linkBookToSeries(bookId = "mid-series", seriesId = "s1", sequence = "3")
+    }
+
+    // ── observeRandomUnstartedBooks ──────────────────────────────────────────────
+
+    @Test
+    fun `observeRandomUnstartedBooks returns mid-series books (neutral, no sequence filter)`() =
+        runTest {
+            seedThreeBooks()
+
+            bookDao.observeRandomUnstartedBooks(limit = 10).test {
+                val emitted = awaitItem().map { it.id.value }.toSet()
+                assertTrue(
+                    "mid-series" in emitted,
+                    "neutral query must include mid-series book; DAO name must not lie",
+                )
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `observeRandomUnstartedBooksFirstInSeriesOnly excludes mid-series books`() =
+        runTest {
+            seedThreeBooks()
+
+            bookDao.observeRandomUnstartedBooksFirstInSeriesOnly(limit = 10).test {
+                val emitted = awaitItem().map { it.id.value }.toSet()
+                assertEquals(
+                    setOf("standalone", "first-in-series"),
+                    emitted,
+                    "filtered query must drop mid-series book (sequence NOT IN '1','0','0.5')",
+                )
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    // ── getRandomUnstartedBooks ──────────────────────────────────────────────────
+
+    @Test
+    fun `getRandomUnstartedBooks returns mid-series books (neutral, no sequence filter)`() =
+        runTest {
+            seedThreeBooks()
+
+            val emitted = bookDao.getRandomUnstartedBooks(limit = 10).map { it.id.value }.toSet()
+            assertTrue(
+                "mid-series" in emitted,
+                "neutral query must include mid-series book; DAO name must not lie",
+            )
+        }
+
+    @Test
+    fun `getRandomUnstartedBooksFirstInSeriesOnly excludes mid-series books`() =
+        runTest {
+            seedThreeBooks()
+
+            val emitted =
+                bookDao.getRandomUnstartedBooksFirstInSeriesOnly(limit = 10).map { it.id.value }.toSet()
+            assertEquals(
+                setOf("standalone", "first-in-series"),
+                emitted,
+                "filtered query must drop mid-series book (sequence NOT IN '1','0','0.5')",
+            )
+        }
+
+    // ── observeRandomUnstartedBooksWithAuthor ────────────────────────────────────
+
+    @Test
+    fun `observeRandomUnstartedBooksWithAuthor returns mid-series books (neutral, no sequence filter)`() =
+        runTest {
+            seedThreeBooks()
+
+            bookDao.observeRandomUnstartedBooksWithAuthor(limit = 10).test {
+                val emitted = awaitItem().map { it.id.value }.toSet()
+                assertTrue(
+                    "mid-series" in emitted,
+                    "neutral query must include mid-series book; DAO name must not lie",
+                )
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `observeRandomUnstartedBooksFirstInSeriesWithAuthor excludes mid-series books`() =
+        runTest {
+            seedThreeBooks()
+
+            bookDao.observeRandomUnstartedBooksFirstInSeriesWithAuthor(limit = 10).test {
+                val emitted = awaitItem().map { it.id.value }.toSet()
+                assertEquals(
+                    setOf("standalone", "first-in-series"),
+                    emitted,
+                    "filtered query must drop mid-series book (sequence NOT IN '1','0','0.5')",
+                )
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+}

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/BookWithContributorsMapperTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/BookWithContributorsMapperTest.kt
@@ -1,0 +1,259 @@
+package com.calypsan.listenup.client.data.local.db
+
+import com.calypsan.listenup.client.core.BookId
+import com.calypsan.listenup.client.core.ContributorId
+import com.calypsan.listenup.client.core.SeriesId
+import com.calypsan.listenup.client.core.Timestamp
+import com.calypsan.listenup.client.domain.model.BookContributor
+import com.calypsan.listenup.client.domain.model.BookSeries
+import com.calypsan.listenup.client.domain.repository.ImageStorage
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Golden-output tests for the canonical [BookWithContributors.toDomain] mapper.
+ *
+ * These tests pin the canonical mapper's current behavior so a future regression
+ * fails immediately. They assert what the mapper DOES produce, not what a caller
+ * might wish it produced (e.g., allContributors is always emptyList here — that
+ * is the canonical mapper's contract; see Task 13 drift row for future consolidation).
+ */
+class BookWithContributorsMapperTest {
+    private val bookId = BookId("book-1")
+    private val createdAt = Timestamp(1_700_000_000_000L)
+    private val updatedAt = Timestamp(1_700_000_001_000L)
+
+    private fun makeBook() =
+        BookEntity(
+            id = bookId,
+            title = "The Way of Kings",
+            sortTitle = "Way of Kings, The",
+            subtitle = "The Stormlight Archive",
+            coverUrl = "https://example.com/cover.jpg",
+            coverBlurHash = "L5H2EC=PM+yV",
+            dominantColor = 0xFF2244CC.toInt(),
+            darkMutedColor = 0xFF112233.toInt(),
+            vibrantColor = 0xFF3366FF.toInt(),
+            totalDuration = 72_000_000L,
+            description = "A fantasy epic.",
+            publishYear = 2010,
+            publisher = "Tor Books",
+            language = "en",
+            isbn = "978-0-7653-2637-9",
+            asin = "B003P2WO5E",
+            abridged = false,
+            syncState = SyncState.SYNCED,
+            lastModified = updatedAt,
+            serverVersion = updatedAt,
+            createdAt = createdAt,
+            updatedAt = updatedAt,
+        )
+
+    private val authorId = ContributorId("contrib-author")
+    private val narratorId = ContributorId("contrib-narrator")
+    private val narrator2Id = ContributorId("contrib-narrator2")
+    private val seriesId = SeriesId("series-1")
+
+    private fun makeContributors() =
+        listOf(
+            ContributorEntity(
+                id = authorId,
+                name = "Brandon Sanderson",
+                sortName = "Sanderson, Brandon",
+                asin = null,
+                description = null,
+                imagePath = null,
+                syncState = SyncState.SYNCED,
+                lastModified = updatedAt,
+                serverVersion = updatedAt,
+                createdAt = createdAt,
+                updatedAt = updatedAt,
+            ),
+            ContributorEntity(
+                id = narratorId,
+                name = "Michael Kramer",
+                sortName = null,
+                asin = null,
+                description = null,
+                imagePath = null,
+                syncState = SyncState.SYNCED,
+                lastModified = updatedAt,
+                serverVersion = updatedAt,
+                createdAt = createdAt,
+                updatedAt = updatedAt,
+            ),
+            ContributorEntity(
+                id = narrator2Id,
+                name = "Kate Reading",
+                sortName = null,
+                asin = null,
+                description = null,
+                imagePath = null,
+                syncState = SyncState.SYNCED,
+                lastModified = updatedAt,
+                serverVersion = updatedAt,
+                createdAt = createdAt,
+                updatedAt = updatedAt,
+            ),
+        )
+
+    private fun makeContributorRoles() =
+        listOf(
+            BookContributorCrossRef(
+                bookId = bookId,
+                contributorId = authorId,
+                role = "author",
+                creditedAs = null,
+            ),
+            BookContributorCrossRef(
+                bookId = bookId,
+                contributorId = narratorId,
+                role = "narrator",
+                creditedAs = null,
+            ),
+            BookContributorCrossRef(
+                bookId = bookId,
+                contributorId = narrator2Id,
+                role = "narrator",
+                creditedAs = null,
+            ),
+        )
+
+    private fun makeSeries() =
+        listOf(
+            SeriesEntity(
+                id = seriesId,
+                name = "The Stormlight Archive",
+                description = null,
+                syncState = SyncState.SYNCED,
+                lastModified = updatedAt,
+                serverVersion = updatedAt,
+                createdAt = createdAt,
+                updatedAt = updatedAt,
+            ),
+        )
+
+    private fun makeSeriesSequences() =
+        listOf(
+            BookSeriesCrossRef(
+                bookId = bookId,
+                seriesId = seriesId,
+                sequence = "1",
+            ),
+        )
+
+    @Test
+    fun `toDomain preserves all populated fields with a representative fixture`() {
+        val imageStorage: ImageStorage = mock()
+        every { imageStorage.exists(any()) } returns true
+        every { imageStorage.getCoverPath(any()) } returns "/data/covers/book-1.jpg"
+
+        val fixture =
+            BookWithContributors(
+                book = makeBook(),
+                contributors = makeContributors(),
+                contributorRoles = makeContributorRoles(),
+                series = makeSeries(),
+                seriesSequences = makeSeriesSequences(),
+            )
+
+        val result = fixture.toDomain(imageStorage, includeSeries = true)
+
+        assertEquals(bookId, result.id)
+        assertEquals("The Way of Kings", result.title)
+        assertEquals("Way of Kings, The", result.sortTitle)
+        assertEquals("The Stormlight Archive", result.subtitle)
+        assertEquals("/data/covers/book-1.jpg", result.coverPath)
+        assertEquals("L5H2EC=PM+yV", result.coverBlurHash)
+        assertEquals(0xFF2244CC.toInt(), result.dominantColor)
+        assertEquals(0xFF112233.toInt(), result.darkMutedColor)
+        assertEquals(0xFF3366FF.toInt(), result.vibrantColor)
+        assertEquals(72_000_000L, result.duration)
+        assertEquals("A fantasy epic.", result.description)
+        assertEquals(2010, result.publishYear)
+        assertEquals("Tor Books", result.publisher)
+        assertEquals("en", result.language)
+        assertEquals("978-0-7653-2637-9", result.isbn)
+        assertEquals("B003P2WO5E", result.asin)
+        assertEquals(false, result.abridged)
+        assertEquals(createdAt, result.addedAt)
+        assertEquals(updatedAt, result.updatedAt)
+        // genres and tags are always emptyList — loaded on-demand when editing
+        assertEquals(emptyList(), result.genres)
+        assertEquals(emptyList(), result.tags)
+        // allContributors is always emptyList from this mapper (see Task 13 drift row)
+        assertEquals(emptyList(), result.allContributors)
+        // rating is always null from this mapper
+        assertEquals(null, result.rating)
+        // authors
+        assertEquals(
+            listOf(BookContributor(id = authorId.value, name = "Brandon Sanderson")),
+            result.authors,
+        )
+        // narrators
+        assertEquals(
+            listOf(
+                BookContributor(id = narratorId.value, name = "Michael Kramer"),
+                BookContributor(id = narrator2Id.value, name = "Kate Reading"),
+            ),
+            result.narrators,
+        )
+        // series
+        assertEquals(
+            listOf(BookSeries(seriesId = seriesId.value, seriesName = "The Stormlight Archive", sequence = "1")),
+            result.series,
+        )
+    }
+
+    @Test
+    fun `toDomain with includeSeries=false omits series fields`() {
+        val imageStorage: ImageStorage = mock()
+        every { imageStorage.exists(any()) } returns false
+
+        val fixture =
+            BookWithContributors(
+                book = makeBook(),
+                contributors = makeContributors(),
+                contributorRoles = makeContributorRoles(),
+                series = makeSeries(),
+                seriesSequences = makeSeriesSequences(),
+            )
+
+        val result = fixture.toDomain(imageStorage, includeSeries = false)
+
+        assertEquals(emptyList(), result.series)
+        // cover is null because imageStorage.exists returns false
+        assertEquals(null, result.coverPath)
+        // non-series fields still populated
+        assertEquals("The Way of Kings", result.title)
+        assertEquals(
+            listOf(BookContributor(id = authorId.value, name = "Brandon Sanderson")),
+            result.authors,
+        )
+    }
+
+    @Test
+    fun `toDomain handles empty contributors list`() {
+        val imageStorage: ImageStorage = mock()
+        every { imageStorage.exists(any()) } returns false
+
+        val fixture =
+            BookWithContributors(
+                book = makeBook(),
+                contributors = emptyList(),
+                contributorRoles = emptyList(),
+                series = emptyList(),
+                seriesSequences = emptyList(),
+            )
+
+        val result = fixture.toDomain(imageStorage, includeSeries = true)
+
+        assertEquals(emptyList(), result.authors)
+        assertEquals(emptyList(), result.narrators)
+        assertEquals(emptyList(), result.series)
+    }
+}

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/ShelfRepositoryImplCommandTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/ShelfRepositoryImplCommandTest.kt
@@ -1,0 +1,389 @@
+package com.calypsan.listenup.client.data.repository
+
+import com.calypsan.listenup.client.core.BookId
+import com.calypsan.listenup.client.core.Timestamp
+import com.calypsan.listenup.client.core.UserId
+import com.calypsan.listenup.client.data.local.db.BookEntity
+import com.calypsan.listenup.client.data.local.db.EntityType
+import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
+import com.calypsan.listenup.client.data.local.db.OperationType
+import com.calypsan.listenup.client.data.local.db.RoomTransactionRunner
+import com.calypsan.listenup.client.data.local.db.ShelfBookCrossRef
+import com.calypsan.listenup.client.data.local.db.ShelfEntity
+import com.calypsan.listenup.client.data.local.db.SyncState
+import com.calypsan.listenup.client.data.local.db.UserEntity
+import com.calypsan.listenup.client.data.remote.ShelfApiContract
+import com.calypsan.listenup.client.data.sync.push.AddBooksToShelfHandler
+import com.calypsan.listenup.client.data.sync.push.CreateShelfHandler
+import com.calypsan.listenup.client.data.sync.push.DeleteShelfHandler
+import com.calypsan.listenup.client.data.sync.push.PendingOperationRepositoryContract
+import com.calypsan.listenup.client.data.sync.push.RemoveBookFromShelfHandler
+import com.calypsan.listenup.client.data.sync.push.UpdateShelfHandler
+import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
+import dev.mokkery.answering.throws
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import kotlinx.coroutines.test.runTest
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Seam-level tests for [ShelfRepositoryImpl]'s 5 command methods.
+ *
+ * Each method is tested for:
+ * 1. Happy path — Room row written + pending-op queued with correct type/entityId.
+ * 2. Transaction atomicity — when the queue step throws, the Room write rolls back.
+ *
+ * Uses a real in-memory [ListenUpDatabase] with a real [RoomTransactionRunner] so
+ * transaction rollback is exercised end-to-end. Handlers are real instances (they
+ * are final classes) backed by a mocked [ShelfApiContract] — the API is never called
+ * inside the `atomically` block, so the mock is never touched. The
+ * [PendingOperationRepositoryContract] is mocked only for the atomicity tests where
+ * we need `queue` to throw.
+ */
+class ShelfRepositoryImplCommandTest {
+    private val db: ListenUpDatabase = createInMemoryTestDatabase()
+    private val shelfApi: ShelfApiContract = mock()
+
+    @AfterTest
+    fun tearDown() {
+        db.close()
+    }
+
+    // -------------------------------------------------------------------------
+    // createShelf
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `createShelf writes entity to Room and queues CREATE_SHELF pending op`() =
+        runTest {
+            seedUser()
+
+            val repo = createRepo()
+            val shelf = repo.createShelf(name = "Fantasy", description = "Epic reads")
+
+            // Room has the new shelf
+            val stored = db.shelfDao().getById(shelf.id)
+            assertNotNull(stored, "shelf must be persisted to Room")
+            assertEquals("Fantasy", stored.name)
+            assertEquals("Epic reads", stored.description)
+            assertEquals(SyncState.NOT_SYNCED, stored.syncState)
+
+            // A pending op was queued
+            val ops = db.pendingOperationDao().getOldestPending()
+            assertNotNull(ops, "a pending operation must have been queued")
+            assertEquals(OperationType.CREATE_SHELF, ops.operationType)
+            assertEquals(shelf.id, ops.entityId)
+            assertEquals(EntityType.SHELF, ops.entityType)
+        }
+
+    @Test
+    fun `createShelf returns Shelf domain model with correct fields`() =
+        runTest {
+            seedUser(displayName = "Simon")
+
+            val repo = createRepo()
+            val shelf = repo.createShelf(name = "Sci-Fi", description = null)
+
+            assertEquals("Sci-Fi", shelf.name)
+            assertNull(shelf.description)
+            assertTrue(shelf.id.isNotEmpty())
+        }
+
+    @Test
+    fun `createShelf rolls back Room write when queue throws`() =
+        runTest {
+            seedUser()
+
+            val repo = createRepo(pendingOpQueueThrows = true)
+            val shelfId =
+                runCatching { repo.createShelf(name = "Horror", description = null) }
+                    .fold(onSuccess = { it.id }, onFailure = { null })
+
+            // If the throw propagated, shelfId is null; if somehow set, Room must be empty
+            val stored = shelfId?.let { db.shelfDao().getById(it) }
+            assertNull(stored, "Room write must roll back when queue throws")
+
+            // No pending ops either
+            assertNull(db.pendingOperationDao().getOldestPending(), "no pending op after rollback")
+        }
+
+    // -------------------------------------------------------------------------
+    // updateShelf
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `updateShelf writes updated entity to Room and queues UPDATE_SHELF pending op`() =
+        runTest {
+            val shelfId = seedShelf(name = "Old Name")
+
+            val repo = createRepo()
+            repo.updateShelf(shelfId, name = "New Name", description = "Updated desc")
+
+            val stored = db.shelfDao().getById(shelfId)
+            assertNotNull(stored)
+            assertEquals("New Name", stored.name)
+            assertEquals("Updated desc", stored.description)
+            assertEquals(SyncState.NOT_SYNCED, stored.syncState)
+
+            val ops = db.pendingOperationDao().getOldestPending()
+            assertNotNull(ops)
+            assertEquals(OperationType.UPDATE_SHELF, ops.operationType)
+            assertEquals(shelfId, ops.entityId)
+        }
+
+    @Test
+    fun `updateShelf returns updated Shelf domain model`() =
+        runTest {
+            val shelfId = seedShelf(name = "Original")
+
+            val repo = createRepo()
+            val result = repo.updateShelf(shelfId, name = "Revised", description = "New desc")
+
+            assertEquals("Revised", result.name)
+            assertEquals("New desc", result.description)
+        }
+
+    @Test
+    fun `updateShelf rolls back Room write when queue throws`() =
+        runTest {
+            val shelfId = seedShelf(name = "Stable Name")
+
+            val repo = createRepo(pendingOpQueueThrows = true)
+            runCatching { repo.updateShelf(shelfId, name = "Changed", description = null) }
+
+            val stored = db.shelfDao().getById(shelfId)
+            assertNotNull(stored)
+            assertEquals("Stable Name", stored.name, "name must roll back")
+            assertEquals(SyncState.SYNCED, stored.syncState, "syncState must roll back")
+        }
+
+    // -------------------------------------------------------------------------
+    // deleteShelf
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `deleteShelf removes entity from Room and queues DELETE_SHELF pending op`() =
+        runTest {
+            val shelfId = seedShelf(name = "To Delete")
+
+            val repo = createRepo()
+            repo.deleteShelf(shelfId)
+
+            assertNull(db.shelfDao().getById(shelfId), "shelf must be removed from Room")
+
+            val ops = db.pendingOperationDao().getOldestPending()
+            assertNotNull(ops)
+            assertEquals(OperationType.DELETE_SHELF, ops.operationType)
+            assertEquals(shelfId, ops.entityId)
+        }
+
+    @Test
+    fun `deleteShelf rolls back Room delete when queue throws`() =
+        runTest {
+            val shelfId = seedShelf(name = "Should Survive")
+
+            val repo = createRepo(pendingOpQueueThrows = true)
+            runCatching { repo.deleteShelf(shelfId) }
+
+            // Shelf must still exist after rollback
+            assertNotNull(db.shelfDao().getById(shelfId), "shelf deletion must roll back")
+            assertNull(db.pendingOperationDao().getOldestPending(), "no pending op after rollback")
+        }
+
+    // -------------------------------------------------------------------------
+    // addBooksToShelf
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `addBooksToShelf inserts junction rows and queues ADD_BOOKS_TO_SHELF pending op`() =
+        runTest {
+            val shelfId = seedShelf(name = "Reading List")
+            seedBook("book-1")
+            seedBook("book-2")
+
+            val repo = createRepo()
+            repo.addBooksToShelf(shelfId, bookIds = listOf("book-1", "book-2"))
+
+            val bookIds = db.shelfBookDao().getShelfBookIds(shelfId)
+            assertEquals(2, bookIds.size, "two junction rows must be written")
+            assertTrue("book-1" in bookIds)
+            assertTrue("book-2" in bookIds)
+
+            val ops = db.pendingOperationDao().getOldestPending()
+            assertNotNull(ops)
+            assertEquals(OperationType.ADD_BOOKS_TO_SHELF, ops.operationType)
+            assertEquals(shelfId, ops.entityId)
+        }
+
+    @Test
+    fun `addBooksToShelf rolls back junction writes when queue throws`() =
+        runTest {
+            val shelfId = seedShelf(name = "Protected Shelf")
+            seedBook("book-99")
+
+            val repo = createRepo(pendingOpQueueThrows = true)
+            runCatching { repo.addBooksToShelf(shelfId, bookIds = listOf("book-99")) }
+
+            val bookIds = db.shelfBookDao().getShelfBookIds(shelfId)
+            assertEquals(0, bookIds.size, "junction insert must roll back")
+        }
+
+    // -------------------------------------------------------------------------
+    // removeBookFromShelf
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `removeBookFromShelf deletes junction row and queues REMOVE_BOOK_FROM_SHELF pending op`() =
+        runTest {
+            val shelfId = seedShelf(name = "My Shelf")
+            seedBook("book-a")
+            seedBook("book-b")
+            seedShelfBook(shelfId = shelfId, bookId = "book-a")
+            seedShelfBook(shelfId = shelfId, bookId = "book-b")
+
+            val repo = createRepo()
+            repo.removeBookFromShelf(shelfId, bookId = "book-a")
+
+            val bookIds = db.shelfBookDao().getShelfBookIds(shelfId)
+            assertEquals(1, bookIds.size, "only one junction row must remain")
+            assertTrue("book-b" in bookIds, "book-b must still be present")
+
+            val ops = db.pendingOperationDao().getOldestPending()
+            assertNotNull(ops)
+            assertEquals(OperationType.REMOVE_BOOK_FROM_SHELF, ops.operationType)
+            assertEquals(shelfId, ops.entityId)
+        }
+
+    @Test
+    fun `removeBookFromShelf rolls back junction delete when queue throws`() =
+        runTest {
+            val shelfId = seedShelf(name = "Protected")
+            seedBook("book-x")
+            seedShelfBook(shelfId = shelfId, bookId = "book-x")
+
+            val repo = createRepo(pendingOpQueueThrows = true)
+            runCatching { repo.removeBookFromShelf(shelfId, bookId = "book-x") }
+
+            val bookIds = db.shelfBookDao().getShelfBookIds(shelfId)
+            assertEquals(1, bookIds.size, "junction delete must roll back")
+            assertTrue("book-x" in bookIds, "book-x must be restored after rollback")
+        }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private suspend fun seedUser(
+        id: String = "user-1",
+        displayName: String = "Test User",
+        avatarColor: String = "#6B7280",
+    ) {
+        db.userDao().upsert(
+            UserEntity(
+                id = UserId(id),
+                email = "test@example.com",
+                displayName = displayName,
+                isRoot = false,
+                createdAt = Timestamp(1L),
+                updatedAt = Timestamp(1L),
+                avatarColor = avatarColor,
+            ),
+        )
+    }
+
+    private suspend fun seedShelf(
+        id: String = "shelf-seed-${System.nanoTime()}",
+        name: String,
+    ): String {
+        db.shelfDao().upsert(
+            ShelfEntity(
+                id = id,
+                name = name,
+                description = null,
+                ownerId = "user-1",
+                ownerDisplayName = "Test User",
+                ownerAvatarColor = "#6B7280",
+                bookCount = 0,
+                totalDurationSeconds = 0L,
+                createdAt = Timestamp(1L),
+                updatedAt = Timestamp(1L),
+                syncState = SyncState.SYNCED,
+            ),
+        )
+        return id
+    }
+
+    private suspend fun seedShelfBook(
+        shelfId: String,
+        bookId: String,
+    ) {
+        db.shelfBookDao().upsert(
+            ShelfBookCrossRef(shelfId = shelfId, bookId = bookId, addedAt = System.currentTimeMillis()),
+        )
+    }
+
+    private suspend fun seedBook(id: String) {
+        db.bookDao().upsert(
+            BookEntity(
+                id = BookId(id),
+                title = "Book $id",
+                coverUrl = null,
+                totalDuration = 0L,
+                syncState = SyncState.SYNCED,
+                lastModified = Timestamp(1L),
+                serverVersion = Timestamp(1L),
+                createdAt = Timestamp(1L),
+                updatedAt = Timestamp(1L),
+            ),
+        )
+    }
+
+    /**
+     * Builds a [ShelfRepositoryImpl] backed by the real in-memory DB.
+     *
+     * When [pendingOpQueueThrows] is true, the [PendingOperationRepositoryContract] is
+     * replaced with a mock whose `queue` always throws — verifying that the preceding
+     * DAO write rolls back atomically.
+     */
+    private fun createRepo(pendingOpQueueThrows: Boolean = false): ShelfRepositoryImpl {
+        val pendingOpRepo: PendingOperationRepositoryContract =
+            if (pendingOpQueueThrows) {
+                mock<PendingOperationRepositoryContract>().also {
+                    everySuspend {
+                        it.queue<Any>(any(), any(), any(), any(), any())
+                    } throws RuntimeException("boom — pending-op queue failed")
+                }
+            } else {
+                // Use a real PendingOperationRepository backed by the in-memory DB so we
+                // can assert on what was actually queued.
+                com.calypsan.listenup.client.data.sync.push.PendingOperationRepository(
+                    transactionRunner = RoomTransactionRunner(db),
+                    dao = db.pendingOperationDao(),
+                    bookDao = db.bookDao(),
+                    contributorDao = db.contributorDao(),
+                    seriesDao = db.seriesDao(),
+                    shelfDao = db.shelfDao(),
+                )
+            }
+
+        return ShelfRepositoryImpl(
+            dao = db.shelfDao(),
+            shelfBookDao = db.shelfBookDao(),
+            userDao = db.userDao(),
+            shelfApi = shelfApi,
+            pendingOperationRepository = pendingOpRepo,
+            transactionRunner = RoomTransactionRunner(db),
+            createShelfHandler = CreateShelfHandler(api = shelfApi),
+            updateShelfHandler = UpdateShelfHandler(api = shelfApi),
+            deleteShelfHandler = DeleteShelfHandler(api = shelfApi),
+            addBooksToShelfHandler = AddBooksToShelfHandler(api = shelfApi),
+            removeBookFromShelfHandler = RemoveBookFromShelfHandler(api = shelfApi),
+        )
+    }
+}

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/sse/SSEEventProcessorAtomicityTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/sse/SSEEventProcessorAtomicityTest.kt
@@ -31,7 +31,7 @@ import com.calypsan.listenup.client.data.sync.SSEChannelMessage
 import com.calypsan.listenup.client.data.sync.SSEEvent
 import com.calypsan.listenup.client.data.sync.SessionDaos
 import com.calypsan.listenup.client.data.sync.UserDaos
-import com.calypsan.listenup.client.data.sync.pull.BookRelationshipDaos
+import com.calypsan.listenup.client.data.sync.sse.BookRelationshipDaos
 import com.calypsan.listenup.client.domain.repository.AvatarDownloadRepository
 import com.calypsan.listenup.client.domain.repository.CoverDownloadRepository
 import com.calypsan.listenup.client.domain.repository.SessionRepository

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/sse/SSEEventProcessorAtomicityTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/sse/SSEEventProcessorAtomicityTest.kt
@@ -68,6 +68,10 @@ class SSEEventProcessorAtomicityTest {
     private val noOpAvatarDownloadRepository =
         object : AvatarDownloadRepository {
             override fun queueAvatarDownload(userId: String) = Unit
+
+            override fun queueAvatarForceRefresh(userId: String) = Unit
+
+            override suspend fun deleteAvatar(userId: String) = Unit
         }
 
     @AfterTest

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/sse/SSEEventProcessorProgressMergeTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/sse/SSEEventProcessorProgressMergeTest.kt
@@ -65,6 +65,10 @@ class SSEEventProcessorProgressMergeTest {
     private val noOpAvatarDownloadRepository =
         object : AvatarDownloadRepository {
             override fun queueAvatarDownload(userId: String) = Unit
+
+            override fun queueAvatarForceRefresh(userId: String) = Unit
+
+            override suspend fun deleteAvatar(userId: String) = Unit
         }
 
     @AfterTest

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/sse/SSEEventProcessorProgressMergeTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/sync/sse/SSEEventProcessorProgressMergeTest.kt
@@ -22,7 +22,7 @@ import com.calypsan.listenup.client.data.sync.SSEChannelMessage
 import com.calypsan.listenup.client.data.sync.SSEEvent
 import com.calypsan.listenup.client.data.sync.SessionDaos
 import com.calypsan.listenup.client.data.sync.UserDaos
-import com.calypsan.listenup.client.data.sync.pull.BookRelationshipDaos
+import com.calypsan.listenup.client.data.sync.sse.BookRelationshipDaos
 import com.calypsan.listenup.client.domain.repository.AvatarDownloadRepository
 import com.calypsan.listenup.client.domain.repository.CoverDownloadRepository
 import com.calypsan.listenup.client.domain.repository.SessionRepository


### PR DESCRIPTION
## Summary

14 commits closing W6's repository-layer loose ends. 5 drift rows closed; 5 new W7-bound + 2 future-work rows logged for follow-up.

### Landed (14 commits)

**Deletes / dead code (4):**
- 🔥 delete \`DeepLinkParser.parseHttpsScheme\` (Finding 11 D5) + 📝 MainActivity comment sync.
- 🔥 delete \`BookReadersViewModel.loadReaders\` vestigial shim.
- 🔥 delete legacy \`SessionRepository.getBookReaders(Result)\` + remove \`@file:Suppress\` (drift #8) + 🎨 log parseTimestampToEpoch instead of swallowing.

**Relocates / renames (2):**
- ♻️ relocate \`BookRelationshipDaos\` to \`data.sync.sse\` (drift #6).
- ♻️ rename Random-unstarted sibling DAO queries + add neutral variants (drift #1; matches Phase A Bug 5 precedent).

**Interface extensions (1):**
- ♻️ extend \`AvatarDownloadRepository\` with \`queueAvatarForceRefresh\` + \`deleteAvatar\`; reroute \`SSEEventProcessor.handleProfileUpdated\` (drift #5).

**Tests + golden coverage (1):**
- ✨ add \`BookWithContributorsMapperTest\` golden-output tests (D7 partial — see drift #12 for real consolidation).

**Performance (1):**
- 🚀 fix N+1 queries in \`HomeRepositoryImpl\` + \`TagDetailViewModel\` via \`BookRepository.getBooks(ids)\`.

**Ownership audit (1):**
- ♻️ route \`ProgressTracker.clearProgress\` → \`positionRepository.delete\`. Five other playback-layer sites deferred to W7 (see drift #9-#11).

**VM consolidation (1):**
- ♻️ consolidate \`BookDetailViewModel\` per-book observers via \`combine\`; delete Phase E \`activeBookIdFlow\` (drift #7).

**Shelf offline-first (2):**
- ✨ add 5 Shelf \`OperationHandlers\` + payloads + \`OperationType\` enum values.
- ♻️ rewire \`ShelfRepositoryImpl\` onto Room-first + pending-op pattern; 12 seam-level command tests.

## Drift log

### Closed
- Row #1 (Random-unstarted siblings) — closed via \`b658abdd\`.
- Row #5 (profile-updated avatar gap) — closed via \`bc60fd83\`.
- Row #6 (BookRelationshipDaos relocation) — closed via \`e81d98d3\`.
- Row #7 (activeBookIdFlow consolidation) — closed via \`825cc255\`.
- Row #8 (SessionRepositoryImpl @file:Suppress) — closed via \`6154cd5a\` + \`5a6a00bd\`.

### New (W7-bound)
- Row #9 — \`PlaybackManager.kt:694-697\` 3-write atomic block; needs new \`BookRepository.upsertWithAudioFiles\`.
- Row #10 — \`ProgressTracker.kt:524\` \`downloadDao.deleteForBook\`; needs \`DownloadRepository.deleteForBook\`.
- Row #11 — \`ProgressTracker.kt:632\` \`listeningEventDao.upsert\`; needs listening-event repo write surface.

### New (later W6 / post-W6)
- Row #12 — Real \`BookEntityMapper\` consolidation. Plan's \"dead duplicate\" framing was wrong; the private function is live and computes \`allContributors\` differently. Golden test shipped; real unification requires updating canonical mapper.
- Row #13 — \`BookDetailViewModel\` uses manual \`loadJob\` cancellation rather than canonical \`MutableStateFlow + flatMapLatest\`. Structural asymmetry with sibling VMs.

## Reviewer notes

- **History was rebased at handoff** to fix two §M1 findings: a commit had accidentally included unrelated iosApp + schema files (rebase \`edit\` reset and re-added only the intended diff); another commit had a \`Co-Authored-By: Claude\` footer (rebase \`edit\` rewrote the message without it). All 14 commits post-rebase are clean.
- **Phase E merge-order caveat.** Phase F branched from \`main\` at \`c3efa6d9\` **before** Phase E PR #256 merged. \`BookDetailViewModel.kt\` was consolidated against the pre-Phase-E shape (\`currentBookId.flatMapLatest\` observers). When Phase E merges first, Phase F will require manual rebase conflict resolution on that file.
- **\`BookDetailViewModel\` \`loadJob\` idiom** is deliberate (drift row #13). Acceptable under \`Dispatchers.Main.immediate\`; structurally asymmetric with sibling VMs. Future consolidation candidate.
- Mandatory §M1 code-reviewer pass: **CLEAR** (after rebase fixes). All 6 rubric rules confirmed. \`ShelfRepositoryImpl\` handler-injection pattern matches existing \`PreferencesSyncObserver\` precedent.

## Test plan

- [x] \`./gradlew :shared:jvmTest --no-daemon\` — green
- [x] \`./gradlew spotlessCheck detekt --no-daemon\` — green
- [ ] \`Build APK\` expected red on \`AudiobookNotificationProvider\` Media3 baseline (W7 territory, accepted)
- [ ] User approves handoff before Phase G brainstorming opens

## Plan + spec

- Plan (with end-of-phase state): \`docs/superpowers/plans/2026-04-23-w6-f-ssot-ownership-deadcode.md\`
- Spec: \`docs/superpowers/specs/2026-04-22-w6-f-ssot-ownership-deadcode-design.md\`