### PR TITLE
W7 Phase A — Bug 3 speed fix + restore Build APK

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,13 +211,13 @@ Before `git push`, from the repo root:
 |---|---|
 | `Unit Tests` | `./gradlew :shared:jvmTest --no-daemon` |
 | `Lint & Static Analysis` | `./gradlew spotlessCheck detekt --no-daemon` |
-| `Build APK` | **Expected red until W7.** See `../docs/architecture/restoration-roadmap.md` → "Known Baseline Breakage." Do not gate pushes on it. Re-check once W7 lands and remove this exception. |
+| `Build APK` | `./gradlew :androidApp:assembleDebug --no-daemon` — **must pass** (restored to green by W7 Phase A on 2026-04-25; previously red on `AudiobookNotificationProvider` Media3 drift since the 2026-04-21 dependency bump). |
 
 Rules:
 
 - Every command above must pass before `git push`.
 - `spotlessApply` is the automatic fixer for formatting failures — run it, review the diff, commit as a `🎨` cleanup.
-- If a *different* failure mode appears in `Build APK` remotely (i.e. not the `AudiobookNotificationProvider` baseline), treat it as a regression and fix it before continuing.
+- If `Build APK` fails remotely after going green in W7 Phase A, treat it as a regression and fix it before continuing.
 - When the act action-resolution bug is fixed (pin `gradle/actions/setup-gradle` to a commit SHA, or upstream fixes the subpath issue), promote this policy back to a literal `act -W .github/workflows/ci.yml` gate.
 
 ---

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/ListenUpNavigation.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/ListenUpNavigation.kt
@@ -68,8 +68,8 @@ import com.calypsan.listenup.client.presentation.admin.AdminSettingsViewModel
 import com.calypsan.listenup.client.presentation.admin.AdminViewModel
 import com.calypsan.listenup.client.presentation.admin.CreateInviteViewModel
 import com.calypsan.listenup.client.presentation.auth.PendingApprovalViewModel
+import com.calypsan.listenup.client.presentation.invite.InviteRegistrationUiState
 import com.calypsan.listenup.client.presentation.invite.InviteRegistrationViewModel
-import com.calypsan.listenup.client.presentation.invite.InviteSubmissionStatus
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
@@ -218,8 +218,8 @@ private fun InviteRegistrationNavigation(
 
     // Watch for successful registration to trigger completion
     val state by viewModel.state.collectAsStateWithLifecycle()
-    LaunchedEffect(state.submissionStatus) {
-        if (state.submissionStatus is InviteSubmissionStatus.Success) {
+    LaunchedEffect(state) {
+        if (state is InviteRegistrationUiState.Submitted) {
             onComplete()
         }
     }

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/playback/AudiobookNotificationProvider.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/playback/AudiobookNotificationProvider.kt
@@ -108,7 +108,7 @@ class AudiobookNotificationProvider(
                 .setDeleteIntent(
                     actionFactory.createMediaActionPendingIntent(
                         mediaSession,
-                        Player.COMMAND_STOP.toLong(),
+                        Player.COMMAND_STOP,
                     ),
                 )
 
@@ -216,6 +216,12 @@ class AudiobookNotificationProvider(
 
         return MediaNotification(NOTIFICATION_ID, builder.build())
     }
+
+    override fun getNotificationChannelInfo(): MediaNotification.Provider.NotificationChannelInfo =
+        MediaNotification.Provider.NotificationChannelInfo(
+            CHANNEL_ID,
+            "Playback",
+        )
 
     override fun handleCustomCommand(
         session: MediaSession,

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
@@ -416,9 +416,7 @@ class PlaybackService : MediaLibraryService() {
      * Extracted to keep onAddMediaItems and onPlaybackResumption within complexity limits.
      */
     private fun applyResumeSpeed(speed: Float) {
-        if (speed != 1.0f) {
-            player?.setPlaybackSpeed(speed)
-        }
+        player?.setPlaybackSpeed(speed)
     }
 
     /**

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackManager.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackManager.kt
@@ -382,9 +382,7 @@ class PlaybackManager(
         player.load(segments)
 
         // Set speed before seeking/playing
-        if (resumeSpeed != 1.0f) {
-            player.setSpeed(resumeSpeed)
-        }
+        player.setSpeed(resumeSpeed)
         playbackSpeed.value = resumeSpeed
 
         // Resume from saved position
@@ -458,17 +456,17 @@ class PlaybackManager(
     }
 
     /**
-     * Called when user explicitly changes playback speed.
-     * Updates state and marks the book as having a custom speed.
+     * Called when user explicitly changes playback speed for the current book.
+     *
+     * Writes per-book only via [progressTracker.onSpeedChanged], which sets
+     * `hasCustomSpeed = true`. The global default is changed only via
+     * Settings → Default Speed; per-book changes do NOT mutate the global default.
      */
     fun onSpeedChanged(speed: Float) {
         val bookId = currentBookId.value ?: return
         val positionMs = currentPositionMs.value
         playbackSpeed.value = speed
         progressTracker.onSpeedChanged(bookId, positionMs, speed)
-
-        // Persist as the universal default so it survives app restarts
-        scope.launch { playbackPreferences.setDefaultPlaybackSpeed(speed) }
     }
 
     /**

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerSpeedTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerSpeedTest.kt
@@ -1,0 +1,324 @@
+package com.calypsan.listenup.client.playback
+
+import com.calypsan.listenup.client.core.BookId
+import com.calypsan.listenup.client.core.ServerUrl
+import com.calypsan.listenup.client.core.Timestamp
+import com.calypsan.listenup.client.data.local.db.AudioFileEntity
+import com.calypsan.listenup.client.data.local.db.BookEntity
+import com.calypsan.listenup.client.data.local.db.DownloadDao
+import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
+import com.calypsan.listenup.client.data.local.db.ListeningEventDao
+import com.calypsan.listenup.client.data.local.db.PlaybackPositionDao
+import com.calypsan.listenup.client.data.local.db.RoomTransactionRunner
+import com.calypsan.listenup.client.data.local.db.SyncState
+import com.calypsan.listenup.client.data.remote.SyncApiContract
+import com.calypsan.listenup.client.data.sync.push.ListeningEventPayload
+import com.calypsan.listenup.client.data.sync.push.OperationHandler
+import com.calypsan.listenup.client.data.sync.push.PendingOperationRepositoryContract
+import com.calypsan.listenup.client.data.sync.push.PushSyncOrchestratorContract
+import com.calypsan.listenup.client.device.DeviceContext
+import com.calypsan.listenup.client.device.DeviceType
+import com.calypsan.listenup.client.domain.repository.ImageStorage
+import com.calypsan.listenup.client.domain.repository.PlaybackPositionRepository
+import com.calypsan.listenup.client.domain.repository.PlaybackPreferences
+import com.calypsan.listenup.client.domain.repository.ServerConfig
+import com.calypsan.listenup.client.download.DownloadResult
+import com.calypsan.listenup.client.download.DownloadService
+import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verify
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.AfterTest
+import kotlin.test.Test
+
+/**
+ * Bug 3 regression tests for PlaybackManager speed paths.
+ *
+ * Pins three invariants:
+ * 1. onSpeedChanged invokes progressTracker.onSpeedChanged with the new speed
+ *    (was already correct, locked here against future regression).
+ * 2. startPlayback with effective speed 1.0f calls audioPlayer.setSpeed(1.0f)
+ *    even after the player was previously at non-1.0f speed (was suppressed
+ *    by the if (speed != 1.0f) guard at PlaybackManager:385-387).
+ * 3. onSpeedChanged writes per-book ONLY; never touches the global default
+ *    via playbackPreferences.setDefaultPlaybackSpeed (was double-writing
+ *    via scope.launch at PlaybackManager:471, conflating per-book and global).
+ *
+ * If any of these tests regress in the future, the corresponding W7 Phase A
+ * deletion was likely re-introduced. Investigate before "fixing" the test.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class PlaybackManagerSpeedTest {
+    private val db: ListenUpDatabase = createInMemoryTestDatabase()
+
+    @AfterTest
+    fun tearDown() {
+        db.close()
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 1 — progressTracker write is always invoked regardless of speed value
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `onSpeedChanged with 1_0f propagates progressTracker write`() =
+        runTest {
+            val positionDao: PlaybackPositionDao = mock()
+            everySuspend { positionDao.get(any()) } returns null
+            everySuspend { positionDao.save(any()) } returns Unit
+
+            val (manager, _) =
+                createPlaybackManagerWithScope(
+                    positionDao = positionDao,
+                )
+
+            manager.activateBook(BookId("book-1"))
+            manager.onSpeedChanged(1.0f)
+
+            // Drain the scope.launch inside ProgressTracker.onSpeedChanged
+            advanceUntilIdle()
+
+            verifySuspend(VerifyMode.exactly(1)) { positionDao.save(any()) }
+        }
+
+    // -------------------------------------------------------------------------
+    // Test 2 — startPlayback always calls setSpeed, even when speed == 1.0f
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `startPlayback with effective speed 1_0f calls audioPlayer setSpeed 1_0f`() =
+        runTest {
+            seedBookAndAudioFiles()
+
+            val playbackPreferences: PlaybackPreferences = mock()
+            everySuspend { playbackPreferences.getDefaultPlaybackSpeed() } returns 1.0f
+
+            val positionDao: PlaybackPositionDao = mock()
+            everySuspend { positionDao.get(any()) } returns null
+
+            val manager =
+                createPlaybackManager(
+                    playbackPreferences = playbackPreferences,
+                    positionDao = positionDao,
+                    // Use a detached scope so the positionMs.collect launch does not
+                    // keep the TestScope alive and block runTest completion.
+                    scope = CoroutineScope(Job()),
+                )
+
+            val result = manager.prepareForPlayback(BookId("book-1"))
+            checkNotNull(result) { "prepareForPlayback must succeed" }
+            manager.activateBook(BookId("book-1"))
+
+            val audioPlayer: AudioPlayer = mock()
+            everySuspend { audioPlayer.load(any()) } returns Unit
+            every { audioPlayer.positionMs } returns MutableStateFlow(0L)
+            every { audioPlayer.state } returns MutableStateFlow(PlaybackState.Idle)
+            every { audioPlayer.setSpeed(any()) } returns Unit
+            every { audioPlayer.play() } returns Unit
+
+            manager.startPlayback(
+                player = audioPlayer,
+                resumePositionMs = 0L,
+                resumeSpeed = 1.0f,
+            )
+
+            verify(VerifyMode.exactly(1)) { audioPlayer.setSpeed(1.0f) }
+        }
+
+    // -------------------------------------------------------------------------
+    // Test 3 — onSpeedChanged writes per-book ONLY; global default stays clean
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `onSpeedChanged does not call playbackPreferences setDefaultPlaybackSpeed`() =
+        runTest {
+            val playbackPreferences: PlaybackPreferences = mock()
+            everySuspend { playbackPreferences.getDefaultPlaybackSpeed() } returns 1.0f
+            everySuspend { playbackPreferences.setDefaultPlaybackSpeed(any()) } returns Unit
+
+            val positionDao: PlaybackPositionDao = mock()
+            everySuspend { positionDao.get(any()) } returns null
+            everySuspend { positionDao.save(any()) } returns Unit
+
+            val (manager, _) =
+                createPlaybackManagerWithScope(
+                    playbackPreferences = playbackPreferences,
+                    positionDao = positionDao,
+                )
+
+            manager.activateBook(BookId("book-1"))
+            manager.onSpeedChanged(2.0f)
+
+            // Drain all pending coroutines so any rogue setDefaultPlaybackSpeed call
+            // has had a chance to run before we assert it didn't.
+            advanceUntilIdle()
+
+            verifySuspend(VerifyMode.exactly(1)) { positionDao.save(any()) }
+            verifySuspend(VerifyMode.exactly(0)) { playbackPreferences.setDefaultPlaybackSpeed(any()) }
+        }
+
+    // =========================================================================
+    // Fixture helpers
+    // =========================================================================
+
+    /**
+     * Creates a [PlaybackManager] whose internal [CoroutineScope] is backed by the
+     * [TestScope] from [runTest]. Use this for tests that need [advanceUntilIdle]
+     * to drain coroutines launched inside [PlaybackManager] or [ProgressTracker].
+     *
+     * Returns both the manager and the [positionDao] mock so tests can assert
+     * on it.
+     */
+    private fun TestScope.createPlaybackManagerWithScope(
+        playbackPreferences: PlaybackPreferences = defaultPlaybackPreferences(),
+        positionDao: PlaybackPositionDao = defaultPositionDao(),
+    ): Pair<PlaybackManager, PlaybackPositionDao> {
+        val progressTrackerScope = CoroutineScope(coroutineContext)
+        val managerScope = CoroutineScope(coroutineContext)
+
+        val progressTracker =
+            buildProgressTracker(
+                positionDao = positionDao,
+                scope = progressTrackerScope,
+            )
+
+        val manager =
+            createPlaybackManager(
+                playbackPreferences = playbackPreferences,
+                positionDao = positionDao,
+                progressTracker = progressTracker,
+                scope = managerScope,
+            )
+
+        return manager to positionDao
+    }
+
+    private fun defaultPlaybackPreferences(): PlaybackPreferences {
+        val prefs: PlaybackPreferences = mock()
+        everySuspend { prefs.getDefaultPlaybackSpeed() } returns 1.0f
+        everySuspend { prefs.setDefaultPlaybackSpeed(any()) } returns Unit
+        return prefs
+    }
+
+    private fun defaultPositionDao(): PlaybackPositionDao {
+        val dao: PlaybackPositionDao = mock()
+        everySuspend { dao.get(any()) } returns null
+        everySuspend { dao.save(any()) } returns Unit
+        return dao
+    }
+
+    private fun buildProgressTracker(
+        positionDao: PlaybackPositionDao,
+        scope: CoroutineScope,
+    ): ProgressTracker =
+        ProgressTracker(
+            positionDao = positionDao,
+            downloadDao = mock<DownloadDao>(),
+            listeningEventDao = mock<ListeningEventDao>(),
+            syncApi = mock<SyncApiContract>(),
+            pendingOperationRepository = mock<PendingOperationRepositoryContract>(),
+            listeningEventHandler = mock<OperationHandler<ListeningEventPayload>>(),
+            pushSyncOrchestrator = mock<PushSyncOrchestratorContract>(),
+            positionRepository = mock<PlaybackPositionRepository>(),
+            deviceId = "test-device",
+            scope = scope,
+        )
+
+    private fun createPlaybackManager(
+        playbackPreferences: PlaybackPreferences = defaultPlaybackPreferences(),
+        positionDao: PlaybackPositionDao = defaultPositionDao(),
+        progressTracker: ProgressTracker =
+            buildProgressTracker(
+                positionDao = positionDao,
+                scope = CoroutineScope(Job()),
+            ),
+        scope: CoroutineScope = CoroutineScope(Job()),
+    ): PlaybackManager {
+        val tokenProvider: AudioTokenProvider = mock()
+        everySuspend { tokenProvider.prepareForPlayback() } returns Unit
+
+        val serverConfig: ServerConfig = mock()
+        everySuspend { serverConfig.getServerUrl() } returns ServerUrl("https://example.test")
+
+        val imageStorage: ImageStorage = mock()
+        every { imageStorage.exists(any()) } returns false
+
+        val downloadService: DownloadService = mock()
+        everySuspend { downloadService.getLocalPath(any()) } returns null
+        everySuspend { downloadService.wasExplicitlyDeleted(any()) } returns false
+        everySuspend { downloadService.downloadBook(any()) } returns DownloadResult.AlreadyDownloaded
+
+        return PlaybackManager(
+            transactionRunner = RoomTransactionRunner(db),
+            serverConfig = serverConfig,
+            playbackPreferences = playbackPreferences,
+            bookDao = db.bookDao(),
+            audioFileDao = db.audioFileDao(),
+            chapterDao = db.chapterDao(),
+            imageStorage = imageStorage,
+            progressTracker = progressTracker,
+            tokenProvider = tokenProvider,
+            deviceContext = DeviceContext(type = DeviceType.Phone),
+            downloadService = downloadService,
+            playbackApi = null,
+            capabilityDetector = null,
+            syncApi = null,
+            scope = scope,
+        )
+    }
+
+    private suspend fun seedBookAndAudioFiles() {
+        db.bookDao().upsert(
+            BookEntity(
+                id = BookId("book-1"),
+                title = "Test Book",
+                sortTitle = "Test Book",
+                subtitle = null,
+                coverUrl = null,
+                coverBlurHash = null,
+                dominantColor = null,
+                darkMutedColor = null,
+                vibrantColor = null,
+                totalDuration = 1_800_000L,
+                description = null,
+                publishYear = null,
+                publisher = null,
+                language = null,
+                isbn = null,
+                asin = null,
+                abridged = false,
+                syncState = SyncState.SYNCED,
+                lastModified = Timestamp(1L),
+                serverVersion = Timestamp(1L),
+                createdAt = Timestamp(1L),
+                updatedAt = Timestamp(1L),
+            ),
+        )
+        db.audioFileDao().upsertAll(
+            listOf(
+                AudioFileEntity(
+                    bookId = BookId("book-1"),
+                    index = 0,
+                    id = "af-0",
+                    filename = "chapter1.m4b",
+                    format = "m4b",
+                    codec = "aac",
+                    duration = 1_800_000L,
+                    size = 45_000_000L,
+                ),
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- **Bug 3 closed.** Three deletions in `PlaybackManager` + `PlaybackService`: two `if (speed != 1.0f)` guards (resume path) + the dual-persistence write at `PlaybackManager:471` (which was mutating the global default whenever the user changed per-book speed). Per-book speed changes now stay per-book; global default is changed only via Settings → Default Speed.
- **Build APK CI restored.** Two real Media3 1.10.0 fixes in `AudiobookNotificationProvider`: line 111 `Long → Int` narrowing on `createMediaActionPendingIntent`, plus a new `getNotificationChannelInfo()` override (Media3 1.10.0 made it abstract). `:androidApp:assembleDebug` green for the first time since `c3efa6d9` (2026-04-21). Same commit also bundled a 6-line W5/W6 sealed-hierarchy straggler fix in `ListenUpNavigation.kt` that was independently blocking compile (necessary bundle — splitting would produce two commits where neither alone restores Build APK).
- **CLAUDE.md `Build APK` exception retired** — `Build APK` is now a hard gate again.

## Diagnostic divergence note
The spec (v1/v2/v3) inherited a W6-era misread that "4 broken `createCustomActionFromCustomCommandButton` sites at lines 141/153/181/193" needed replacement. Task 0's context7 query against actual Media3 1.10.0 source confirmed those sites still compile fine — the original `restoration-roadmap.md` Known-Baseline-Breakage description was correct all along ("not abstract (missing interface impl) + Long/Int type mismatch at line 111"). Task 2 implemented the actual fix.

## UX migration note
Users who relied on the buggy dual-write to set their global default may notice their default speed is whatever-they-last-set-per-book. Recovery: open Settings → Default Speed and pick the desired value. The corrupted default also synced cross-device pre-Phase-A; users on multiple devices may need to set it once on one device after upgrade.

## Spec / Plan
- Spec: `docs/superpowers/specs/2026-04-25-w7-a-bug3-speed-and-build-apk-design.md` (revised v1→v2→v3 during brainstorming as codebase reality was confirmed)
- Plan: `docs/superpowers/plans/2026-04-25-w7-a-bug3-speed-and-build-apk.md` (End-of-phase state appended)

## Test plan
- [x] `:shared:jvmTest` green at every commit
- [x] `spotlessCheck detekt` green at every commit
- [x] `:androidApp:assembleDebug` green from commit 2 onward (was red since 2026-04-21)
- [x] §M1 code-reviewer PASS — no Critical or Important findings
- [x] Three Bug 3 regression tests in `PlaybackManagerSpeedTest.kt` pin the invariants

## W7 status
**Phase A is the first of five W7 phases (A-E per the roadmap).** Phase B (PlaybackPositionRepository expansion + ListeningEventRepository extraction; absorbs drift #9/#10/#11) opens next. The persistence and resolver layers are already correctly built (per Phase A's spec-revision findings) — Phase B's scope is repository expansion for the remaining playback-layer DAO writes that bypass the repository pattern.