### PR TITLE
W7 Phase B — PlaybackPositionRepository expansion + ListeningEventRepository extraction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,13 +211,13 @@ Before `git push`, from the repo root:
 |---|---|
 | `Unit Tests` | `./gradlew :shared:jvmTest --no-daemon` |
 | `Lint & Static Analysis` | `./gradlew spotlessCheck detekt --no-daemon` |
-| `Build APK` | **Expected red until W7.** See `../docs/architecture/restoration-roadmap.md` → "Known Baseline Breakage." Do not gate pushes on it. Re-check once W7 lands and remove this exception. |
+| `Build APK` | `./gradlew :androidApp:assembleDebug --no-daemon` — **must pass** (restored to green by W7 Phase A on 2026-04-25; previously red on `AudiobookNotificationProvider` Media3 drift since the 2026-04-21 dependency bump). |
 
 Rules:
 
 - Every command above must pass before `git push`.
 - `spotlessApply` is the automatic fixer for formatting failures — run it, review the diff, commit as a `🎨` cleanup.
-- If a *different* failure mode appears in `Build APK` remotely (i.e. not the `AudiobookNotificationProvider` baseline), treat it as a regression and fix it before continuing.
+- If `Build APK` fails remotely after going green in W7 Phase A, treat it as a regression and fix it before continuing.
 - When the act action-resolution bug is fixed (pin `gradle/actions/setup-gradle` to a commit SHA, or upstream fixes the subpath issue), promote this policy back to a literal `act -W .github/workflows/ci.yml` gate.
 
 ---

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
@@ -107,7 +107,7 @@ val playbackModule =
         single {
             ProgressTracker(
                 positionDao = get(),
-                downloadDao = get(),
+                downloadRepository = get(),
                 listeningEventDao = get(),
                 syncApi = get(),
                 pendingOperationRepository = get(),

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
@@ -47,6 +47,7 @@ import org.koin.core.context.startKoin
 import org.koin.core.logger.Level
 import org.koin.core.module.dsl.viewModel
 import org.koin.core.module.dsl.viewModelOf
+import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
 /**
@@ -77,7 +78,7 @@ val androidModule =
 val playbackModule =
     module {
         // Device ID for listening events (stable across app reinstalls on Android 8+)
-        single {
+        single(qualifier = named("deviceId")) {
             val context: Context = get()
             Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
                 ?: "unknown-device"
@@ -114,7 +115,7 @@ val playbackModule =
                 listeningEventHandler = get<ListeningEventHandler>(),
                 pushSyncOrchestrator = get(),
                 positionRepository = get(),
-                deviceId = get(),
+                deviceId = get(qualifier = named("deviceId")),
                 scope = get(),
             )
         }

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
@@ -10,7 +10,6 @@ import coil3.PlatformContext
 import coil3.SingletonImageLoader
 import com.calypsan.listenup.client.core.ImageLoaderFactory
 import com.calypsan.listenup.client.data.remote.PlaybackApi
-import com.calypsan.listenup.client.data.sync.push.ListeningEventHandler
 import com.calypsan.listenup.client.di.sharedModules
 import com.calypsan.listenup.client.download.DownloadFileManager
 import com.calypsan.listenup.client.download.DownloadManager
@@ -103,19 +102,14 @@ val playbackModule =
         single { get<AudioTokenProvider>() as AndroidAudioTokenProvider }
 
         // Progress tracker for position persistence and event recording
-        // Note: get<ListeningEventHandler>() is required because the parameter type is
-        // OperationHandler<ListeningEventPayload> but Koin can't resolve generic types.
         single {
             ProgressTracker(
                 positionDao = get(),
                 downloadRepository = get(),
-                listeningEventDao = get(),
+                listeningEventRepository = get(),
                 syncApi = get(),
-                pendingOperationRepository = get(),
-                listeningEventHandler = get<ListeningEventHandler>(),
                 pushSyncOrchestrator = get(),
                 positionRepository = get(),
-                deviceId = get(qualifier = named("deviceId")),
                 scope = get(),
             )
         }

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
@@ -136,7 +136,6 @@ val playbackModule =
         // Playback manager - orchestrates playback startup
         single {
             PlaybackManager(
-                transactionRunner = get(),
                 serverConfig = get(),
                 playbackPreferences = get(),
                 bookDao = get(),
@@ -151,6 +150,7 @@ val playbackModule =
                 capabilityDetector = get(),
                 syncApi = get(),
                 scope = get(),
+                bookRepository = get(),
             )
         }
 

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/ListenUpNavigation.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/navigation/ListenUpNavigation.kt
@@ -68,8 +68,8 @@ import com.calypsan.listenup.client.presentation.admin.AdminSettingsViewModel
 import com.calypsan.listenup.client.presentation.admin.AdminViewModel
 import com.calypsan.listenup.client.presentation.admin.CreateInviteViewModel
 import com.calypsan.listenup.client.presentation.auth.PendingApprovalViewModel
+import com.calypsan.listenup.client.presentation.invite.InviteRegistrationUiState
 import com.calypsan.listenup.client.presentation.invite.InviteRegistrationViewModel
-import com.calypsan.listenup.client.presentation.invite.InviteSubmissionStatus
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
@@ -218,8 +218,8 @@ private fun InviteRegistrationNavigation(
 
     // Watch for successful registration to trigger completion
     val state by viewModel.state.collectAsStateWithLifecycle()
-    LaunchedEffect(state.submissionStatus) {
-        if (state.submissionStatus is InviteSubmissionStatus.Success) {
+    LaunchedEffect(state) {
+        if (state is InviteRegistrationUiState.Submitted) {
             onComplete()
         }
     }

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/playback/AudiobookNotificationProvider.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/playback/AudiobookNotificationProvider.kt
@@ -108,7 +108,7 @@ class AudiobookNotificationProvider(
                 .setDeleteIntent(
                     actionFactory.createMediaActionPendingIntent(
                         mediaSession,
-                        Player.COMMAND_STOP.toLong(),
+                        Player.COMMAND_STOP,
                     ),
                 )
 
@@ -216,6 +216,12 @@ class AudiobookNotificationProvider(
 
         return MediaNotification(NOTIFICATION_ID, builder.build())
     }
+
+    override fun getNotificationChannelInfo(): MediaNotification.Provider.NotificationChannelInfo =
+        MediaNotification.Provider.NotificationChannelInfo(
+            CHANNEL_ID,
+            "Playback",
+        )
 
     override fun handleCustomCommand(
         session: MediaSession,

--- a/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
+++ b/composeApp/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
@@ -416,9 +416,7 @@ class PlaybackService : MediaLibraryService() {
      * Extracted to keep onAddMediaItems and onPlaybackResumption within complexity limits.
      */
     private fun applyResumeSpeed(speed: Float) {
-        if (speed != 1.0f) {
-            player?.setPlaybackSpeed(speed)
-        }
+        player?.setPlaybackSpeed(speed)
     }
 
     /**

--- a/composeApp/src/desktopMain/kotlin/com/calypsan/listenup/client/di/PlatformModule.kt
+++ b/composeApp/src/desktopMain/kotlin/com/calypsan/listenup/client/di/PlatformModule.kt
@@ -2,7 +2,6 @@ package com.calypsan.listenup.client.di
 
 import com.calypsan.listenup.client.core.IODispatcher
 import com.calypsan.listenup.client.data.remote.PlaybackApi
-import com.calypsan.listenup.client.data.sync.push.ListeningEventHandler
 import com.calypsan.listenup.client.features.bookdetail.BookDetailPlatformActions
 import com.calypsan.listenup.client.features.bookdetail.DesktopBookDetailPlatformActions
 import com.calypsan.listenup.client.download.DownloadFileManager
@@ -94,13 +93,10 @@ val platformModule: Module =
             ProgressTracker(
                 positionDao = get(),
                 downloadRepository = get(),
-                listeningEventDao = get(),
+                listeningEventRepository = get(),
                 syncApi = get(),
-                pendingOperationRepository = get(),
-                listeningEventHandler = get<ListeningEventHandler>(),
                 pushSyncOrchestrator = get(),
                 positionRepository = get(),
-                deviceId = get(qualifier = named("deviceId")),
                 scope = get(qualifier = named("playbackScope")),
             )
         }

--- a/composeApp/src/desktopMain/kotlin/com/calypsan/listenup/client/di/PlatformModule.kt
+++ b/composeApp/src/desktopMain/kotlin/com/calypsan/listenup/client/di/PlatformModule.kt
@@ -115,7 +115,6 @@ val platformModule: Module =
         // Playback manager (with codec negotiation enabled)
         single {
             PlaybackManager(
-                transactionRunner = get(),
                 serverConfig = get(),
                 playbackPreferences = get(),
                 bookDao = get(),
@@ -130,6 +129,7 @@ val platformModule: Module =
                 syncApi = get(),
                 deviceContext = get(),
                 scope = get(qualifier = named("playbackScope")),
+                bookRepository = get(),
             )
         }
 

--- a/composeApp/src/desktopMain/kotlin/com/calypsan/listenup/client/di/PlatformModule.kt
+++ b/composeApp/src/desktopMain/kotlin/com/calypsan/listenup/client/di/PlatformModule.kt
@@ -93,7 +93,7 @@ val platformModule: Module =
         single {
             ProgressTracker(
                 positionDao = get(),
-                downloadDao = get(),
+                downloadRepository = get(),
                 listeningEventDao = get(),
                 syncApi = get(),
                 pendingOperationRepository = get(),

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/BookRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/BookRepositoryImpl.kt
@@ -1,10 +1,15 @@
 package com.calypsan.listenup.client.data.repository
 
-import com.calypsan.listenup.client.core.BookId
 import com.calypsan.listenup.client.core.AppResult
+import com.calypsan.listenup.client.core.BookId
+import com.calypsan.listenup.client.core.suspendRunCatching
+import com.calypsan.listenup.client.data.local.db.AudioFileDao
+import com.calypsan.listenup.client.data.local.db.AudioFileEntity
 import com.calypsan.listenup.client.data.local.db.BookDao
+import com.calypsan.listenup.client.data.local.db.BookEntity
 import com.calypsan.listenup.client.data.local.db.ChapterDao
 import com.calypsan.listenup.client.data.local.db.ChapterEntity
+import com.calypsan.listenup.client.data.local.db.TransactionRunner
 import com.calypsan.listenup.client.data.local.db.toDetail
 import com.calypsan.listenup.client.data.local.db.toListItem
 import com.calypsan.listenup.client.data.sync.SyncManagerContract
@@ -39,6 +44,8 @@ import kotlinx.coroutines.flow.map
  *
  * @property bookDao Room DAO for book operations
  * @property chapterDao Room DAO for chapter operations
+ * @property audioFileDao Room DAO for audio-file operations
+ * @property transactionRunner Runs multi-table writes atomically
  * @property syncManager Sync orchestrator for server communication
  * @property imageStorage Storage for resolving cover image paths
  * @property genreRepository Upstream Flow source for a book's genres, composed
@@ -49,6 +56,8 @@ import kotlinx.coroutines.flow.map
 class BookRepositoryImpl(
     private val bookDao: BookDao,
     private val chapterDao: ChapterDao,
+    private val audioFileDao: AudioFileDao,
+    private val transactionRunner: TransactionRunner,
     private val syncManager: SyncManagerContract,
     private val imageStorage: ImageStorage,
     private val genreRepository: GenreRepository,
@@ -149,6 +158,20 @@ class BookRepositoryImpl(
         val tags = tagRepository.observeTagsForBook(id).first()
         return row.toDetail(imageStorage, genres, tags)
     }
+
+    override suspend fun upsertWithAudioFiles(
+        book: BookEntity,
+        audioFiles: List<AudioFileEntity>,
+    ): AppResult<Unit> =
+        suspendRunCatching {
+            transactionRunner.atomically {
+                bookDao.upsert(book)
+                audioFileDao.deleteForBook(book.id.value)
+                if (audioFiles.isNotEmpty()) {
+                    audioFileDao.upsertAll(audioFiles)
+                }
+            }
+        }
 }
 
 /**

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/DownloadRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/DownloadRepositoryImpl.kt
@@ -18,6 +18,10 @@ class DownloadRepositoryImpl(
     private val downloadDao: DownloadDao,
     private val bookRepository: BookRepository,
 ) : DownloadRepository {
+    override suspend fun deleteForBook(bookId: String) {
+        downloadDao.deleteForBook(bookId)
+    }
+
     override fun observeDownloadedBooks(): Flow<List<DownloadedBookSummary>> =
         downloadDao.observeAll().map { downloads ->
             val completedByBook =

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/ListeningEventRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/ListeningEventRepositoryImpl.kt
@@ -1,0 +1,129 @@
+@file:OptIn(ExperimentalTime::class)
+
+package com.calypsan.listenup.client.data.repository
+
+import com.calypsan.listenup.client.core.AppResult
+import com.calypsan.listenup.client.core.BookId
+import com.calypsan.listenup.client.core.suspendRunCatching
+import com.calypsan.listenup.client.data.local.db.BookDuration
+import com.calypsan.listenup.client.data.local.db.ListeningEventDao
+import com.calypsan.listenup.client.data.local.db.ListeningEventEntity
+import com.calypsan.listenup.client.data.local.db.OperationType
+import com.calypsan.listenup.client.data.local.db.SyncState
+import com.calypsan.listenup.client.data.local.db.TransactionRunner
+import com.calypsan.listenup.client.data.sync.push.ListeningEventHandler
+import com.calypsan.listenup.client.data.sync.push.ListeningEventPayload
+import com.calypsan.listenup.client.data.sync.push.PendingOperationRepositoryContract
+import com.calypsan.listenup.client.domain.repository.ListeningEventRepository
+import com.calypsan.listenup.client.util.NanoId
+import kotlinx.coroutines.flow.Flow
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+
+/**
+ * Room-backed implementation of [ListeningEventRepository].
+ *
+ * The write path wraps both DAO calls inside [TransactionRunner.atomically] so
+ * the local upsert and the pending-op queue are atomic — if either fails the
+ * transaction rolls back and [AppResult.Failure] is returned. No partial writes
+ * ever reach the database.
+ *
+ * [suspendRunCatching] handles [kotlinx.coroutines.CancellationException] rethrow
+ * automatically (EM-R1).
+ *
+ * @param listeningEventDao Room DAO for listening event operations.
+ * @param pendingOperationRepository Sync queue for outbound server push.
+ * @param listeningEventHandler Handler used to serialise/dispatch the pending op.
+ * @param transactionRunner Wraps both writes in a single DB transaction.
+ * @param deviceId Stable device identifier injected from the DI graph.
+ */
+class ListeningEventRepositoryImpl(
+    private val listeningEventDao: ListeningEventDao,
+    private val pendingOperationRepository: PendingOperationRepositoryContract,
+    private val listeningEventHandler: ListeningEventHandler,
+    private val transactionRunner: TransactionRunner,
+    private val deviceId: String,
+) : ListeningEventRepository {
+    override suspend fun queueListeningEvent(
+        bookId: BookId,
+        startPositionMs: Long,
+        endPositionMs: Long,
+        startedAt: Long,
+        endedAt: Long,
+        playbackSpeed: Float,
+    ): AppResult<Unit> =
+        suspendRunCatching {
+            val eventId = NanoId.generate("evt")
+            val now = Clock.System.now().toEpochMilliseconds()
+
+            val entity =
+                ListeningEventEntity(
+                    id = eventId,
+                    bookId = bookId.value,
+                    startPositionMs = startPositionMs,
+                    endPositionMs = endPositionMs,
+                    startedAt = startedAt,
+                    endedAt = endedAt,
+                    playbackSpeed = playbackSpeed,
+                    deviceId = deviceId,
+                    syncState = SyncState.NOT_SYNCED,
+                    createdAt = now,
+                    source = "playback",
+                )
+
+            val payload =
+                ListeningEventPayload(
+                    id = eventId,
+                    bookId = bookId.value,
+                    startPositionMs = startPositionMs,
+                    endPositionMs = endPositionMs,
+                    startedAt = startedAt,
+                    endedAt = endedAt,
+                    playbackSpeed = playbackSpeed,
+                    deviceId = deviceId,
+                )
+
+            transactionRunner.atomically {
+                listeningEventDao.upsert(entity)
+                pendingOperationRepository.queue(
+                    type = OperationType.LISTENING_EVENT,
+                    entityType = null,
+                    entityId = null,
+                    payload = payload,
+                    handler = listeningEventHandler,
+                )
+            }
+        }
+
+    // ==================== Read methods ====================
+
+    override fun observeEventsForBook(bookId: String): Flow<List<ListeningEventEntity>> =
+        listeningEventDao.observeEventsForBook(bookId)
+
+    override fun observeEventsInRange(
+        startMs: Long,
+        endMs: Long,
+    ): Flow<List<ListeningEventEntity>> = listeningEventDao.observeEventsInRange(startMs, endMs)
+
+    override fun observeEventsSince(startMs: Long): Flow<List<ListeningEventEntity>> =
+        listeningEventDao.observeEventsSince(startMs)
+
+    override suspend fun getTotalDurationSince(startMs: Long): Long = listeningEventDao.getTotalDurationSince(startMs)
+
+    override fun observeTotalDurationSince(startMs: Long): Flow<Long> =
+        listeningEventDao.observeTotalDurationSince(startMs)
+
+    override fun observeDistinctBooksSince(startMs: Long): Flow<Int> =
+        listeningEventDao.observeDistinctBooksSince(startMs)
+
+    override fun observeDistinctDaysSince(startMs: Long): Flow<List<Long>> =
+        listeningEventDao.observeDistinctDaysSince(startMs)
+
+    override suspend fun getDistinctDaysWithActivity(startMs: Long): List<Long> =
+        listeningEventDao.getDistinctDaysWithActivity(startMs)
+
+    override suspend fun getDurationByBook(
+        startMs: Long,
+        endMs: Long,
+    ): List<BookDuration> = listeningEventDao.getDurationByBook(startMs, endMs)
+}

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/PlaybackPositionRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/PlaybackPositionRepositoryImpl.kt
@@ -1,5 +1,3 @@
-@file:Suppress("TooManyFunctions")
-
 package com.calypsan.listenup.client.data.repository
 
 import com.calypsan.listenup.client.core.AppResult

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/PlaybackPositionRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/PlaybackPositionRepositoryImpl.kt
@@ -620,6 +620,6 @@ private fun epochMillisToIso8601(millis: Long): String = Instant.fromEpochMillis
 private fun parseIsoOrNull(iso: String): Long? =
     try {
         Instant.parse(iso).toEpochMilliseconds()
-    } catch (_: IllegalArgumentException) {
+    } catch (_: Exception) {
         null
     }

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/PlaybackPositionRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/PlaybackPositionRepositoryImpl.kt
@@ -33,12 +33,13 @@ private val logger = KotlinLogging.logger {}
  * Wraps PlaybackPositionDao and converts entities to domain models.
  * Position operations are instant and local-first.
  *
- * The mark/discard/restart operations use optimistic updates:
- * 1. Update local database immediately for instant UI response
- * 2. Sync to server in background
- * 3. Rollback local changes if server sync fails
+ * [markComplete] is a thin facade over [savePlaybackState] and uses the outbox
+ * pattern: local save + unconditional MARK_COMPLETE pending-op queue (the sync
+ * engine processes it asynchronously). [discardProgress] and [restartBook] retain
+ * their own implementations with optimistic local update + immediate server sync +
+ * rollback on failure — no pending-op infrastructure exists for those operations yet.
  *
- * The newer [savePlaybackState] entry point owns per-book Mutex serialization
+ * The [savePlaybackState] entry point owns per-book Mutex serialization
  * plus per-call transactional dispatch over the 11-variant [PlaybackUpdate]
  * sealed hierarchy. Every variant handler runs inside [TransactionRunner.atomically]
  * so each fetch-then-save pair is rollback-safe. Concurrent writes for the same
@@ -86,7 +87,7 @@ class PlaybackPositionRepositoryImpl(
     override suspend fun getRecentPositions(limit: Int): List<PlaybackPosition> =
         dao.getRecentPositions(limit).map { it.toDomain() }
 
-    // ----- Existing write paths (untouched in Task 2; will become facades in Task 7) --------
+    // ----- Write paths -----------------------------------------------------------------------
 
     override suspend fun save(
         bookId: String,
@@ -121,68 +122,7 @@ class PlaybackPositionRepositoryImpl(
         bookId: String,
         startedAt: Long?,
         finishedAt: Long?,
-    ): AppResult<Unit> {
-        logger.debug { "markComplete: $bookId" }
-        val existing = dao.get(BookId(bookId))
-        val now = currentEpochMilliseconds()
-        val effectiveFinishedAt = finishedAt ?: now
-        val effectiveStartedAt = startedAt ?: existing?.startedAt ?: now
-
-        // Optimistic local update
-        val updated =
-            existing?.copy(
-                isFinished = true,
-                finishedAt = effectiveFinishedAt,
-                startedAt = effectiveStartedAt,
-                updatedAt = now,
-            ) ?: PlaybackPositionEntity(
-                bookId = BookId(bookId),
-                positionMs = 0,
-                playbackSpeed = 1.0f,
-                hasCustomSpeed = false,
-                updatedAt = now,
-                lastPlayedAt = now,
-                isFinished = true,
-                finishedAt = effectiveFinishedAt,
-                startedAt = effectiveStartedAt,
-            )
-        dao.save(updated)
-
-        // Convert to ISO 8601 for API
-        val startedAtIso = epochMillisToIso8601(effectiveStartedAt)
-        val finishedAtIso = epochMillisToIso8601(effectiveFinishedAt)
-
-        // Sync to server
-        return when (val result = syncApi.markComplete(bookId, startedAt = startedAtIso, finishedAt = finishedAtIso)) {
-            is Success -> {
-                logger.info { "markComplete: synced $bookId to server" }
-                Success(Unit)
-            }
-
-            is Failure -> {
-                logger.warn {
-                    "markComplete: server sync failed for $bookId, enqueueing for retry"
-                }
-                // Do NOT rollback. Optimistic local update is correct.
-                // Enqueue for retry so PushSyncOrchestrator will keep trying,
-                // preventing ProgressPuller from overwriting local isFinished=true.
-                pendingOps.queue(
-                    type = OperationType.MARK_COMPLETE,
-                    entityType = EntityType.BOOK,
-                    entityId = bookId,
-                    payload =
-                        MarkCompletePayload(
-                            bookId = bookId,
-                            startedAt = startedAtIso,
-                            finishedAt = finishedAtIso,
-                        ),
-                    handler = markCompleteHandler,
-                )
-                // Return success since local state is correct and retry is enqueued
-                Success(Unit)
-            }
-        }
-    }
+    ): AppResult<Unit> = savePlaybackState(BookId(bookId), PlaybackUpdate.MarkComplete(startedAt, finishedAt))
 
     override suspend fun discardProgress(bookId: String): AppResult<Unit> {
         logger.debug { "discardProgress: $bookId" }

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/PlaybackPositionRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/PlaybackPositionRepositoryImpl.kt
@@ -1,23 +1,30 @@
+@file:Suppress("TooManyFunctions")
+
 package com.calypsan.listenup.client.data.repository
 
+import com.calypsan.listenup.client.core.AppResult
 import com.calypsan.listenup.client.core.BookId
 import com.calypsan.listenup.client.core.Failure
-import com.calypsan.listenup.client.core.AppResult
 import com.calypsan.listenup.client.core.Success
 import com.calypsan.listenup.client.core.currentEpochMilliseconds
-import com.calypsan.listenup.client.data.local.db.PlaybackPositionDao
-import com.calypsan.listenup.client.data.local.db.PlaybackPositionEntity
-import com.calypsan.listenup.client.data.remote.SyncApiContract
+import com.calypsan.listenup.client.core.suspendRunCatching
 import com.calypsan.listenup.client.data.local.db.EntityType
 import com.calypsan.listenup.client.data.local.db.OperationType
+import com.calypsan.listenup.client.data.local.db.PlaybackPositionDao
+import com.calypsan.listenup.client.data.local.db.PlaybackPositionEntity
+import com.calypsan.listenup.client.data.local.db.TransactionRunner
+import com.calypsan.listenup.client.data.remote.SyncApiContract
 import com.calypsan.listenup.client.data.sync.push.MarkCompleteHandler
 import com.calypsan.listenup.client.data.sync.push.MarkCompletePayload
 import com.calypsan.listenup.client.data.sync.push.PendingOperationRepositoryContract
 import com.calypsan.listenup.client.domain.model.PlaybackPosition
 import com.calypsan.listenup.client.domain.repository.PlaybackPositionRepository
+import com.calypsan.listenup.client.domain.repository.PlaybackUpdate
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlin.time.Instant
 
 private val logger = KotlinLogging.logger {}
@@ -33,15 +40,42 @@ private val logger = KotlinLogging.logger {}
  * 2. Sync to server in background
  * 3. Rollback local changes if server sync fails
  *
+ * The newer [savePlaybackState] entry point owns per-book Mutex serialization
+ * plus per-call transactional dispatch over the 11-variant [PlaybackUpdate]
+ * sealed hierarchy. Every variant handler runs inside [TransactionRunner.atomically]
+ * so each fetch-then-save pair is rollback-safe. Concurrent writes for the same
+ * book serialize on a per-book Mutex; different books proceed in parallel.
+ *
  * @property dao Room DAO for position operations
  * @property syncApi API for syncing progress changes to server
+ * @property pendingOps Queue for pending push operations
+ * @property markCompleteHandler Handler for MARK_COMPLETE pending ops
+ * @property transactionRunner Runs each variant handler inside a write transaction
  */
 class PlaybackPositionRepositoryImpl(
     private val dao: PlaybackPositionDao,
     private val syncApi: SyncApiContract,
     private val pendingOps: PendingOperationRepositoryContract,
     private val markCompleteHandler: MarkCompleteHandler,
+    private val transactionRunner: TransactionRunner,
 ) : PlaybackPositionRepository {
+    // ----- Per-book Mutex map ---------------------------------------------------------------
+
+    private val mutexMapLock = Mutex()
+    private val mutexes = mutableMapOf<BookId, Mutex>()
+
+    /**
+     * Returns the [Mutex] guarding writes for [bookId]. Creates and stores a new
+     * Mutex on first access; subsequent accesses for the same book return the same
+     * instance. The map grows monotonically; eviction is a future optimization.
+     *
+     * Holds [mutexMapLock] only for the duration of [getOrPut] so other books'
+     * Mutex creations don't block on per-book write durations.
+     */
+    private suspend fun mutexFor(bookId: BookId): Mutex = mutexMapLock.withLock { mutexes.getOrPut(bookId) { Mutex() } }
+
+    // ----- Read paths -----------------------------------------------------------------------
+
     override suspend fun get(bookId: String): PlaybackPosition? = dao.get(BookId(bookId))?.toDomain()
 
     override fun observe(bookId: String): Flow<PlaybackPosition?> = dao.observe(BookId(bookId)).map { it?.toDomain() }
@@ -53,6 +87,8 @@ class PlaybackPositionRepositoryImpl(
 
     override suspend fun getRecentPositions(limit: Int): List<PlaybackPosition> =
         dao.getRecentPositions(limit).map { it.toDomain() }
+
+    // ----- Existing write paths (untouched in Task 2; will become facades in Task 7) --------
 
     override suspend fun save(
         bookId: String,
@@ -228,6 +264,330 @@ class PlaybackPositionRepositoryImpl(
             }
         }
     }
+
+    // ----- Canonical entry point ------------------------------------------------------------
+
+    override suspend fun savePlaybackState(
+        bookId: BookId,
+        update: PlaybackUpdate,
+    ): AppResult<Unit> =
+        suspendRunCatching {
+            mutexFor(bookId).withLock {
+                transactionRunner.atomically {
+                    handle(bookId, update)
+                }
+            }
+        }
+
+    /**
+     * Exhaustive dispatcher over the 11-variant [PlaybackUpdate] hierarchy.
+     *
+     * Adding a new variant produces a `when` exhaustiveness compile error here —
+     * the sealed-hierarchy contract every consumer must satisfy.
+     */
+    private suspend fun handle(
+        bookId: BookId,
+        update: PlaybackUpdate,
+    ) {
+        when (update) {
+            is PlaybackUpdate.Position -> handlePosition(bookId, update)
+            is PlaybackUpdate.Speed -> handleSpeed(bookId, update)
+            is PlaybackUpdate.SpeedReset -> handleSpeedReset(bookId, update)
+            is PlaybackUpdate.PlaybackStarted -> handlePlaybackStarted(bookId, update)
+            is PlaybackUpdate.PlaybackPaused -> handlePlaybackPaused(bookId, update)
+            is PlaybackUpdate.PeriodicUpdate -> handlePeriodicUpdate(bookId, update)
+            is PlaybackUpdate.BookFinished -> handleBookFinished(bookId, update)
+            is PlaybackUpdate.CrossDeviceSync -> handleCrossDeviceSync(bookId, update)
+            is PlaybackUpdate.MarkComplete -> handleMarkComplete(bookId, update)
+            PlaybackUpdate.DiscardProgress -> handleDiscardProgress(bookId)
+            PlaybackUpdate.Restart -> handleRestart(bookId)
+        }
+    }
+
+    // ----- Per-variant handlers -------------------------------------------------------------
+
+    private suspend fun handlePosition(
+        bookId: BookId,
+        u: PlaybackUpdate.Position,
+    ) {
+        // Periodic position save during playback. Use updatePositionOnly to preserve
+        // hasCustomSpeed + playbackSpeed against concurrent speed-change writers
+        // (PlaybackPositionDao.updatePositionOnly contract).
+        val now = currentEpochMilliseconds()
+        dao.updatePositionOnly(bookId, u.positionMs, updatedAt = now, lastPlayedAt = now)
+    }
+
+    private suspend fun handleSpeed(
+        bookId: BookId,
+        u: PlaybackUpdate.Speed,
+    ) {
+        val existing = dao.get(bookId)
+        val now = currentEpochMilliseconds()
+        val merged =
+            existing?.copy(
+                positionMs = u.positionMs,
+                playbackSpeed = u.speed,
+                hasCustomSpeed = u.custom,
+                updatedAt = now,
+                lastPlayedAt = now,
+                syncedAt = null,
+            ) ?: blank(bookId, now).copy(
+                positionMs = u.positionMs,
+                playbackSpeed = u.speed,
+                hasCustomSpeed = u.custom,
+            )
+        dao.save(merged)
+    }
+
+    private suspend fun handleSpeedReset(
+        bookId: BookId,
+        u: PlaybackUpdate.SpeedReset,
+    ) {
+        val existing = dao.get(bookId)
+        val now = currentEpochMilliseconds()
+        val merged =
+            existing?.copy(
+                positionMs = u.positionMs,
+                playbackSpeed = u.defaultSpeed,
+                hasCustomSpeed = false,
+                updatedAt = now,
+                lastPlayedAt = now,
+                syncedAt = null,
+            ) ?: blank(bookId, now).copy(
+                positionMs = u.positionMs,
+                playbackSpeed = u.defaultSpeed,
+                hasCustomSpeed = false,
+            )
+        dao.save(merged)
+    }
+
+    private suspend fun handlePlaybackStarted(
+        bookId: BookId,
+        u: PlaybackUpdate.PlaybackStarted,
+    ) {
+        val existing = dao.get(bookId)
+        val now = currentEpochMilliseconds()
+        val merged =
+            existing?.copy(
+                positionMs = u.positionMs,
+                playbackSpeed = u.speed,
+                startedAt = existing.startedAt ?: now, // preserve original startedAt if set
+                lastPlayedAt = now,
+                updatedAt = now,
+                syncedAt = null,
+            ) ?: blank(bookId, now).copy(
+                positionMs = u.positionMs,
+                playbackSpeed = u.speed,
+                startedAt = now,
+            )
+        dao.save(merged)
+    }
+
+    private suspend fun handlePlaybackPaused(
+        bookId: BookId,
+        u: PlaybackUpdate.PlaybackPaused,
+    ) {
+        // Same shape as Position — periodic position flush; speed preserved via
+        // updatePositionOnly (per dao contract).
+        val now = currentEpochMilliseconds()
+        dao.updatePositionOnly(bookId, u.positionMs, updatedAt = now, lastPlayedAt = now)
+    }
+
+    private suspend fun handlePeriodicUpdate(
+        bookId: BookId,
+        u: PlaybackUpdate.PeriodicUpdate,
+    ) {
+        val now = currentEpochMilliseconds()
+        dao.updatePositionOnly(bookId, u.positionMs, updatedAt = now, lastPlayedAt = now)
+    }
+
+    private suspend fun handleBookFinished(
+        bookId: BookId,
+        u: PlaybackUpdate.BookFinished,
+    ) {
+        val existing = dao.get(bookId)
+        val now = currentEpochMilliseconds()
+        val finishedAt = existing?.finishedAt ?: now
+        val startedAt = existing?.startedAt ?: now
+        val merged =
+            existing?.copy(
+                positionMs = u.finalPositionMs,
+                isFinished = true,
+                finishedAt = finishedAt,
+                startedAt = startedAt,
+                updatedAt = now,
+                lastPlayedAt = now,
+                syncedAt = null,
+            ) ?: blank(bookId, now).copy(
+                positionMs = u.finalPositionMs,
+                isFinished = true,
+                finishedAt = finishedAt,
+                startedAt = startedAt,
+            )
+        dao.save(merged)
+        // Queue MARK_COMPLETE for server sync. Mirrors the existing markComplete
+        // facade's failure-path queueing semantics so both write paths converge on
+        // the same pending-op shape.
+        pendingOps.queue(
+            type = OperationType.MARK_COMPLETE,
+            entityType = EntityType.BOOK,
+            entityId = bookId.value,
+            payload =
+                MarkCompletePayload(
+                    bookId = bookId.value,
+                    startedAt = epochMillisToIso8601(startedAt),
+                    finishedAt = epochMillisToIso8601(finishedAt),
+                ),
+            handler = markCompleteHandler,
+        )
+    }
+
+    private suspend fun handleCrossDeviceSync(
+        bookId: BookId,
+        u: PlaybackUpdate.CrossDeviceSync,
+    ) {
+        // Reconcile-with-stored: only apply if event is newer than stored.
+        // Mirrors `SSEEventProcessor.handleProgressUpdated` lifecycle; ported here
+        // so the canonical merge lives in the repository (Phase B's single-writer
+        // goal). The handler's caller is responsible for "is this book locally
+        // playing? skip" — that's a higher-level policy, not a per-row write rule.
+        val payload = u.event.data
+        val lastPlayedAtMs = parseIsoOrNull(payload.lastPlayedAt) ?: return
+        val finishedAtMs = payload.finishedAt?.let { parseIsoOrNull(it) }
+        val startedAtMs = payload.startedAt?.let { parseIsoOrNull(it) }
+
+        val existing = dao.get(bookId)
+        if (existing != null && (existing.lastPlayedAt ?: 0L) >= lastPlayedAtMs) {
+            // Local is newer — nothing to do.
+            return
+        }
+
+        val merged =
+            existing?.copy(
+                positionMs = payload.currentPositionMs,
+                isFinished = payload.isFinished,
+                lastPlayedAt = lastPlayedAtMs,
+                updatedAt = lastPlayedAtMs,
+                syncedAt = lastPlayedAtMs,
+                // Server omits null timestamps; wire-absence means "no change".
+                finishedAt = finishedAtMs ?: existing.finishedAt,
+                startedAt = startedAtMs ?: existing.startedAt,
+                // playbackSpeed and hasCustomSpeed preserved implicitly via .copy().
+            ) ?: PlaybackPositionEntity(
+                bookId = bookId,
+                positionMs = payload.currentPositionMs,
+                playbackSpeed = 1.0f,
+                hasCustomSpeed = false,
+                isFinished = payload.isFinished,
+                lastPlayedAt = lastPlayedAtMs,
+                updatedAt = lastPlayedAtMs,
+                syncedAt = lastPlayedAtMs,
+                finishedAt = finishedAtMs,
+                startedAt = startedAtMs,
+            )
+        dao.save(merged)
+    }
+
+    private suspend fun handleMarkComplete(
+        bookId: BookId,
+        u: PlaybackUpdate.MarkComplete,
+    ) {
+        val existing = dao.get(bookId)
+        val now = currentEpochMilliseconds()
+        val effectiveFinishedAt = u.finishedAt ?: now
+        val effectiveStartedAt = u.startedAt ?: existing?.startedAt ?: now
+        val merged =
+            existing?.copy(
+                isFinished = true,
+                finishedAt = effectiveFinishedAt,
+                startedAt = effectiveStartedAt,
+                updatedAt = now,
+                syncedAt = null,
+            ) ?: PlaybackPositionEntity(
+                bookId = bookId,
+                positionMs = 0L,
+                playbackSpeed = 1.0f,
+                hasCustomSpeed = false,
+                updatedAt = now,
+                lastPlayedAt = now,
+                isFinished = true,
+                finishedAt = effectiveFinishedAt,
+                startedAt = effectiveStartedAt,
+            )
+        dao.save(merged)
+        pendingOps.queue(
+            type = OperationType.MARK_COMPLETE,
+            entityType = EntityType.BOOK,
+            entityId = bookId.value,
+            payload =
+                MarkCompletePayload(
+                    bookId = bookId.value,
+                    startedAt = epochMillisToIso8601(effectiveStartedAt),
+                    finishedAt = epochMillisToIso8601(effectiveFinishedAt),
+                ),
+            handler = markCompleteHandler,
+        )
+    }
+
+    private suspend fun handleDiscardProgress(bookId: BookId) {
+        // Local-only reset. The existing public `discardProgress(bookId)` facade
+        // owns the server-sync side (syncApi.discardProgress + rollback). No
+        // pending-op infrastructure exists for DISCARD_PROGRESS; the handler's
+        // job is just the local DB write inside the same transaction.
+        val existing = dao.get(bookId) ?: return // no-op if no row
+        val now = currentEpochMilliseconds()
+        dao.save(
+            existing.copy(
+                positionMs = 0L,
+                isFinished = false,
+                finishedAt = null,
+                updatedAt = now,
+                lastPlayedAt = now,
+                syncedAt = null,
+            ),
+        )
+    }
+
+    private suspend fun handleRestart(bookId: BookId) {
+        // Local-only reset. The existing public `restartBook(bookId)` facade owns
+        // the server-sync side (syncApi.restartBook + rollback). No pending-op
+        // infrastructure exists for RESTART_BOOK; the handler's job is just the
+        // local DB write inside the same transaction.
+        val existing = dao.get(bookId) ?: return // no-op if no row
+        val now = currentEpochMilliseconds()
+        dao.save(
+            existing.copy(
+                positionMs = 0L,
+                isFinished = false,
+                finishedAt = null,
+                startedAt = now, // new reading session starts now (matches existing facade)
+                updatedAt = now,
+                lastPlayedAt = now,
+                syncedAt = null,
+            ),
+        )
+    }
+
+    /**
+     * Construct a fresh blank entity for [bookId] anchored at [now].
+     * Used when a variant handler must materialize a row that doesn't yet exist.
+     */
+    private fun blank(
+        bookId: BookId,
+        now: Long,
+    ): PlaybackPositionEntity =
+        PlaybackPositionEntity(
+            bookId = bookId,
+            positionMs = 0L,
+            playbackSpeed = 1.0f,
+            hasCustomSpeed = false,
+            updatedAt = now,
+            syncedAt = null,
+            lastPlayedAt = now,
+            isFinished = false,
+            finishedAt = null,
+            startedAt = now,
+        )
 }
 
 /**
@@ -251,3 +611,17 @@ private fun PlaybackPositionEntity.toDomain(): PlaybackPosition =
  * Convert epoch milliseconds to ISO 8601 string for API communication.
  */
 private fun epochMillisToIso8601(millis: Long): String = Instant.fromEpochMilliseconds(millis).toString()
+
+/**
+ * Parse ISO 8601 to epoch ms; returns null on malformed input.
+ *
+ * Mirrors `SSEEventProcessor.parseLastPlayedOrNull` — used by [PlaybackUpdate.CrossDeviceSync]
+ * to skip rows whose timestamps the server malformed, leaving the next sync to reconcile.
+ */
+@Suppress("SwallowedException", "TooGenericExceptionCaught")
+private fun parseIsoOrNull(iso: String): Long? =
+    try {
+        Instant.parse(iso).toEpochMilliseconds()
+    } catch (_: IllegalArgumentException) {
+        null
+    }

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/PlaybackPositionRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/PlaybackPositionRepositoryImpl.kt
@@ -345,6 +345,7 @@ class PlaybackPositionRepositoryImpl(
     ) {
         val existing = dao.get(bookId)
         val now = currentEpochMilliseconds()
+        // Preserve original finishedAt on re-finish — first-completion timestamp is sticky.
         val finishedAt = existing?.finishedAt ?: now
         val startedAt = existing?.startedAt ?: now
         val merged =

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/di/Koin.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/di/Koin.kt
@@ -1350,6 +1350,8 @@ val syncModule =
             BookRepositoryImpl(
                 bookDao = get(),
                 chapterDao = get(),
+                audioFileDao = get(),
+                transactionRunner = get(),
                 syncManager = get(),
                 imageStorage = get(),
                 genreRepository = get(),

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/di/Koin.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/di/Koin.kt
@@ -1474,6 +1474,7 @@ val syncModule =
                 syncApi = get(),
                 pendingOps = get(),
                 markCompleteHandler = get(),
+                transactionRunner = get(),
             )
         }
 

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/di/Koin.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/di/Koin.kt
@@ -66,6 +66,7 @@ import com.calypsan.listenup.client.data.repository.EventStreamRepositoryImpl
 import com.calypsan.listenup.client.data.repository.GenreRepositoryImpl
 import com.calypsan.listenup.client.data.repository.HomeRepositoryImpl
 import com.calypsan.listenup.client.data.repository.ImageRepositoryImpl
+import com.calypsan.listenup.client.data.repository.ListeningEventRepositoryImpl
 import com.calypsan.listenup.client.data.repository.InstanceRepositoryImpl
 import com.calypsan.listenup.client.data.repository.LeaderboardRepositoryImpl
 import com.calypsan.listenup.client.data.repository.ShelfRepositoryImpl
@@ -160,6 +161,7 @@ import com.calypsan.listenup.client.domain.repository.ShelfRepository
 import com.calypsan.listenup.client.domain.repository.LibraryPreferences
 import com.calypsan.listenup.client.domain.repository.LibrarySync
 import com.calypsan.listenup.client.domain.repository.LocalPreferences
+import com.calypsan.listenup.client.domain.repository.ListeningEventRepository
 import com.calypsan.listenup.client.domain.repository.PlaybackPositionRepository
 import com.calypsan.listenup.client.domain.repository.PlaybackPreferences
 import com.calypsan.listenup.client.domain.repository.ProfileRepository
@@ -1385,6 +1387,22 @@ val syncModule =
                 userStatsDao = get(),
                 userDao = get(),
                 leaderboardApi = get(),
+            )
+        }
+
+        // ListeningEventRepository — transactional write (upsert + pending-op) + DAO read surface
+        single<ListeningEventRepository> {
+            ListeningEventRepositoryImpl(
+                listeningEventDao = get(),
+                pendingOperationRepository = get(),
+                listeningEventHandler = get(),
+                transactionRunner = get(),
+                deviceId =
+                    get(
+                        qualifier =
+                            org.koin.core.qualifier
+                                .named("deviceId"),
+                    ),
             )
         }
 

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/di/Koin.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/di/Koin.kt
@@ -227,6 +227,7 @@ import com.calypsan.listenup.client.domain.usecase.series.UpdateSeriesUseCase
 import com.calypsan.listenup.client.playback.PlaybackManager
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.factoryOf
+import org.koin.core.qualifier.named
 import org.koin.dsl.bind
 import org.koin.dsl.module
 import com.calypsan.listenup.client.data.repository.ContributorEditRepository as ContributorEditRepositoryImpl
@@ -1397,12 +1398,7 @@ val syncModule =
                 pendingOperationRepository = get(),
                 listeningEventHandler = get(),
                 transactionRunner = get(),
-                deviceId =
-                    get(
-                        qualifier =
-                            org.koin.core.qualifier
-                                .named("deviceId"),
-                    ),
+                deviceId = get(qualifier = named("deviceId")),
             )
         }
 

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/BookRepository.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/BookRepository.kt
@@ -1,6 +1,8 @@
 package com.calypsan.listenup.client.domain.repository
 
 import com.calypsan.listenup.client.core.AppResult
+import com.calypsan.listenup.client.data.local.db.AudioFileEntity
+import com.calypsan.listenup.client.data.local.db.BookEntity
 import com.calypsan.listenup.client.domain.model.BookDetail
 import com.calypsan.listenup.client.domain.model.BookListItem
 import com.calypsan.listenup.client.domain.model.Chapter
@@ -105,6 +107,22 @@ interface BookRepository {
      * @return Detail shape, or null if the book doesn't exist.
      */
     suspend fun getBookDetail(id: String): BookDetail?
+
+    /**
+     * Atomically upsert a book row and replace its audio-file rows.
+     *
+     * Deletes existing audio-file rows for the book and inserts the new
+     * set inside a single transaction, so the DB never holds a book with
+     * a partially-replaced audio-file list.
+     *
+     * @param book The book entity to upsert.
+     * @param audioFiles The complete set of audio-file entities to store.
+     *   Pass an empty list to clear all audio files without inserting new ones.
+     */
+    suspend fun upsertWithAudioFiles(
+        book: BookEntity,
+        audioFiles: List<AudioFileEntity>,
+    ): AppResult<Unit>
 }
 
 /**

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/DownloadRepository.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/DownloadRepository.kt
@@ -17,4 +17,12 @@ interface DownloadRepository {
      * Observe all fully-downloaded books as domain summaries, sorted largest first.
      */
     fun observeDownloadedBooks(): Flow<List<DownloadedBookSummary>>
+
+    /**
+     * Delete all download records for the given book.
+     *
+     * Called when a book finishes playing so the next playback session
+     * auto-downloads again (the user's default behaviour).
+     */
+    suspend fun deleteForBook(bookId: String)
 }

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/ListeningEventRepository.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/ListeningEventRepository.kt
@@ -1,0 +1,73 @@
+package com.calypsan.listenup.client.domain.repository
+
+import com.calypsan.listenup.client.core.AppResult
+import com.calypsan.listenup.client.core.BookId
+import com.calypsan.listenup.client.data.local.db.BookDuration
+import com.calypsan.listenup.client.data.local.db.ListeningEventEntity
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Repository for listening events.
+ *
+ * Encapsulates the two-write atomic operation (local upsert + pending-op queue) behind
+ * a single transactional call. All read methods surface DAO queries to callers that
+ * currently access [com.calypsan.listenup.client.data.local.db.ListeningEventDao] directly
+ * (Stats, Leaderboard) — so those callers can migrate through this interface later.
+ *
+ * Read methods return [ListeningEventEntity] rather than a domain type because no
+ * `ListeningEvent` domain class exists; the entity fields are the canonical representation
+ * in this codebase (confirmed: grep found no `class ListeningEvent` domain type).
+ */
+interface ListeningEventRepository {
+    /**
+     * Save a listening event locally and queue it for server sync, atomically.
+     *
+     * Both the DAO upsert and the pending-op queue happen inside a single
+     * [com.calypsan.listenup.client.data.local.db.TransactionRunner.atomically] block.
+     * If either write fails the transaction rolls back. [kotlinx.coroutines.CancellationException]
+     * is always rethrown (EM-R1).
+     */
+    suspend fun queueListeningEvent(
+        bookId: BookId,
+        startPositionMs: Long,
+        endPositionMs: Long,
+        startedAt: Long,
+        endedAt: Long,
+        playbackSpeed: Float,
+    ): AppResult<Unit>
+
+    // ==================== Read methods (external callers today) ====================
+
+    /** All events for [bookId], newest first. Used by future per-book stats. */
+    fun observeEventsForBook(bookId: String): Flow<List<ListeningEventEntity>>
+
+    /** Events in [startMs]..[endMs] window, newest first. */
+    fun observeEventsInRange(
+        startMs: Long,
+        endMs: Long,
+    ): Flow<List<ListeningEventEntity>>
+
+    /** Events since [startMs], no upper bound, newest first. */
+    fun observeEventsSince(startMs: Long): Flow<List<ListeningEventEntity>>
+
+    /** Total listening duration (ms) across events since [startMs]. */
+    suspend fun getTotalDurationSince(startMs: Long): Long
+
+    /** Reactive total listening duration since [startMs]. */
+    fun observeTotalDurationSince(startMs: Long): Flow<Long>
+
+    /** Reactive distinct-book count since [startMs]. */
+    fun observeDistinctBooksSince(startMs: Long): Flow<Int>
+
+    /** Reactive distinct days (epoch ms) with listening activity since [startMs]. */
+    fun observeDistinctDaysSince(startMs: Long): Flow<List<Long>>
+
+    /** Distinct days (epoch ms) with listening activity since [startMs] (one-shot). */
+    suspend fun getDistinctDaysWithActivity(startMs: Long): List<Long>
+
+    /** Total duration grouped by book for [startMs]..[endMs]. */
+    suspend fun getDurationByBook(
+        startMs: Long,
+        endMs: Long,
+    ): List<BookDuration>
+}

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/PlaybackPositionRepository.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/PlaybackPositionRepository.kt
@@ -1,8 +1,9 @@
 package com.calypsan.listenup.client.domain.repository
 
+import com.calypsan.listenup.client.core.AppResult
+import com.calypsan.listenup.client.core.BookId
 import com.calypsan.listenup.client.domain.model.PlaybackPosition
 import kotlinx.coroutines.flow.Flow
-import com.calypsan.listenup.client.core.AppResult
 
 /**
  * Repository contract for playback position operations.
@@ -120,4 +121,24 @@ interface PlaybackPositionRepository {
      * @return Result with Unit on success, or Failure on error
      */
     suspend fun restartBook(bookId: String): com.calypsan.listenup.client.core.AppResult<Unit>
+
+    /**
+     * Single canonical entry point for every mutation of `playback_positions`.
+     *
+     * The repository owns the per-book Mutex + transaction discipline; callers
+     * just specify intent via the [PlaybackUpdate] variant. Concurrent writes
+     * for the same book serialize via a per-book Mutex; different books proceed
+     * in parallel. Every variant handler runs inside `TransactionRunner.atomically`
+     * so partial-write states are impossible.
+     *
+     * @param bookId The book whose playback state is being mutated.
+     * @param update The intent describing the mutation.
+     * @return [AppResult.Success] if the transaction committed; [AppResult.Failure]
+     *   if the underlying DAO write threw or the transaction rolled back.
+     *   `CancellationException` is rethrown.
+     */
+    suspend fun savePlaybackState(
+        bookId: BookId,
+        update: PlaybackUpdate,
+    ): AppResult<Unit>
 }

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/PlaybackUpdate.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/PlaybackUpdate.kt
@@ -76,6 +76,6 @@ sealed interface PlaybackUpdate {
     /** User command: discard progress (reset to 0 + isFinished=false). */
     data object DiscardProgress : PlaybackUpdate
 
-    /** User command: restart book (position=0, isFinished=false; preserves startedAt). */
+    /** User command: restart book (position=0, isFinished=false; resets startedAt to now — new reading session). */
     data object Restart : PlaybackUpdate
 }

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/PlaybackUpdate.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/domain/repository/PlaybackUpdate.kt
@@ -1,0 +1,81 @@
+package com.calypsan.listenup.client.domain.repository
+
+import com.calypsan.listenup.client.data.sync.SSEEvent
+
+/**
+ * Sealed hierarchy describing every distinct write pattern that can mutate a
+ * book's playback position. Funnels every write — player events, user commands,
+ * cross-device SSE merges — through a single repository entry point
+ * ([PlaybackPositionRepository.savePlaybackState]).
+ *
+ * Per Finding 09 D6, the eight player-event variants describe distinct semantic
+ * intents even when their persistence shapes overlap (e.g., Position /
+ * PlaybackPaused / PeriodicUpdate all save position+speed but represent
+ * different events). Three additional variants (MarkComplete / DiscardProgress /
+ * Restart) describe user commands from BookDetail menu actions.
+ *
+ * Single-writer ownership rule: every mutation of `playback_positions` MUST
+ * route through one of these variants. Adding a new write pattern means adding
+ * a new variant — the sealed `when` exhaustiveness compile-error reminds every
+ * consumer to handle it.
+ */
+sealed interface PlaybackUpdate {
+    /** Periodic position save (no session-state side effects). */
+    data class Position(
+        val positionMs: Long,
+        val speed: Float,
+    ) : PlaybackUpdate
+
+    /** Explicit user-driven speed change. Sets hasCustomSpeed = [custom]. */
+    data class Speed(
+        val positionMs: Long,
+        val speed: Float,
+        val custom: Boolean,
+    ) : PlaybackUpdate
+
+    /** User reset to global default speed. Sets hasCustomSpeed = false. */
+    data class SpeedReset(
+        val positionMs: Long,
+        val defaultSpeed: Float,
+    ) : PlaybackUpdate
+
+    /** Player started playback. Records startedAt if currently null. */
+    data class PlaybackStarted(
+        val positionMs: Long,
+        val speed: Float,
+    ) : PlaybackUpdate
+
+    /** Player paused. */
+    data class PlaybackPaused(
+        val positionMs: Long,
+        val speed: Float,
+    ) : PlaybackUpdate
+
+    /** 30s periodic flush during active playback. */
+    data class PeriodicUpdate(
+        val positionMs: Long,
+        val speed: Float,
+    ) : PlaybackUpdate
+
+    /** Player reached end of book. Sets isFinished = true; queues MarkComplete pending-op. */
+    data class BookFinished(
+        val finalPositionMs: Long,
+    ) : PlaybackUpdate
+
+    /** Cross-device sync merge from SSE event. Reconciles with stored state. */
+    data class CrossDeviceSync(
+        val event: SSEEvent.ProgressUpdated,
+    ) : PlaybackUpdate
+
+    /** User command: mark complete from BookDetail menu. */
+    data class MarkComplete(
+        val startedAt: Long?,
+        val finishedAt: Long?,
+    ) : PlaybackUpdate
+
+    /** User command: discard progress (reset to 0 + isFinished=false). */
+    data object DiscardProgress : PlaybackUpdate
+
+    /** User command: restart book (position=0, isFinished=false; preserves startedAt). */
+    data object Restart : PlaybackUpdate
+}

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackManager.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackManager.kt
@@ -15,7 +15,6 @@ import com.calypsan.listenup.client.data.local.db.AudioFileDao
 import com.calypsan.listenup.client.data.local.db.AudioFileEntity
 import com.calypsan.listenup.client.data.local.db.BookDao
 import com.calypsan.listenup.client.data.local.db.ChapterDao
-import com.calypsan.listenup.client.data.local.db.TransactionRunner
 import com.calypsan.listenup.client.data.remote.PlaybackApi
 import com.calypsan.listenup.client.data.remote.SyncApiContract
 import com.calypsan.listenup.client.data.remote.installListenUpErrorHandling
@@ -27,6 +26,7 @@ import com.calypsan.listenup.client.domain.model.Chapter
 import com.calypsan.listenup.client.domain.model.ContributorRole
 import com.calypsan.listenup.client.domain.playback.PlaybackTimeline
 import com.calypsan.listenup.client.domain.playback.StreamPrepareResult
+import com.calypsan.listenup.client.domain.repository.BookRepository
 import com.calypsan.listenup.client.domain.repository.ImageStorage
 import com.calypsan.listenup.client.domain.repository.PlaybackPreferences
 import com.calypsan.listenup.client.domain.repository.ServerConfig
@@ -56,7 +56,6 @@ private val logger = KotlinLogging.logger {}
  * - Negotiate audio format with server for transcoding support
  */
 class PlaybackManager(
-    private val transactionRunner: TransactionRunner,
     private val serverConfig: ServerConfig,
     private val playbackPreferences: PlaybackPreferences,
     private val bookDao: BookDao,
@@ -71,6 +70,7 @@ class PlaybackManager(
     private val capabilityDetector: AudioCapabilityDetector?,
     private val syncApi: SyncApiContract?,
     private val scope: CoroutineScope,
+    private val bookRepository: BookRepository,
 ) : PlaybackStateProvider {
     private val _currentBookId = MutableStateFlow<BookId?>(null)
     override val currentBookId: StateFlow<BookId?> = _currentBookId
@@ -688,13 +688,7 @@ class PlaybackManager(
                         )
                     }
 
-                transactionRunner.atomically {
-                    bookDao.upsert(entity)
-                    audioFileDao.deleteForBook(bookId.value)
-                    if (audioFileRows.isNotEmpty()) {
-                        audioFileDao.upsertAll(audioFileRows)
-                    }
-                }
+                bookRepository.upsertWithAudioFiles(entity, audioFileRows)
 
                 logger.debug { "Saved fetched book + ${audioFileRows.size} audio files to local database" }
                 true

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackManager.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackManager.kt
@@ -382,9 +382,7 @@ class PlaybackManager(
         player.load(segments)
 
         // Set speed before seeking/playing
-        if (resumeSpeed != 1.0f) {
-            player.setSpeed(resumeSpeed)
-        }
+        player.setSpeed(resumeSpeed)
         playbackSpeed.value = resumeSpeed
 
         // Resume from saved position
@@ -458,17 +456,17 @@ class PlaybackManager(
     }
 
     /**
-     * Called when user explicitly changes playback speed.
-     * Updates state and marks the book as having a custom speed.
+     * Called when user explicitly changes playback speed for the current book.
+     *
+     * Writes per-book only via [progressTracker.onSpeedChanged], which sets
+     * `hasCustomSpeed = true`. The global default is changed only via
+     * Settings → Default Speed; per-book changes do NOT mutate the global default.
      */
     fun onSpeedChanged(speed: Float) {
         val bookId = currentBookId.value ?: return
         val positionMs = currentPositionMs.value
         playbackSpeed.value = speed
         progressTracker.onSpeedChanged(bookId, positionMs, speed)
-
-        // Persist as the universal default so it survives app restarts
-        scope.launch { playbackPreferences.setDefaultPlaybackSpeed(speed) }
     }
 
     /**

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackManager.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackManager.kt
@@ -8,6 +8,7 @@
 
 package com.calypsan.listenup.client.playback
 
+import com.calypsan.listenup.client.core.AppResult
 import com.calypsan.listenup.client.core.BookId
 import com.calypsan.listenup.client.core.Failure
 import com.calypsan.listenup.client.core.Success
@@ -688,10 +689,17 @@ class PlaybackManager(
                         )
                     }
 
-                bookRepository.upsertWithAudioFiles(entity, audioFileRows)
+                when (val writeResult = bookRepository.upsertWithAudioFiles(entity, audioFileRows)) {
+                    is AppResult.Success -> {
+                        logger.debug { "Saved fetched book + ${audioFileRows.size} audio files to local database" }
+                        true
+                    }
 
-                logger.debug { "Saved fetched book + ${audioFileRows.size} audio files to local database" }
-                true
+                    is AppResult.Failure -> {
+                        logger.error { "Failed to persist fetched book ${bookId.value}: ${writeResult.error.message}" }
+                        false
+                    }
+                }
             }
 
             is Failure -> {

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/ProgressTracker.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/ProgressTracker.kt
@@ -3,22 +3,16 @@
 
 package com.calypsan.listenup.client.playback
 
+import com.calypsan.listenup.client.core.AppResult
 import com.calypsan.listenup.client.core.BookId
-import com.calypsan.listenup.client.data.local.db.ListeningEventDao
-import com.calypsan.listenup.client.data.local.db.ListeningEventEntity
-import com.calypsan.listenup.client.data.local.db.OperationType
 import com.calypsan.listenup.client.data.local.db.PlaybackPositionDao
 import com.calypsan.listenup.client.data.local.db.PlaybackPositionEntity
-import com.calypsan.listenup.client.data.local.db.SyncState
 import com.calypsan.listenup.client.data.remote.SyncApiContract
 import com.calypsan.listenup.client.data.remote.model.PlaybackProgressResponse
-import com.calypsan.listenup.client.data.sync.push.ListeningEventPayload
-import com.calypsan.listenup.client.data.sync.push.OperationHandler
-import com.calypsan.listenup.client.data.sync.push.PendingOperationRepositoryContract
 import com.calypsan.listenup.client.data.sync.push.PushSyncOrchestratorContract
 import com.calypsan.listenup.client.domain.repository.DownloadRepository
+import com.calypsan.listenup.client.domain.repository.ListeningEventRepository
 import com.calypsan.listenup.client.domain.repository.PlaybackPositionRepository
-import com.calypsan.listenup.client.util.NanoId
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -43,13 +37,10 @@ private val logger = KotlinLogging.logger {}
 class ProgressTracker(
     private val positionDao: PlaybackPositionDao,
     private val downloadRepository: DownloadRepository,
-    private val listeningEventDao: ListeningEventDao,
+    private val listeningEventRepository: ListeningEventRepository,
     private val syncApi: SyncApiContract,
-    private val pendingOperationRepository: PendingOperationRepositoryContract,
-    private val listeningEventHandler: OperationHandler<ListeningEventPayload>,
     private val pushSyncOrchestrator: PushSyncOrchestratorContract,
     private val positionRepository: PlaybackPositionRepository,
-    private val deviceId: String,
     private val scope: CoroutineScope,
 ) {
     private var currentSession: ListeningSession? = null
@@ -582,10 +573,11 @@ class ProgressTracker(
     )
 
     /**
-     * Save a listening event to Room and queue for server sync.
+     * Validate and delegate a listening event to [ListeningEventRepository].
      *
-     * Offline-first: Event is saved locally first, then queued for sync.
-     * This ensures stats are immediately available even when offline.
+     * Position validation is applied here (not in the repository) because ProgressTracker
+     * owns the "what counts as a valid event" decision at the playback layer. The repository
+     * owns atomicity of the write, not event semantics.
      */
     private suspend fun queueListeningEvent(
         bookId: BookId,
@@ -595,8 +587,8 @@ class ProgressTracker(
         endedAt: Long,
         playbackSpeed: Float,
     ) {
-        // Validate positions to prevent corrupted events
-        // Max reasonable audiobook position: 7 days worth of audio (168 hours)
+        // Validate positions to prevent corrupted events.
+        // Max reasonable audiobook position: 7 days worth of audio (168 hours).
         val maxReasonablePositionMs = 7L * 24 * 60 * 60 * 1000 // ~604,800,000ms
         if (endPositionMs < 0 || endPositionMs > maxReasonablePositionMs) {
             logger.error {
@@ -613,63 +605,28 @@ class ProgressTracker(
             return
         }
 
-        val eventId = NanoId.generate("evt")
-        val now = Clock.System.now().toEpochMilliseconds()
-        logger.info {
-            "🎧 CREATING EVENT: id=$eventId, book=${bookId.value}, start=$startPositionMs, end=$endPositionMs"
-        }
+        when (
+            val result =
+                listeningEventRepository.queueListeningEvent(
+                    bookId = bookId,
+                    startPositionMs = startPositionMs,
+                    endPositionMs = endPositionMs,
+                    startedAt = startedAt,
+                    endedAt = endedAt,
+                    playbackSpeed = playbackSpeed,
+                )
+        ) {
+            is AppResult.Success -> {
+                logger.info {
+                    "🎧 EVENT QUEUED: book=${bookId.value}, start=$startPositionMs, end=$endPositionMs"
+                }
+            }
 
-        // 1. Save to Room first (offline-first)
-        val entity =
-            ListeningEventEntity(
-                id = eventId,
-                bookId = bookId.value,
-                startPositionMs = startPositionMs,
-                endPositionMs = endPositionMs,
-                startedAt = startedAt,
-                endedAt = endedAt,
-                playbackSpeed = playbackSpeed,
-                deviceId = deviceId,
-                syncState = SyncState.NOT_SYNCED,
-                createdAt = now,
-            )
-
-        try {
-            listeningEventDao.upsert(entity)
-            logger.info { "🎧 EVENT SAVED TO ROOM: id=$eventId" }
-        } catch (e: kotlin.coroutines.cancellation.CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            logger.error(e) { "🎧 FAILED TO SAVE EVENT TO ROOM: id=$eventId" }
-            // Continue to queue for sync anyway - worst case it syncs without local storage
-        }
-
-        // 2. Queue for server sync
-        val payload =
-            ListeningEventPayload(
-                id = eventId,
-                bookId = bookId.value,
-                startPositionMs = startPositionMs,
-                endPositionMs = endPositionMs,
-                startedAt = startedAt,
-                endedAt = endedAt,
-                playbackSpeed = playbackSpeed,
-                deviceId = deviceId,
-            )
-
-        try {
-            pendingOperationRepository.queue(
-                type = OperationType.LISTENING_EVENT,
-                entityType = null, // Events don't target a specific entity type
-                entityId = null, // Events batch together, not by entity
-                payload = payload,
-                handler = listeningEventHandler,
-            )
-            logger.info { "🎧 EVENT QUEUED FOR SYNC: id=$eventId" }
-        } catch (e: kotlin.coroutines.cancellation.CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            logger.error(e) { "🎧 FAILED TO QUEUE EVENT FOR SYNC: id=$eventId" }
+            is AppResult.Failure -> {
+                logger.warn {
+                    "🎧 FAILED TO QUEUE EVENT: book=${bookId.value}: ${result.error.message}"
+                }
+            }
         }
     }
 

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/ProgressTracker.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/ProgressTracker.kt
@@ -521,8 +521,14 @@ class ProgressTracker(
             // Clear any DELETED download records so future playback will auto-download again
             // This means that the next time a user wants to listen to the same book. We assume
             // They want the default behavior again (stream + download)
-            downloadRepository.deleteForBook(bookId.value)
-            logger.debug { "Cleared download records for finished book: ${bookId.value}" }
+            try {
+                downloadRepository.deleteForBook(bookId.value)
+                logger.debug { "Cleared download records for finished book: ${bookId.value}" }
+            } catch (e: kotlin.coroutines.cancellation.CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                logger.warn { "Failed to delete download records for ${bookId.value} (non-fatal): ${e.message}" }
+            }
 
             // Mark book as complete (Issue #206)
             val finishedAt = Clock.System.now().toEpochMilliseconds()

--- a/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/ProgressTracker.kt
+++ b/shared/src/commonMain/kotlin/com/calypsan/listenup/client/playback/ProgressTracker.kt
@@ -4,7 +4,6 @@
 package com.calypsan.listenup.client.playback
 
 import com.calypsan.listenup.client.core.BookId
-import com.calypsan.listenup.client.data.local.db.DownloadDao
 import com.calypsan.listenup.client.data.local.db.ListeningEventDao
 import com.calypsan.listenup.client.data.local.db.ListeningEventEntity
 import com.calypsan.listenup.client.data.local.db.OperationType
@@ -17,6 +16,7 @@ import com.calypsan.listenup.client.data.sync.push.ListeningEventPayload
 import com.calypsan.listenup.client.data.sync.push.OperationHandler
 import com.calypsan.listenup.client.data.sync.push.PendingOperationRepositoryContract
 import com.calypsan.listenup.client.data.sync.push.PushSyncOrchestratorContract
+import com.calypsan.listenup.client.domain.repository.DownloadRepository
 import com.calypsan.listenup.client.domain.repository.PlaybackPositionRepository
 import com.calypsan.listenup.client.util.NanoId
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -42,7 +42,7 @@ private val logger = KotlinLogging.logger {}
  */
 class ProgressTracker(
     private val positionDao: PlaybackPositionDao,
-    private val downloadDao: DownloadDao,
+    private val downloadRepository: DownloadRepository,
     private val listeningEventDao: ListeningEventDao,
     private val syncApi: SyncApiContract,
     private val pendingOperationRepository: PendingOperationRepositoryContract,
@@ -521,7 +521,7 @@ class ProgressTracker(
             // Clear any DELETED download records so future playback will auto-download again
             // This means that the next time a user wants to listen to the same book. We assume
             // They want the default behavior again (stream + download)
-            downloadDao.deleteForBook(bookId.value)
+            downloadRepository.deleteForBook(bookId.value)
             logger.debug { "Cleared download records for finished book: ${bookId.value}" }
 
             // Mark book as complete (Issue #206)

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/BookRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/BookRepositoryTest.kt
@@ -3,10 +3,12 @@ package com.calypsan.listenup.client.data.repository
 import com.calypsan.listenup.client.core.BookId
 import com.calypsan.listenup.client.core.ChapterId
 import com.calypsan.listenup.client.core.Timestamp
+import com.calypsan.listenup.client.data.local.db.AudioFileDao
 import com.calypsan.listenup.client.data.local.db.BookDao
 import com.calypsan.listenup.client.data.local.db.ChapterDao
 import com.calypsan.listenup.client.data.local.db.ChapterEntity
 import com.calypsan.listenup.client.data.local.db.SyncState
+import com.calypsan.listenup.client.data.local.db.TransactionRunner
 import com.calypsan.listenup.client.data.sync.SyncManagerContract
 import com.calypsan.listenup.client.domain.repository.ImageStorage
 import dev.mokkery.answering.returns
@@ -39,6 +41,8 @@ class BookRepositoryTest {
     private class TestFixture {
         val bookDao: BookDao = mock()
         val chapterDao: ChapterDao = mock()
+        val audioFileDao: AudioFileDao = mock()
+        val transactionRunner: TransactionRunner = mock()
         val syncManager: SyncManagerContract = mock()
         val imageStorage: ImageStorage = mock()
         val genreRepository: com.calypsan.listenup.client.domain.repository.GenreRepository = mock()
@@ -48,6 +52,8 @@ class BookRepositoryTest {
             BookRepositoryImpl(
                 bookDao = bookDao,
                 chapterDao = chapterDao,
+                audioFileDao = audioFileDao,
+                transactionRunner = transactionRunner,
                 syncManager = syncManager,
                 imageStorage = imageStorage,
                 genreRepository = genreRepository,

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/ListeningEventRepositoryImplTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/ListeningEventRepositoryImplTest.kt
@@ -1,0 +1,410 @@
+package com.calypsan.listenup.client.data.repository
+
+import com.calypsan.listenup.client.core.AppResult
+import com.calypsan.listenup.client.core.BookId
+import com.calypsan.listenup.client.data.local.db.BookDuration
+import com.calypsan.listenup.client.data.local.db.ListeningEventDao
+import com.calypsan.listenup.client.data.local.db.ListeningEventEntity
+import com.calypsan.listenup.client.data.local.db.OperationType
+import com.calypsan.listenup.client.data.local.db.SyncState
+import com.calypsan.listenup.client.data.local.db.TransactionRunner
+import com.calypsan.listenup.client.data.local.db.PlaybackPositionDao
+import com.calypsan.listenup.client.data.remote.SyncApiContract
+import com.calypsan.listenup.client.data.sync.push.ListeningEventHandler
+import com.calypsan.listenup.client.data.sync.push.ListeningEventPayload
+import com.calypsan.listenup.client.data.sync.push.PendingOperationRepositoryContract
+import com.calypsan.listenup.client.test.db.passThroughTransactionRunner
+import dev.mokkery.MockMode
+import dev.mokkery.answering.calls
+import dev.mokkery.answering.returns
+import dev.mokkery.answering.throws
+import dev.mokkery.every
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+
+/**
+ * Tests for [ListeningEventRepositoryImpl].
+ *
+ * Covers:
+ * - Happy path: both DAO upsert and pending-op queue happen inside atomically.
+ * - Rollback on DAO failure: pending-op is NOT queued.
+ * - Rollback on pending-op failure: DAO upsert was attempted but transaction rolls back.
+ * - CancellationException is rethrown (EM-R1).
+ * - Read methods delegate straight to the DAO.
+ *
+ * Uses Mokkery for [ListeningEventDao] and [PendingOperationRepositoryContract].
+ * Uses [passThroughTransactionRunner] to execute the atomically block inline.
+ */
+class ListeningEventRepositoryImplTest {
+    // ==================== Test Data Factories ====================
+
+    private val testDeviceId = "device-test-123"
+    private val testBookId = BookId("book-abc")
+
+    private fun createMockDao(): ListeningEventDao = mock<ListeningEventDao>(MockMode.autoUnit)
+
+    private fun createMockSyncApi(): SyncApiContract = mock<SyncApiContract>(MockMode.autoUnit)
+
+    private fun createMockPositionDao(): PlaybackPositionDao = mock<PlaybackPositionDao>(MockMode.autoUnit)
+
+    private fun createMockPendingOps(): PendingOperationRepositoryContract = mock<PendingOperationRepositoryContract>(MockMode.autoUnit)
+
+    private fun createRepo(
+        dao: ListeningEventDao = createMockDao(),
+        pendingOps: PendingOperationRepositoryContract = createMockPendingOps(),
+        handler: ListeningEventHandler = ListeningEventHandler(api = createMockSyncApi(), positionDao = createMockPositionDao()),
+        transactionRunner: TransactionRunner = passThroughTransactionRunner(),
+        deviceId: String = testDeviceId,
+    ): ListeningEventRepositoryImpl =
+        ListeningEventRepositoryImpl(
+            listeningEventDao = dao,
+            pendingOperationRepository = pendingOps,
+            listeningEventHandler = handler,
+            transactionRunner = transactionRunner,
+            deviceId = deviceId,
+        )
+
+    private fun makeEntity(bookId: String = "book-abc"): ListeningEventEntity =
+        ListeningEventEntity(
+            id = "evt-test-1",
+            bookId = bookId,
+            startPositionMs = 0L,
+            endPositionMs = 60_000L,
+            startedAt = 1_000_000L,
+            endedAt = 1_060_000L,
+            playbackSpeed = 1.0f,
+            deviceId = testDeviceId,
+            syncState = SyncState.NOT_SYNCED,
+            createdAt = 1_000_000L,
+            source = "playback",
+        )
+
+    // ==================== queueListeningEvent() — Happy Path ====================
+
+    @Test
+    fun `queueListeningEvent writes both DAO and pending-op inside transaction`() =
+        runTest {
+            // Given
+            val dao = createMockDao()
+            val pendingOps = createMockPendingOps()
+            val transactionRunner = passThroughTransactionRunner()
+            val repo = createRepo(dao = dao, pendingOps = pendingOps, transactionRunner = transactionRunner)
+
+            // When
+            val result =
+                repo.queueListeningEvent(
+                    bookId = testBookId,
+                    startPositionMs = 0L,
+                    endPositionMs = 60_000L,
+                    startedAt = 1_000_000L,
+                    endedAt = 1_060_000L,
+                    playbackSpeed = 1.5f,
+                )
+
+            // Then
+            assertIs<AppResult.Success<Unit>>(result)
+            verifySuspend(VerifyMode.exactly(1)) { dao.upsert(any()) }
+            verifySuspend(VerifyMode.exactly(1)) {
+                pendingOps.queue<ListeningEventPayload>(
+                    type = OperationType.LISTENING_EVENT,
+                    entityType = null,
+                    entityId = null,
+                    payload = any(),
+                    handler = any(),
+                )
+            }
+            verifySuspend(VerifyMode.exactly(1)) { transactionRunner.atomically(any<suspend () -> Any>()) }
+        }
+
+    @Test
+    fun `queueListeningEvent entity has correct bookId and deviceId`() =
+        runTest {
+            // Given
+            val dao = createMockDao()
+            val captured = mutableListOf<ListeningEventEntity>()
+            everySuspend { dao.upsert(any()) } calls { args ->
+                captured.add(args.arg(0) as ListeningEventEntity)
+                Unit
+            }
+            val repo = createRepo(dao = dao, deviceId = "my-device")
+
+            // When
+            repo.queueListeningEvent(
+                bookId = BookId("book-xyz"),
+                startPositionMs = 100L,
+                endPositionMs = 200L,
+                startedAt = 500L,
+                endedAt = 600L,
+                playbackSpeed = 2.0f,
+            )
+
+            // Then
+            val entity = captured.single()
+            assertEquals("book-xyz", entity.bookId)
+            assertEquals("my-device", entity.deviceId)
+            assertEquals(SyncState.NOT_SYNCED, entity.syncState)
+            assertEquals("playback", entity.source)
+            assertNotNull(entity.id)
+        }
+
+    @Test
+    fun `queueListeningEvent upsert happens before pending-op queue`() =
+        runTest {
+            // Given
+            val callOrder = mutableListOf<String>()
+            val dao = createMockDao()
+            val pendingOps = createMockPendingOps()
+            everySuspend { dao.upsert(any()) } calls { _ ->
+                callOrder.add("upsert")
+                Unit
+            }
+            everySuspend { pendingOps.queue<ListeningEventPayload>(any(), any(), any(), any(), any()) } calls { _ ->
+                callOrder.add("queue")
+                Unit
+            }
+            val repo = createRepo(dao = dao, pendingOps = pendingOps)
+
+            // When
+            repo.queueListeningEvent(testBookId, 0L, 60_000L, 1_000_000L, 1_060_000L, 1.0f)
+
+            // Then — entity upsert must precede pending-op queue so the ID is committed first
+            assertEquals(listOf("upsert", "queue"), callOrder)
+        }
+
+    // ==================== queueListeningEvent() — Rollback on DAO Failure ====================
+
+    @Test
+    fun `queueListeningEvent returns Failure when DAO upsert throws`() =
+        runTest {
+            // Given
+            val dao = createMockDao()
+            val pendingOps = createMockPendingOps()
+            everySuspend { dao.upsert(any()) } throws RuntimeException("DB write failed")
+            val repo = createRepo(dao = dao, pendingOps = pendingOps)
+
+            // When
+            val result = repo.queueListeningEvent(testBookId, 0L, 60_000L, 1_000_000L, 1_060_000L, 1.0f)
+
+            // Then — failure, and pending-op was never queued (transaction rolled back)
+            assertIs<AppResult.Failure>(result)
+            verifySuspend(VerifyMode.exactly(0)) {
+                pendingOps.queue<ListeningEventPayload>(any(), any(), any(), any(), any())
+            }
+        }
+
+    // ==================== queueListeningEvent() — Rollback on Pending-Op Failure ====================
+
+    @Test
+    fun `queueListeningEvent returns Failure when pending-op queue throws`() =
+        runTest {
+            // Given
+            val dao = createMockDao()
+            val pendingOps = createMockPendingOps()
+            everySuspend {
+                pendingOps.queue<ListeningEventPayload>(any(), any(), any(), any(), any())
+            } throws RuntimeException("Queue write failed")
+            val repo = createRepo(dao = dao, pendingOps = pendingOps)
+
+            // When
+            val result = repo.queueListeningEvent(testBookId, 0L, 60_000L, 1_000_000L, 1_060_000L, 1.0f)
+
+            // Then — upsert was attempted, failure propagated, atomically wraps both
+            assertIs<AppResult.Failure>(result)
+            verifySuspend(VerifyMode.exactly(1)) { dao.upsert(any()) }
+        }
+
+    // ==================== queueListeningEvent() — CancellationException Rethrow ====================
+
+    @Test
+    fun `queueListeningEvent rethrows CancellationException from DAO upsert`() =
+        runTest {
+            // Given
+            val dao = createMockDao()
+            everySuspend { dao.upsert(any()) } throws CancellationException("cancelled")
+            val repo = createRepo(dao = dao)
+
+            // When / Then — suspendRunCatching must rethrow CancellationException (EM-R1)
+            var caught: Throwable? = null
+            try {
+                repo.queueListeningEvent(testBookId, 0L, 60_000L, 1_000_000L, 1_060_000L, 1.0f)
+            } catch (e: CancellationException) {
+                caught = e
+            }
+            assertNotNull(caught)
+        }
+
+    @Test
+    fun `queueListeningEvent rethrows CancellationException from pending-op queue`() =
+        runTest {
+            // Given
+            val dao = createMockDao()
+            val pendingOps = createMockPendingOps()
+            everySuspend {
+                pendingOps.queue<ListeningEventPayload>(any(), any(), any(), any(), any())
+            } throws CancellationException("cancelled")
+            val repo = createRepo(dao = dao, pendingOps = pendingOps)
+
+            // When / Then
+            var caught: Throwable? = null
+            try {
+                repo.queueListeningEvent(testBookId, 0L, 60_000L, 1_000_000L, 1_060_000L, 1.0f)
+            } catch (e: CancellationException) {
+                caught = e
+            }
+            assertNotNull(caught)
+        }
+
+    // ==================== Read Method Delegation Tests ====================
+
+    @Test
+    fun `observeEventsForBook delegates to DAO`() =
+        runTest {
+            // Given
+            val dao = createMockDao()
+            val entities = listOf(makeEntity())
+            every { dao.observeEventsForBook("book-abc") } returns flowOf(entities)
+            val repo = createRepo(dao = dao)
+
+            // When
+            val result = repo.observeEventsForBook("book-abc").first()
+
+            // Then
+            assertEquals(entities, result)
+        }
+
+    @Test
+    fun `observeEventsInRange delegates to DAO`() =
+        runTest {
+            // Given
+            val dao = createMockDao()
+            val entities = listOf(makeEntity())
+            every { dao.observeEventsInRange(100L, 200L) } returns flowOf(entities)
+            val repo = createRepo(dao = dao)
+
+            // When
+            val result = repo.observeEventsInRange(100L, 200L).first()
+
+            // Then
+            assertEquals(entities, result)
+        }
+
+    @Test
+    fun `observeEventsSince delegates to DAO`() =
+        runTest {
+            // Given
+            val dao = createMockDao()
+            val entities = listOf(makeEntity())
+            every { dao.observeEventsSince(500L) } returns flowOf(entities)
+            val repo = createRepo(dao = dao)
+
+            // When
+            val result = repo.observeEventsSince(500L).first()
+
+            // Then
+            assertEquals(entities, result)
+        }
+
+    @Test
+    fun `getTotalDurationSince delegates to DAO`() =
+        runTest {
+            // Given
+            val dao = createMockDao()
+            everySuspend { dao.getTotalDurationSince(1_000L) } returns 3_600_000L
+            val repo = createRepo(dao = dao)
+
+            // When
+            val result = repo.getTotalDurationSince(1_000L)
+
+            // Then
+            assertEquals(3_600_000L, result)
+        }
+
+    @Test
+    fun `observeTotalDurationSince delegates to DAO`() =
+        runTest {
+            // Given
+            val dao = createMockDao()
+            every { dao.observeTotalDurationSince(0L) } returns flowOf(7_200_000L)
+            val repo = createRepo(dao = dao)
+
+            // When
+            val result = repo.observeTotalDurationSince(0L).first()
+
+            // Then
+            assertEquals(7_200_000L, result)
+        }
+
+    @Test
+    fun `observeDistinctBooksSince delegates to DAO`() =
+        runTest {
+            // Given
+            val dao = createMockDao()
+            every { dao.observeDistinctBooksSince(0L) } returns flowOf(5)
+            val repo = createRepo(dao = dao)
+
+            // When
+            val result = repo.observeDistinctBooksSince(0L).first()
+
+            // Then
+            assertEquals(5, result)
+        }
+
+    @Test
+    fun `observeDistinctDaysSince delegates to DAO`() =
+        runTest {
+            // Given
+            val dao = createMockDao()
+            val days = listOf(1_000_000L, 2_000_000L)
+            every { dao.observeDistinctDaysSince(0L) } returns flowOf(days)
+            val repo = createRepo(dao = dao)
+
+            // When
+            val result = repo.observeDistinctDaysSince(0L).first()
+
+            // Then
+            assertEquals(days, result)
+        }
+
+    @Test
+    fun `getDistinctDaysWithActivity delegates to DAO`() =
+        runTest {
+            // Given
+            val dao = createMockDao()
+            val days = listOf(1_000_000L, 2_000_000L)
+            everySuspend { dao.getDistinctDaysWithActivity(0L) } returns days
+            val repo = createRepo(dao = dao)
+
+            // When
+            val result = repo.getDistinctDaysWithActivity(0L)
+
+            // Then
+            assertEquals(days, result)
+        }
+
+    @Test
+    fun `getDurationByBook delegates to DAO`() =
+        runTest {
+            // Given
+            val dao = createMockDao()
+            val durations = listOf(BookDuration(bookId = "book-abc", totalMs = 900_000L))
+            everySuspend { dao.getDurationByBook(100L, 200L) } returns durations
+            val repo = createRepo(dao = dao)
+
+            // When
+            val result = repo.getDurationByBook(100L, 200L)
+
+            // Then
+            assertEquals(durations, result)
+        }
+}

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/PlaybackPositionRepositoryImplTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/PlaybackPositionRepositoryImplTest.kt
@@ -8,6 +8,7 @@ import com.calypsan.listenup.client.data.local.db.PlaybackPositionDao
 import com.calypsan.listenup.client.data.local.db.PlaybackPositionEntity
 import com.calypsan.listenup.client.data.local.db.TransactionRunner
 import com.calypsan.listenup.client.data.remote.SyncApiContract
+import com.calypsan.listenup.client.test.db.passThroughTransactionRunner
 import com.calypsan.listenup.client.data.sync.SSEEvent
 import com.calypsan.listenup.client.data.sync.ProgressPayload
 import com.calypsan.listenup.client.data.sync.push.MarkCompleteHandler
@@ -83,19 +84,6 @@ class PlaybackPositionRepositoryImplTest {
     private fun createMockSyncApi(): SyncApiContract = mock<SyncApiContract>(MockMode.autoUnit)
 
     /**
-     * Pass-through [TransactionRunner] mock — invokes the supplied block directly.
-     * Mirrors the seam-level pattern used in `ProgressPullerDeltaSyncTest`.
-     */
-    private fun passthroughTxRunner(): TransactionRunner =
-        mock<TransactionRunner> {
-            everySuspend { atomically(any<suspend () -> Any>()) } calls { args ->
-                @Suppress("UNCHECKED_CAST")
-                val block = args.arg(0) as suspend () -> Any
-                block()
-            }
-        }
-
-    /**
      * Constructs a repository with sensible default mocks. Tests that need a
      * specific mock (e.g., a non-passthrough TransactionRunner for contention
      * tests) supply that arg explicitly.
@@ -105,7 +93,7 @@ class PlaybackPositionRepositoryImplTest {
         syncApi: SyncApiContract = createMockSyncApi(),
         pendingOps: PendingOperationRepositoryContract = mock<PendingOperationRepositoryContract>(MockMode.autoUnit),
         markCompleteHandler: MarkCompleteHandler = MarkCompleteHandler(createMockSyncApi()),
-        transactionRunner: TransactionRunner = passthroughTxRunner(),
+        transactionRunner: TransactionRunner = passThroughTransactionRunner(),
     ): PlaybackPositionRepositoryImpl =
         PlaybackPositionRepositoryImpl(
             dao = dao,
@@ -782,7 +770,7 @@ class PlaybackPositionRepositoryImplTest {
     fun `savePlaybackState Position calls updatePositionOnly inside atomically`() =
         runTest {
             val dao = createMockDao()
-            val txRunner = passthroughTxRunner()
+            val txRunner = passThroughTransactionRunner()
             val bookId = BookId("book-1")
             everySuspend { dao.updatePositionOnly(any(), any(), any(), any()) } returns 1
             val repository = createRepo(dao = dao, transactionRunner = txRunner)
@@ -926,7 +914,7 @@ class PlaybackPositionRepositoryImplTest {
     fun `savePlaybackState PlaybackPaused calls updatePositionOnly`() =
         runTest {
             val dao = createMockDao()
-            val txRunner = passthroughTxRunner()
+            val txRunner = passThroughTransactionRunner()
             val bookId = BookId("book-1")
             everySuspend { dao.updatePositionOnly(any(), any(), any(), any()) } returns 1
             val repository = createRepo(dao = dao, transactionRunner = txRunner)
@@ -1193,7 +1181,7 @@ class PlaybackPositionRepositoryImplTest {
     fun `savePlaybackState returns Failure when dao throws`() =
         runTest {
             val dao = createMockDao()
-            val txRunner = passthroughTxRunner()
+            val txRunner = passThroughTransactionRunner()
             val bookId = BookId("book-1")
             everySuspend { dao.updatePositionOnly(any(), any(), any(), any()) } throws RuntimeException("dao boom")
             val repository = createRepo(dao = dao, transactionRunner = txRunner)

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/PlaybackPositionRepositoryImplTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/PlaybackPositionRepositoryImplTest.kt
@@ -1175,6 +1175,44 @@ class PlaybackPositionRepositoryImplTest {
             verifySuspend(VerifyMode.not) { dao.save(any()) }
         }
 
+    // ========== markComplete — public-facade delegation (Task 7) ==========
+
+    @Test
+    fun `markComplete delegates to savePlaybackState with MarkComplete variant`() =
+        runTest {
+            val dao = createMockDao()
+            val pendingOps = mock<PendingOperationRepositoryContract>(MockMode.autoUnit)
+            val bookId = "book-mc-facade"
+            val startedAt = 1700000000000L
+            val finishedAt = 1800000000000L
+            val existing =
+                createPlaybackPositionEntity(bookId = bookId, positionMs = 5000L).copy(startedAt = startedAt)
+            everySuspend { dao.get(BookId(bookId)) } returns existing
+            val captured = mutableListOf<PlaybackPositionEntity>()
+            everySuspend { dao.save(any()) } calls { args ->
+                captured.add(args.arg(0) as PlaybackPositionEntity)
+                Unit
+            }
+            val repository = createRepo(dao = dao, pendingOps = pendingOps)
+
+            val result = repository.markComplete(bookId, startedAt, finishedAt)
+
+            assertIs<AppResult.Success<Unit>>(result)
+            val saved = captured.single()
+            assertTrue(saved.isFinished)
+            assertEquals(finishedAt, saved.finishedAt)
+            assertEquals(startedAt, saved.startedAt)
+            verifySuspend(VerifyMode.exactly(1)) {
+                pendingOps.queue<MarkCompletePayload>(
+                    type = OperationType.MARK_COMPLETE,
+                    entityType = EntityType.BOOK,
+                    entityId = bookId,
+                    payload = any(),
+                    handler = any(),
+                )
+            }
+        }
+
     // ========== savePlaybackState — failure path (Task 2) ==========
 
     @Test

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/PlaybackPositionRepositoryImplTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/PlaybackPositionRepositoryImplTest.kt
@@ -1,20 +1,31 @@
 package com.calypsan.listenup.client.data.repository
 
+import com.calypsan.listenup.client.core.AppResult
 import com.calypsan.listenup.client.core.BookId
+import com.calypsan.listenup.client.data.local.db.EntityType
+import com.calypsan.listenup.client.data.local.db.OperationType
 import com.calypsan.listenup.client.data.local.db.PlaybackPositionDao
 import com.calypsan.listenup.client.data.local.db.PlaybackPositionEntity
+import com.calypsan.listenup.client.data.local.db.TransactionRunner
 import com.calypsan.listenup.client.data.remote.SyncApiContract
-import com.calypsan.listenup.client.domain.model.PlaybackPosition
+import com.calypsan.listenup.client.data.sync.SSEEvent
+import com.calypsan.listenup.client.data.sync.ProgressPayload
+import com.calypsan.listenup.client.data.sync.push.MarkCompleteHandler
+import com.calypsan.listenup.client.data.sync.push.MarkCompletePayload
+import com.calypsan.listenup.client.data.sync.push.PendingOperationRepositoryContract
+import com.calypsan.listenup.client.domain.repository.PlaybackUpdate
 import dev.mokkery.MockMode
+import dev.mokkery.answering.calls
 import dev.mokkery.answering.returns
+import dev.mokkery.answering.throws
 import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
-import com.calypsan.listenup.client.data.sync.push.MarkCompleteHandler
-import com.calypsan.listenup.client.data.sync.push.PendingOperationRepositoryContract
 import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
-import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.take
@@ -24,6 +35,8 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -69,6 +82,39 @@ class PlaybackPositionRepositoryImplTest {
 
     private fun createMockSyncApi(): SyncApiContract = mock<SyncApiContract>(MockMode.autoUnit)
 
+    /**
+     * Pass-through [TransactionRunner] mock — invokes the supplied block directly.
+     * Mirrors the seam-level pattern used in `ProgressPullerDeltaSyncTest`.
+     */
+    private fun passthroughTxRunner(): TransactionRunner =
+        mock<TransactionRunner> {
+            everySuspend { atomically(any<suspend () -> Any>()) } calls { args ->
+                @Suppress("UNCHECKED_CAST")
+                val block = args.arg(0) as suspend () -> Any
+                block()
+            }
+        }
+
+    /**
+     * Constructs a repository with sensible default mocks. Tests that need a
+     * specific mock (e.g., a non-passthrough TransactionRunner for contention
+     * tests) supply that arg explicitly.
+     */
+    private fun createRepo(
+        dao: PlaybackPositionDao = createMockDao(),
+        syncApi: SyncApiContract = createMockSyncApi(),
+        pendingOps: PendingOperationRepositoryContract = mock<PendingOperationRepositoryContract>(MockMode.autoUnit),
+        markCompleteHandler: MarkCompleteHandler = MarkCompleteHandler(createMockSyncApi()),
+        transactionRunner: TransactionRunner = passthroughTxRunner(),
+    ): PlaybackPositionRepositoryImpl =
+        PlaybackPositionRepositoryImpl(
+            dao = dao,
+            syncApi = syncApi,
+            pendingOps = pendingOps,
+            markCompleteHandler = markCompleteHandler,
+            transactionRunner = transactionRunner,
+        )
+
     // ========== get() Tests ==========
 
     @Test
@@ -78,7 +124,7 @@ class PlaybackPositionRepositoryImplTest {
             val dao = createMockDao()
             val entity = createPlaybackPositionEntity(bookId = "book-123", positionMs = 45000L)
             everySuspend { dao.get(BookId("book-123")) } returns entity
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
+            val repository = createRepo(dao = dao)
 
             // When
             val result = repository.get("book-123")
@@ -95,7 +141,7 @@ class PlaybackPositionRepositoryImplTest {
             // Given
             val dao = createMockDao()
             everySuspend { dao.get(any()) } returns null
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
+            val repository = createRepo(dao = dao)
 
             // When
             val result = repository.get("nonexistent-book")
@@ -110,7 +156,7 @@ class PlaybackPositionRepositoryImplTest {
             // Given
             val dao = createMockDao()
             everySuspend { dao.get(any()) } returns null
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
+            val repository = createRepo(dao = dao)
 
             // When
             repository.get("test-book-id")
@@ -128,7 +174,7 @@ class PlaybackPositionRepositoryImplTest {
             val dao = createMockDao()
             val entity = createPlaybackPositionEntity(bookId = "book-1", positionMs = 30000L)
             every { dao.observe(BookId("book-1")) } returns flowOf(entity)
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
+            val repository = createRepo(dao = dao)
 
             // When
             val result = repository.observe("book-1").first()
@@ -145,7 +191,7 @@ class PlaybackPositionRepositoryImplTest {
             // Given
             val dao = createMockDao()
             every { dao.observe(any()) } returns flowOf(null)
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
+            val repository = createRepo(dao = dao)
 
             // When
             val result = repository.observe("missing-book").first()
@@ -162,7 +208,7 @@ class PlaybackPositionRepositoryImplTest {
             val entity1 = createPlaybackPositionEntity(bookId = "book-1", positionMs = 1000L)
             val entity2 = createPlaybackPositionEntity(bookId = "book-1", positionMs = 2000L)
             every { dao.observe(BookId("book-1")) } returns flowOf(null, entity1, entity2)
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
+            val repository = createRepo(dao = dao)
 
             // When
             val emissions = repository.observe("book-1").take(3).toList()
@@ -188,7 +234,7 @@ class PlaybackPositionRepositoryImplTest {
                     createPlaybackPositionEntity(bookId = "book-3", positionMs = 3000L),
                 )
             every { dao.observeAll() } returns flowOf(entities)
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
+            val repository = createRepo(dao = dao)
 
             // When
             val result = repository.observeAll().first()
@@ -206,7 +252,7 @@ class PlaybackPositionRepositoryImplTest {
             // Given
             val dao = createMockDao()
             every { dao.observeAll() } returns flowOf(emptyList())
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
+            val repository = createRepo(dao = dao)
 
             // When
             val result = repository.observeAll().first()
@@ -228,7 +274,7 @@ class PlaybackPositionRepositoryImplTest {
                     createPlaybackPositionEntity(bookId = "book-2"),
                 )
             every { dao.observeAll() } returns flowOf(list0, list1, list2)
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
+            val repository = createRepo(dao = dao)
 
             // When
             val emissions = repository.observeAll().take(3).toList()
@@ -247,7 +293,7 @@ class PlaybackPositionRepositoryImplTest {
             val dao = createMockDao()
             val entity = createPlaybackPositionEntity(bookId = "unique-book-id-123")
             every { dao.observeAll() } returns flowOf(listOf(entity))
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
+            val repository = createRepo(dao = dao)
 
             // When
             val result = repository.observeAll().first()
@@ -270,7 +316,7 @@ class PlaybackPositionRepositoryImplTest {
                     createPlaybackPositionEntity(bookId = "book-2", positionMs = 2000L),
                 )
             everySuspend { dao.getRecentPositions(10) } returns entities
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
+            val repository = createRepo(dao = dao)
 
             // When
             val result = repository.getRecentPositions(10)
@@ -287,7 +333,7 @@ class PlaybackPositionRepositoryImplTest {
             // Given
             val dao = createMockDao()
             everySuspend { dao.getRecentPositions(5) } returns emptyList()
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
+            val repository = createRepo(dao = dao)
 
             // When
             repository.getRecentPositions(5)
@@ -302,7 +348,7 @@ class PlaybackPositionRepositoryImplTest {
             // Given
             val dao = createMockDao()
             everySuspend { dao.getRecentPositions(any()) } returns emptyList()
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
+            val repository = createRepo(dao = dao)
 
             // When
             val result = repository.getRecentPositions(10)
@@ -332,7 +378,7 @@ class PlaybackPositionRepositoryImplTest {
                     ),
                 )
             everySuspend { dao.getRecentPositions(10) } returns entities
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
+            val repository = createRepo(dao = dao)
 
             // When
             val result = repository.getRecentPositions(10)
@@ -352,7 +398,7 @@ class PlaybackPositionRepositoryImplTest {
             // Given
             val dao = createMockDao()
             everySuspend { dao.get(BookId("new-book")) } returns null
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
+            val repository = createRepo(dao = dao)
 
             // When
             repository.save(
@@ -382,7 +428,7 @@ class PlaybackPositionRepositoryImplTest {
                     syncedAt = 1704067200000L, // Previously synced
                 )
             everySuspend { dao.get(BookId("book-1")) } returns existingEntity
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
+            val repository = createRepo(dao = dao)
 
             // When
             repository.save(
@@ -404,7 +450,7 @@ class PlaybackPositionRepositoryImplTest {
             // Given
             val dao = createMockDao()
             everySuspend { dao.get(BookId("new-book")) } returns null
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
+            val repository = createRepo(dao = dao)
 
             // When
             repository.save(
@@ -425,7 +471,7 @@ class PlaybackPositionRepositoryImplTest {
             // Given
             val dao = createMockDao()
             everySuspend { dao.get(any()) } returns null
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
+            val repository = createRepo(dao = dao)
 
             // When
             repository.save(
@@ -446,7 +492,7 @@ class PlaybackPositionRepositoryImplTest {
         runTest {
             // Given
             val dao = createMockDao()
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
+            val repository = createRepo(dao = dao)
 
             // When
             repository.delete("book-to-delete")
@@ -460,7 +506,7 @@ class PlaybackPositionRepositoryImplTest {
         runTest {
             // Given
             val dao = createMockDao()
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
+            val repository = createRepo(dao = dao)
 
             // When/Then - should not throw
             repository.delete("nonexistent-book")
@@ -478,7 +524,7 @@ class PlaybackPositionRepositoryImplTest {
             val dao = createMockDao()
             val entity = createPlaybackPositionEntity(bookId = "unique-book-123")
             everySuspend { dao.get(BookId("unique-book-123")) } returns entity
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
+            val repository = createRepo(dao = dao)
 
             // When
             val result = repository.get("unique-book-123")
@@ -495,7 +541,7 @@ class PlaybackPositionRepositoryImplTest {
             val dao = createMockDao()
             val entity = createPlaybackPositionEntity(positionMs = 123456789L)
             everySuspend { dao.get(any()) } returns entity
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
+            val repository = createRepo(dao = dao)
 
             // When
             val result = repository.get("book-1")
@@ -512,7 +558,7 @@ class PlaybackPositionRepositoryImplTest {
             val dao = createMockDao()
             val entity = createPlaybackPositionEntity(playbackSpeed = 2.5f)
             everySuspend { dao.get(any()) } returns entity
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
+            val repository = createRepo(dao = dao)
 
             // When
             val result = repository.get("book-1")
@@ -529,7 +575,7 @@ class PlaybackPositionRepositoryImplTest {
             val dao = createMockDao()
             val entity = createPlaybackPositionEntity(hasCustomSpeed = true)
             everySuspend { dao.get(any()) } returns entity
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
+            val repository = createRepo(dao = dao)
 
             // When
             val result = repository.get("book-1")
@@ -546,7 +592,7 @@ class PlaybackPositionRepositoryImplTest {
             val dao = createMockDao()
             val entity = createPlaybackPositionEntity(hasCustomSpeed = false)
             everySuspend { dao.get(any()) } returns entity
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
+            val repository = createRepo(dao = dao)
 
             // When
             val result = repository.get("book-1")
@@ -563,7 +609,7 @@ class PlaybackPositionRepositoryImplTest {
             val dao = createMockDao()
             val entity = createPlaybackPositionEntity(updatedAt = 1704110400000L)
             everySuspend { dao.get(any()) } returns entity
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
+            val repository = createRepo(dao = dao)
 
             // When
             val result = repository.get("book-1")
@@ -580,7 +626,7 @@ class PlaybackPositionRepositoryImplTest {
             val dao = createMockDao()
             val entity = createPlaybackPositionEntity(syncedAt = 1704200000000L)
             everySuspend { dao.get(any()) } returns entity
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
+            val repository = createRepo(dao = dao)
 
             // When
             val result = repository.get("book-1")
@@ -597,7 +643,7 @@ class PlaybackPositionRepositoryImplTest {
             val dao = createMockDao()
             val entity = createPlaybackPositionEntity(syncedAt = null)
             everySuspend { dao.get(any()) } returns entity
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
+            val repository = createRepo(dao = dao)
 
             // When
             val result = repository.get("book-1")
@@ -614,7 +660,7 @@ class PlaybackPositionRepositoryImplTest {
             val dao = createMockDao()
             val entity = createPlaybackPositionEntity(lastPlayedAt = 1704300000000L)
             everySuspend { dao.get(any()) } returns entity
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
+            val repository = createRepo(dao = dao)
 
             // When
             val result = repository.get("book-1")
@@ -631,7 +677,7 @@ class PlaybackPositionRepositoryImplTest {
             val dao = createMockDao()
             val entity = createPlaybackPositionEntity(lastPlayedAt = null)
             everySuspend { dao.get(any()) } returns entity
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
+            val repository = createRepo(dao = dao)
 
             // When
             val result = repository.get("book-1")
@@ -657,7 +703,7 @@ class PlaybackPositionRepositoryImplTest {
                     lastPlayedAt = 1704200000000L,
                 )
             everySuspend { dao.get(BookId("complete-book-123")) } returns entity
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
+            val repository = createRepo(dao = dao)
 
             // When
             val result = repository.get("complete-book-123")
@@ -682,7 +728,7 @@ class PlaybackPositionRepositoryImplTest {
             val dao = createMockDao()
             val entity = createPlaybackPositionEntity(positionMs = 0L)
             everySuspend { dao.get(any()) } returns entity
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
+            val repository = createRepo(dao = dao)
 
             // When
             val result = repository.get("book-1")
@@ -699,7 +745,7 @@ class PlaybackPositionRepositoryImplTest {
             val dao = createMockDao()
             val entity = createPlaybackPositionEntity(playbackSpeed = 1.0f)
             everySuspend { dao.get(any()) } returns entity
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
+            val repository = createRepo(dao = dao)
 
             // When
             val result = repository.get("book-1")
@@ -720,7 +766,7 @@ class PlaybackPositionRepositoryImplTest {
                     createPlaybackPositionEntity(bookId = "book-1", positionMs = 2000L), // duplicate
                 )
             every { dao.observeAll() } returns flowOf(entities)
-            val repository = PlaybackPositionRepositoryImpl(dao, createMockSyncApi(), mock(), MarkCompleteHandler(createMockSyncApi()))
+            val repository = createRepo(dao = dao)
 
             // When
             val result = repository.observeAll().first()
@@ -728,5 +774,490 @@ class PlaybackPositionRepositoryImplTest {
             // Then - should have 1 entry, with the second position value
             assertEquals(1, result.size)
             assertEquals(2000L, result["book-1"]?.positionMs)
+        }
+
+    // ========== savePlaybackState — per-variant tests (Task 2) ==========
+
+    @Test
+    fun `savePlaybackState Position calls updatePositionOnly inside atomically`() =
+        runTest {
+            val dao = createMockDao()
+            val txRunner = passthroughTxRunner()
+            val bookId = BookId("book-1")
+            everySuspend { dao.updatePositionOnly(any(), any(), any(), any()) } returns 1
+            val repository = createRepo(dao = dao, transactionRunner = txRunner)
+
+            val result = repository.savePlaybackState(bookId, PlaybackUpdate.Position(5000L, 1.0f))
+
+            assertIs<AppResult.Success<Unit>>(result)
+            verifySuspend(VerifyMode.exactly(1)) { txRunner.atomically(any<suspend () -> Any>()) }
+            verifySuspend(VerifyMode.exactly(1)) {
+                dao.updatePositionOnly(bookId, 5000L, any(), any())
+            }
+            verifySuspend(VerifyMode.not) { dao.save(any()) }
+        }
+
+    @Test
+    fun `savePlaybackState Speed reads existing then saves merged copy`() =
+        runTest {
+            val dao = createMockDao()
+            val bookId = BookId("book-1")
+            val existing =
+                createPlaybackPositionEntity(bookId = "book-1", positionMs = 1000L, playbackSpeed = 1.0f)
+            everySuspend { dao.get(bookId) } returns existing
+            val captured = mutableListOf<PlaybackPositionEntity>()
+            everySuspend { dao.save(any()) } calls { args ->
+                captured.add(args.arg(0) as PlaybackPositionEntity)
+                Unit
+            }
+            val repository = createRepo(dao = dao)
+
+            val result = repository.savePlaybackState(bookId, PlaybackUpdate.Speed(2000L, 1.5f, custom = true))
+
+            assertIs<AppResult.Success<Unit>>(result)
+            assertEquals(1, captured.size)
+            val saved = captured.single()
+            assertEquals(bookId, saved.bookId)
+            assertEquals(2000L, saved.positionMs)
+            assertEquals(1.5f, saved.playbackSpeed)
+            assertTrue(saved.hasCustomSpeed)
+            assertNull(saved.syncedAt)
+        }
+
+    @Test
+    fun `savePlaybackState Speed creates blank entity when no existing row`() =
+        runTest {
+            val dao = createMockDao()
+            val bookId = BookId("new-book")
+            everySuspend { dao.get(bookId) } returns null
+            val captured = mutableListOf<PlaybackPositionEntity>()
+            everySuspend { dao.save(any()) } calls { args ->
+                captured.add(args.arg(0) as PlaybackPositionEntity)
+                Unit
+            }
+            val repository = createRepo(dao = dao)
+
+            val result = repository.savePlaybackState(bookId, PlaybackUpdate.Speed(500L, 2.0f, custom = true))
+
+            assertIs<AppResult.Success<Unit>>(result)
+            val saved = captured.single()
+            assertEquals(500L, saved.positionMs)
+            assertEquals(2.0f, saved.playbackSpeed)
+            assertTrue(saved.hasCustomSpeed)
+        }
+
+    @Test
+    fun `savePlaybackState SpeedReset clears hasCustomSpeed and applies defaultSpeed`() =
+        runTest {
+            val dao = createMockDao()
+            val bookId = BookId("book-1")
+            val existing =
+                createPlaybackPositionEntity(bookId = "book-1", positionMs = 1000L, playbackSpeed = 1.5f, hasCustomSpeed = true)
+            everySuspend { dao.get(bookId) } returns existing
+            val captured = mutableListOf<PlaybackPositionEntity>()
+            everySuspend { dao.save(any()) } calls { args ->
+                captured.add(args.arg(0) as PlaybackPositionEntity)
+                Unit
+            }
+            val repository = createRepo(dao = dao)
+
+            val result =
+                repository.savePlaybackState(bookId, PlaybackUpdate.SpeedReset(positionMs = 1000L, defaultSpeed = 1.0f))
+
+            assertIs<AppResult.Success<Unit>>(result)
+            val saved = captured.single()
+            assertEquals(1.0f, saved.playbackSpeed)
+            assertFalse(saved.hasCustomSpeed)
+            assertNull(saved.syncedAt)
+        }
+
+    @Test
+    fun `savePlaybackState PlaybackStarted preserves existing startedAt`() =
+        runTest {
+            val dao = createMockDao()
+            val bookId = BookId("book-1")
+            val originalStartedAt = 1700000000000L
+            val existing =
+                createPlaybackPositionEntity(bookId = "book-1", positionMs = 1000L)
+                    .copy(startedAt = originalStartedAt)
+            everySuspend { dao.get(bookId) } returns existing
+            val captured = mutableListOf<PlaybackPositionEntity>()
+            everySuspend { dao.save(any()) } calls { args ->
+                captured.add(args.arg(0) as PlaybackPositionEntity)
+                Unit
+            }
+            val repository = createRepo(dao = dao)
+
+            val result =
+                repository.savePlaybackState(bookId, PlaybackUpdate.PlaybackStarted(positionMs = 2500L, speed = 1.25f))
+
+            assertIs<AppResult.Success<Unit>>(result)
+            val saved = captured.single()
+            assertEquals(2500L, saved.positionMs)
+            assertEquals(1.25f, saved.playbackSpeed)
+            // startedAt is preserved when already set.
+            assertEquals(originalStartedAt, saved.startedAt)
+        }
+
+    @Test
+    fun `savePlaybackState PlaybackStarted sets startedAt when previously null`() =
+        runTest {
+            val dao = createMockDao()
+            val bookId = BookId("book-1")
+            val existing =
+                createPlaybackPositionEntity(bookId = "book-1", positionMs = 1000L).copy(startedAt = null)
+            everySuspend { dao.get(bookId) } returns existing
+            val captured = mutableListOf<PlaybackPositionEntity>()
+            everySuspend { dao.save(any()) } calls { args ->
+                captured.add(args.arg(0) as PlaybackPositionEntity)
+                Unit
+            }
+            val repository = createRepo(dao = dao)
+
+            val result =
+                repository.savePlaybackState(bookId, PlaybackUpdate.PlaybackStarted(positionMs = 2500L, speed = 1.0f))
+
+            assertIs<AppResult.Success<Unit>>(result)
+            val saved = captured.single()
+            assertNotNull(saved.startedAt)
+        }
+
+    @Test
+    fun `savePlaybackState PlaybackPaused calls updatePositionOnly`() =
+        runTest {
+            val dao = createMockDao()
+            val txRunner = passthroughTxRunner()
+            val bookId = BookId("book-1")
+            everySuspend { dao.updatePositionOnly(any(), any(), any(), any()) } returns 1
+            val repository = createRepo(dao = dao, transactionRunner = txRunner)
+
+            val result = repository.savePlaybackState(bookId, PlaybackUpdate.PlaybackPaused(7500L, 1.0f))
+
+            assertIs<AppResult.Success<Unit>>(result)
+            verifySuspend(VerifyMode.exactly(1)) { txRunner.atomically(any<suspend () -> Any>()) }
+            verifySuspend(VerifyMode.exactly(1)) {
+                dao.updatePositionOnly(bookId, 7500L, any(), any())
+            }
+        }
+
+    @Test
+    fun `savePlaybackState PeriodicUpdate calls updatePositionOnly`() =
+        runTest {
+            val dao = createMockDao()
+            val bookId = BookId("book-1")
+            everySuspend { dao.updatePositionOnly(any(), any(), any(), any()) } returns 1
+            val repository = createRepo(dao = dao)
+
+            val result = repository.savePlaybackState(bookId, PlaybackUpdate.PeriodicUpdate(123L, 1.0f))
+
+            assertIs<AppResult.Success<Unit>>(result)
+            verifySuspend(VerifyMode.exactly(1)) {
+                dao.updatePositionOnly(bookId, 123L, any(), any())
+            }
+        }
+
+    @Test
+    fun `savePlaybackState BookFinished sets isFinished and queues MARK_COMPLETE`() =
+        runTest {
+            val dao = createMockDao()
+            val pendingOps = mock<PendingOperationRepositoryContract>(MockMode.autoUnit)
+            val bookId = BookId("book-1")
+            val existing =
+                createPlaybackPositionEntity(bookId = "book-1", positionMs = 1000L).copy(startedAt = 1700000000000L)
+            everySuspend { dao.get(bookId) } returns existing
+            val captured = mutableListOf<PlaybackPositionEntity>()
+            everySuspend { dao.save(any()) } calls { args ->
+                captured.add(args.arg(0) as PlaybackPositionEntity)
+                Unit
+            }
+            val repository = createRepo(dao = dao, pendingOps = pendingOps)
+
+            val result = repository.savePlaybackState(bookId, PlaybackUpdate.BookFinished(finalPositionMs = 99000L))
+
+            assertIs<AppResult.Success<Unit>>(result)
+            val saved = captured.single()
+            assertTrue(saved.isFinished)
+            assertEquals(99000L, saved.positionMs)
+            assertNotNull(saved.finishedAt)
+            // Verifies pending-op queued with the right type/entity.
+            verifySuspend(VerifyMode.exactly(1)) {
+                pendingOps.queue<MarkCompletePayload>(
+                    type = OperationType.MARK_COMPLETE,
+                    entityType = EntityType.BOOK,
+                    entityId = "book-1",
+                    payload = any(),
+                    handler = any(),
+                )
+            }
+        }
+
+    @Test
+    fun `savePlaybackState CrossDeviceSync skips when local is newer`() =
+        runTest {
+            val dao = createMockDao()
+            val bookId = BookId("book-1")
+            // Local last-played at 2026-04-25T12:00:00Z = 1777809600000ms
+            val localLastPlayed = 1777809600000L
+            val existing =
+                createPlaybackPositionEntity(bookId = "book-1", positionMs = 5000L)
+                    .copy(lastPlayedAt = localLastPlayed)
+            everySuspend { dao.get(bookId) } returns existing
+
+            val payload =
+                ProgressPayload(
+                    bookId = "book-1",
+                    currentPositionMs = 1000L,
+                    progress = 0.05,
+                    totalListenTimeMs = 1000L,
+                    isFinished = false,
+                    // Older than local: 2025-01-01T00:00:00Z = 1735689600000ms
+                    lastPlayedAt = "2025-01-01T00:00:00Z",
+                )
+            val event = SSEEvent.ProgressUpdated(timestamp = "2025-01-01T00:00:00Z", data = payload)
+            val repository = createRepo(dao = dao)
+
+            val result = repository.savePlaybackState(bookId, PlaybackUpdate.CrossDeviceSync(event))
+
+            assertIs<AppResult.Success<Unit>>(result)
+            // No write — local is newer.
+            verifySuspend(VerifyMode.not) { dao.save(any()) }
+        }
+
+    @Test
+    fun `savePlaybackState CrossDeviceSync applies merge when remote is newer`() =
+        runTest {
+            val dao = createMockDao()
+            val bookId = BookId("book-1")
+            val localLastPlayed = 1700000000000L
+            val existing =
+                createPlaybackPositionEntity(bookId = "book-1", positionMs = 5000L, playbackSpeed = 1.5f, hasCustomSpeed = true)
+                    .copy(lastPlayedAt = localLastPlayed)
+            everySuspend { dao.get(bookId) } returns existing
+            val captured = mutableListOf<PlaybackPositionEntity>()
+            everySuspend { dao.save(any()) } calls { args ->
+                captured.add(args.arg(0) as PlaybackPositionEntity)
+                Unit
+            }
+
+            val payload =
+                ProgressPayload(
+                    bookId = "book-1",
+                    currentPositionMs = 9000L,
+                    progress = 0.5,
+                    totalListenTimeMs = 9000L,
+                    isFinished = false,
+                    // Newer: 2030-01-01T00:00:00Z
+                    lastPlayedAt = "2030-01-01T00:00:00Z",
+                )
+            val event = SSEEvent.ProgressUpdated(timestamp = "2030-01-01T00:00:00Z", data = payload)
+            val repository = createRepo(dao = dao)
+
+            val result = repository.savePlaybackState(bookId, PlaybackUpdate.CrossDeviceSync(event))
+
+            assertIs<AppResult.Success<Unit>>(result)
+            val saved = captured.single()
+            assertEquals(9000L, saved.positionMs)
+            // Local-only fields preserved by .copy()
+            assertEquals(1.5f, saved.playbackSpeed)
+            assertTrue(saved.hasCustomSpeed)
+        }
+
+    @Test
+    fun `savePlaybackState MarkComplete sets isFinished and queues MARK_COMPLETE`() =
+        runTest {
+            val dao = createMockDao()
+            val pendingOps = mock<PendingOperationRepositoryContract>(MockMode.autoUnit)
+            val bookId = BookId("book-1")
+            val existing =
+                createPlaybackPositionEntity(bookId = "book-1", positionMs = 1000L).copy(startedAt = 1700000000000L)
+            everySuspend { dao.get(bookId) } returns existing
+            val captured = mutableListOf<PlaybackPositionEntity>()
+            everySuspend { dao.save(any()) } calls { args ->
+                captured.add(args.arg(0) as PlaybackPositionEntity)
+                Unit
+            }
+            val repository = createRepo(dao = dao, pendingOps = pendingOps)
+
+            val result =
+                repository.savePlaybackState(
+                    bookId,
+                    PlaybackUpdate.MarkComplete(startedAt = null, finishedAt = 1800000000000L),
+                )
+
+            assertIs<AppResult.Success<Unit>>(result)
+            val saved = captured.single()
+            assertTrue(saved.isFinished)
+            assertEquals(1800000000000L, saved.finishedAt)
+            assertEquals(1700000000000L, saved.startedAt) // preserved from existing
+            verifySuspend(VerifyMode.exactly(1)) {
+                pendingOps.queue<MarkCompletePayload>(
+                    type = OperationType.MARK_COMPLETE,
+                    entityType = EntityType.BOOK,
+                    entityId = "book-1",
+                    payload = any(),
+                    handler = any(),
+                )
+            }
+        }
+
+    @Test
+    fun `savePlaybackState DiscardProgress resets fields when row exists`() =
+        runTest {
+            val dao = createMockDao()
+            val bookId = BookId("book-1")
+            val existing =
+                createPlaybackPositionEntity(bookId = "book-1", positionMs = 5000L).copy(
+                    isFinished = true,
+                    finishedAt = 1800000000000L,
+                )
+            everySuspend { dao.get(bookId) } returns existing
+            val captured = mutableListOf<PlaybackPositionEntity>()
+            everySuspend { dao.save(any()) } calls { args ->
+                captured.add(args.arg(0) as PlaybackPositionEntity)
+                Unit
+            }
+            val repository = createRepo(dao = dao)
+
+            val result = repository.savePlaybackState(bookId, PlaybackUpdate.DiscardProgress)
+
+            assertIs<AppResult.Success<Unit>>(result)
+            val saved = captured.single()
+            assertEquals(0L, saved.positionMs)
+            assertFalse(saved.isFinished)
+            assertNull(saved.finishedAt)
+            assertNull(saved.syncedAt)
+        }
+
+    @Test
+    fun `savePlaybackState DiscardProgress is no-op when no row`() =
+        runTest {
+            val dao = createMockDao()
+            val bookId = BookId("new-book")
+            everySuspend { dao.get(bookId) } returns null
+            val repository = createRepo(dao = dao)
+
+            val result = repository.savePlaybackState(bookId, PlaybackUpdate.DiscardProgress)
+
+            assertIs<AppResult.Success<Unit>>(result)
+            verifySuspend(VerifyMode.not) { dao.save(any()) }
+        }
+
+    @Test
+    fun `savePlaybackState Restart resets to position 0 and starts new session`() =
+        runTest {
+            val dao = createMockDao()
+            val bookId = BookId("book-1")
+            val existing =
+                createPlaybackPositionEntity(bookId = "book-1", positionMs = 5000L).copy(
+                    isFinished = true,
+                    finishedAt = 1800000000000L,
+                    startedAt = 1700000000000L,
+                )
+            everySuspend { dao.get(bookId) } returns existing
+            val captured = mutableListOf<PlaybackPositionEntity>()
+            everySuspend { dao.save(any()) } calls { args ->
+                captured.add(args.arg(0) as PlaybackPositionEntity)
+                Unit
+            }
+            val repository = createRepo(dao = dao)
+
+            val result = repository.savePlaybackState(bookId, PlaybackUpdate.Restart)
+
+            assertIs<AppResult.Success<Unit>>(result)
+            val saved = captured.single()
+            assertEquals(0L, saved.positionMs)
+            assertFalse(saved.isFinished)
+            assertNull(saved.finishedAt)
+            // startedAt is freshly stamped (matches existing restartBook facade semantics).
+            assertNotNull(saved.startedAt)
+            assertNotEquals(1700000000000L, saved.startedAt)
+        }
+
+    @Test
+    fun `savePlaybackState Restart is no-op when no row`() =
+        runTest {
+            val dao = createMockDao()
+            val bookId = BookId("new-book")
+            everySuspend { dao.get(bookId) } returns null
+            val repository = createRepo(dao = dao)
+
+            val result = repository.savePlaybackState(bookId, PlaybackUpdate.Restart)
+
+            assertIs<AppResult.Success<Unit>>(result)
+            verifySuspend(VerifyMode.not) { dao.save(any()) }
+        }
+
+    // ========== savePlaybackState — failure path (Task 2) ==========
+
+    @Test
+    fun `savePlaybackState returns Failure when dao throws`() =
+        runTest {
+            val dao = createMockDao()
+            val txRunner = passthroughTxRunner()
+            val bookId = BookId("book-1")
+            everySuspend { dao.updatePositionOnly(any(), any(), any(), any()) } throws RuntimeException("dao boom")
+            val repository = createRepo(dao = dao, transactionRunner = txRunner)
+
+            val result = repository.savePlaybackState(bookId, PlaybackUpdate.Position(5000L, 1.0f))
+
+            assertIs<AppResult.Failure>(result)
+            // Mutex+atomically still attempted before the throw.
+            verifySuspend(VerifyMode.exactly(1)) { txRunner.atomically(any<suspend () -> Any>()) }
+        }
+
+    // ========== savePlaybackState — Mutex contention (Task 2) ==========
+
+    @Test
+    fun `concurrent savePlaybackState for same book serializes via per-book mutex`() =
+        runTest {
+            val dao = createMockDao()
+            val bookId = BookId("book-1")
+            val activeWriters = mutableListOf<Long>()
+            val maxConcurrent = mutableListOf<Int>()
+            var inFlight = 0
+            // Each DAO call delays 50ms while "in-flight". We track the maximum
+            // concurrency observed; with a per-book Mutex, this must stay at 1.
+            everySuspend { dao.updatePositionOnly(any(), any(), any(), any()) } calls { args ->
+                inFlight++
+                maxConcurrent.add(inFlight)
+                delay(50)
+                activeWriters.add(args.arg(1) as Long)
+                inFlight--
+                1
+            }
+            val repository = createRepo(dao = dao)
+
+            val job1 = launch { repository.savePlaybackState(bookId, PlaybackUpdate.Position(100L, 1.0f)) }
+            val job2 = launch { repository.savePlaybackState(bookId, PlaybackUpdate.Position(200L, 1.0f)) }
+            job1.join()
+            job2.join()
+
+            assertEquals(2, activeWriters.size, "Both DAO calls executed")
+            assertEquals(1, maxConcurrent.max(), "Per-book Mutex must serialize same-book writes (max in-flight == 1)")
+        }
+
+    @Test
+    fun `concurrent savePlaybackState for different books proceeds in parallel`() =
+        runTest {
+            val dao = createMockDao()
+            val bookA = BookId("book-A")
+            val bookB = BookId("book-B")
+            val maxConcurrent = mutableListOf<Int>()
+            var inFlight = 0
+            everySuspend { dao.updatePositionOnly(any(), any(), any(), any()) } calls { _ ->
+                inFlight++
+                maxConcurrent.add(inFlight)
+                delay(50)
+                inFlight--
+                1
+            }
+            val repository = createRepo(dao = dao)
+
+            val jobA = async { repository.savePlaybackState(bookA, PlaybackUpdate.Position(100L, 1.0f)) }
+            val jobB = async { repository.savePlaybackState(bookB, PlaybackUpdate.Position(200L, 1.0f)) }
+            jobA.await()
+            jobB.await()
+
+            assertEquals(2, maxConcurrent.max(), "Different books must NOT serialize (max in-flight == 2)")
         }
 }

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/playback/ProgressTrackerTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/playback/ProgressTrackerTest.kt
@@ -4,17 +4,13 @@ import com.calypsan.listenup.client.core.AppResult
 import com.calypsan.listenup.client.core.BookId
 import com.calypsan.listenup.client.core.Failure
 import com.calypsan.listenup.client.core.Success
-import com.calypsan.listenup.client.data.local.db.ListeningEventDao
-import com.calypsan.listenup.client.data.local.db.OperationType
 import com.calypsan.listenup.client.data.local.db.PlaybackPositionDao
 import com.calypsan.listenup.client.data.local.db.PlaybackPositionEntity
 import com.calypsan.listenup.client.data.remote.SyncApiContract
 import com.calypsan.listenup.client.data.remote.model.PlaybackProgressResponse
-import com.calypsan.listenup.client.data.sync.push.ListeningEventPayload
-import com.calypsan.listenup.client.data.sync.push.OperationHandler
-import com.calypsan.listenup.client.data.sync.push.PendingOperationRepositoryContract
 import com.calypsan.listenup.client.data.sync.push.PushSyncOrchestratorContract
 import com.calypsan.listenup.client.domain.repository.DownloadRepository
+import com.calypsan.listenup.client.domain.repository.ListeningEventRepository
 import com.calypsan.listenup.client.domain.repository.PlaybackPositionRepository
 import dev.mokkery.answering.returns
 import dev.mokkery.answering.throws
@@ -51,10 +47,8 @@ class ProgressTrackerTest {
 
         val positionDao: PlaybackPositionDao = mock()
         val downloadRepository: DownloadRepository = mock()
-        val listeningEventDao: ListeningEventDao = mock()
+        val listeningEventRepository: ListeningEventRepository = mock()
         val syncApi: SyncApiContract = mock()
-        val pendingOperationRepository: PendingOperationRepositoryContract = mock()
-        val listeningEventHandler: OperationHandler<ListeningEventPayload> = mock()
         val pushSyncOrchestrator: PushSyncOrchestratorContract = mock()
         val positionRepository: PlaybackPositionRepository = mock()
 
@@ -62,13 +56,10 @@ class ProgressTrackerTest {
             ProgressTracker(
                 positionDao = positionDao,
                 downloadRepository = downloadRepository,
-                listeningEventDao = listeningEventDao,
+                listeningEventRepository = listeningEventRepository,
                 syncApi = syncApi,
-                pendingOperationRepository = pendingOperationRepository,
-                listeningEventHandler = listeningEventHandler,
                 pushSyncOrchestrator = pushSyncOrchestrator,
                 positionRepository = positionRepository,
-                deviceId = "test-device-123",
                 scope = testScope,
             )
     }
@@ -83,7 +74,7 @@ class ProgressTrackerTest {
         // to fall through to positionDao.save(). Override in individual tests if needed.
         everySuspend { fixture.positionDao.updatePositionOnly(any(), any(), any(), any()) } returns 0
         everySuspend { fixture.syncApi.getProgress(any()) } returns Success(null)
-        everySuspend { fixture.pendingOperationRepository.queue<Any>(any(), any(), any(), any(), any()) } returns Unit
+        everySuspend { fixture.listeningEventRepository.queueListeningEvent(any(), any(), any(), any(), any(), any()) } returns AppResult.Success(Unit)
         everySuspend { fixture.pushSyncOrchestrator.flush() } returns Unit
         everySuspend { fixture.downloadRepository.deleteForBook(any()) } returns Unit
 

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/playback/ProgressTrackerTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/playback/ProgressTrackerTest.kt
@@ -1,9 +1,9 @@
 package com.calypsan.listenup.client.playback
 
+import com.calypsan.listenup.client.core.AppResult
 import com.calypsan.listenup.client.core.BookId
 import com.calypsan.listenup.client.core.Failure
 import com.calypsan.listenup.client.core.Success
-import com.calypsan.listenup.client.data.local.db.DownloadDao
 import com.calypsan.listenup.client.data.local.db.ListeningEventDao
 import com.calypsan.listenup.client.data.local.db.OperationType
 import com.calypsan.listenup.client.data.local.db.PlaybackPositionDao
@@ -14,6 +14,7 @@ import com.calypsan.listenup.client.data.sync.push.ListeningEventPayload
 import com.calypsan.listenup.client.data.sync.push.OperationHandler
 import com.calypsan.listenup.client.data.sync.push.PendingOperationRepositoryContract
 import com.calypsan.listenup.client.data.sync.push.PushSyncOrchestratorContract
+import com.calypsan.listenup.client.domain.repository.DownloadRepository
 import com.calypsan.listenup.client.domain.repository.PlaybackPositionRepository
 import dev.mokkery.answering.returns
 import dev.mokkery.answering.throws
@@ -49,7 +50,7 @@ class ProgressTrackerTest {
         val testScope = TestScope(testDispatcher)
 
         val positionDao: PlaybackPositionDao = mock()
-        val downloadDao: DownloadDao = mock()
+        val downloadRepository: DownloadRepository = mock()
         val listeningEventDao: ListeningEventDao = mock()
         val syncApi: SyncApiContract = mock()
         val pendingOperationRepository: PendingOperationRepositoryContract = mock()
@@ -60,7 +61,7 @@ class ProgressTrackerTest {
         fun build(): ProgressTracker =
             ProgressTracker(
                 positionDao = positionDao,
-                downloadDao = downloadDao,
+                downloadRepository = downloadRepository,
                 listeningEventDao = listeningEventDao,
                 syncApi = syncApi,
                 pendingOperationRepository = pendingOperationRepository,
@@ -84,6 +85,7 @@ class ProgressTrackerTest {
         everySuspend { fixture.syncApi.getProgress(any()) } returns Success(null)
         everySuspend { fixture.pendingOperationRepository.queue<Any>(any(), any(), any(), any(), any()) } returns Unit
         everySuspend { fixture.pushSyncOrchestrator.flush() } returns Unit
+        everySuspend { fixture.downloadRepository.deleteForBook(any()) } returns Unit
 
         return fixture
     }
@@ -413,6 +415,25 @@ class ProgressTrackerTest {
 
             // Then - verify save was called (position captured)
             verifySuspend { fixture.positionDao.save(any()) }
+        }
+
+    // ========== onBookFinished Tests ==========
+
+    @Test
+    fun `onBookFinished routes download-delete through downloadRepository not downloadDao`() =
+        runTest {
+            // Verifies drift #10: DAO writes in /playback/ routed through repository.
+            // downloadRepository.deleteForBook is the correct domain-layer entry point.
+            val fixture = createFixture()
+            val bookId = BookId("book-finished")
+            everySuspend { fixture.positionRepository.markComplete(any(), any(), any()) } returns AppResult.Success(Unit)
+
+            val tracker = fixture.build()
+
+            tracker.onBookFinished(bookId = bookId, finalPositionMs = 100_000L)
+            fixture.testScope.testScheduler.advanceUntilIdle()
+
+            verifySuspend { fixture.downloadRepository.deleteForBook(bookId.value) }
         }
 
     // ========== clearProgress Tests ==========

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/storage/StorageViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/storage/StorageViewModelTest.kt
@@ -38,6 +38,8 @@ class StorageViewModelTest {
         val downloads = MutableStateFlow(initial)
 
         override fun observeDownloadedBooks(): Flow<List<DownloadedBookSummary>> = downloads
+
+        override suspend fun deleteForBook(bookId: String) = Unit
     }
 
     @BeforeTest

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/test/db/PassThroughTransactionRunner.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/test/db/PassThroughTransactionRunner.kt
@@ -1,0 +1,25 @@
+package com.calypsan.listenup.client.test.db
+
+import com.calypsan.listenup.client.data.local.db.TransactionRunner
+import dev.mokkery.answering.calls
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+
+/**
+ * Returns a Mokkery-mocked [TransactionRunner] whose [TransactionRunner.atomically]
+ * pass-through-invokes the lambda. Use in unit tests of repository methods that wrap
+ * DAO writes in `transactionRunner.atomically { ... }` — verifies that the block runs
+ * without requiring a real database.
+ *
+ * Pair with `verifySuspend(VerifyMode.exactly(1)) { runner.atomically(any<suspend () -> Any>()) }`
+ * in the test body to assert the transaction wrapper was used.
+ */
+fun passThroughTransactionRunner(): TransactionRunner =
+    mock<TransactionRunner> {
+        everySuspend { atomically(any<suspend () -> Any>()) } calls { args ->
+            @Suppress("UNCHECKED_CAST")
+            val block = args.arg(0) as suspend () -> Any
+            block()
+        }
+    }

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/test/fake/FakeBookRepository.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/test/fake/FakeBookRepository.kt
@@ -1,7 +1,9 @@
 package com.calypsan.listenup.client.test.fake
 
-import com.calypsan.listenup.client.core.BookId
 import com.calypsan.listenup.client.core.AppResult
+import com.calypsan.listenup.client.core.BookId
+import com.calypsan.listenup.client.data.local.db.AudioFileEntity
+import com.calypsan.listenup.client.data.local.db.BookEntity
 import com.calypsan.listenup.client.domain.model.BookDetail
 import com.calypsan.listenup.client.domain.model.BookListItem
 import com.calypsan.listenup.client.domain.model.Chapter
@@ -61,6 +63,11 @@ class FakeBookRepository(
     override fun observeBookDetail(id: String): Flow<BookDetail?> = flowOf(null)
 
     override suspend fun getBookDetail(id: String): BookDetail? = null
+
+    override suspend fun upsertWithAudioFiles(
+        book: BookEntity,
+        audioFiles: List<AudioFileEntity>,
+    ): AppResult<Unit> = AppResult.Success(Unit)
 
     /** Test helper: replace the book list, emitting to all observers. */
     fun setBooks(list: List<BookListItem>) {

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/test/fake/FakeListeningEventRepository.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/test/fake/FakeListeningEventRepository.kt
@@ -1,0 +1,130 @@
+package com.calypsan.listenup.client.test.fake
+
+import com.calypsan.listenup.client.core.AppResult
+import com.calypsan.listenup.client.core.BookId
+import com.calypsan.listenup.client.core.Success
+import com.calypsan.listenup.client.data.local.db.BookDuration
+import com.calypsan.listenup.client.data.local.db.ListeningEventEntity
+import com.calypsan.listenup.client.data.local.db.SyncState
+import com.calypsan.listenup.client.domain.repository.ListeningEventRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+
+/**
+ * In-memory fake of [ListeningEventRepository].
+ *
+ * Backed by a [MutableStateFlow] of [ListeningEventEntity] so reactive
+ * `observe*` methods emit on every [queueListeningEvent] call — matching the
+ * read-after-write semantics of the Room-backed implementation.
+ *
+ * [queueCount] is exposed for tests that care about how many events were queued
+ * without examining the emitted flows.
+ */
+class FakeListeningEventRepository(
+    initialEvents: List<ListeningEventEntity> = emptyList(),
+) : ListeningEventRepository {
+    private val events = MutableStateFlow(initialEvents)
+
+    /** Number of times [queueListeningEvent] was called successfully. */
+    var queueCount: Int = 0
+        private set
+
+    override suspend fun queueListeningEvent(
+        bookId: BookId,
+        startPositionMs: Long,
+        endPositionMs: Long,
+        startedAt: Long,
+        endedAt: Long,
+        playbackSpeed: Float,
+    ): AppResult<Unit> {
+        val entity =
+            ListeningEventEntity(
+                id = "fake-evt-${queueCount + 1}",
+                bookId = bookId.value,
+                startPositionMs = startPositionMs,
+                endPositionMs = endPositionMs,
+                startedAt = startedAt,
+                endedAt = endedAt,
+                playbackSpeed = playbackSpeed,
+                deviceId = "fake-device",
+                syncState = SyncState.NOT_SYNCED,
+                createdAt = 0L,
+                source = "playback",
+            )
+        events.value = events.value + entity
+        queueCount++
+        return Success(Unit)
+    }
+
+    override fun observeEventsForBook(bookId: String): Flow<List<ListeningEventEntity>> =
+        events.asStateFlow().map { list -> list.filter { it.bookId == bookId } }
+
+    override fun observeEventsInRange(
+        startMs: Long,
+        endMs: Long,
+    ): Flow<List<ListeningEventEntity>> =
+        events.asStateFlow().map { list -> list.filter { it.endedAt in startMs..<endMs } }
+
+    override fun observeEventsSince(startMs: Long): Flow<List<ListeningEventEntity>> =
+        events.asStateFlow().map { list -> list.filter { it.endedAt >= startMs } }
+
+    override suspend fun getTotalDurationSince(startMs: Long): Long =
+        events.value
+            .filter { it.endedAt >= startMs }
+            .sumOf { it.endPositionMs - it.startPositionMs }
+
+    override fun observeTotalDurationSince(startMs: Long): Flow<Long> =
+        events.asStateFlow().map { list ->
+            list.filter { it.endedAt >= startMs }.sumOf { it.endPositionMs - it.startPositionMs }
+        }
+
+    override fun observeDistinctBooksSince(startMs: Long): Flow<Int> =
+        events.asStateFlow().map { list ->
+            list
+                .filter { it.endedAt >= startMs }
+                .map { it.bookId }
+                .toSet()
+                .size
+        }
+
+    override fun observeDistinctDaysSince(startMs: Long): Flow<List<Long>> =
+        events.asStateFlow().map { list ->
+            list
+                .filter { it.endedAt >= startMs }
+                .map { (it.endedAt / 86_400_000L) }
+                .toSet()
+                .sortedDescending()
+        }
+
+    override suspend fun getDistinctDaysWithActivity(startMs: Long): List<Long> =
+        events.value
+            .filter { it.endedAt >= startMs }
+            .map { (it.endedAt / 86_400_000L) * 86_400_000L }
+            .toSet()
+            .sortedDescending()
+
+    override suspend fun getDurationByBook(
+        startMs: Long,
+        endMs: Long,
+    ): List<BookDuration> =
+        events.value
+            .filter { it.endedAt in startMs..<endMs }
+            .groupBy { it.bookId }
+            .map { (bookId, es) ->
+                BookDuration(
+                    bookId = bookId,
+                    totalMs =
+                        es.sumOf {
+                            it.endPositionMs -
+                                it.startPositionMs
+                        },
+                )
+            }.sortedByDescending { it.totalMs }
+
+    /** Test helper: replace all events and emit to all observers. */
+    fun setEvents(list: List<ListeningEventEntity>) {
+        events.value = list
+    }
+}

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/test/fake/FakePlaybackPositionRepository.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/test/fake/FakePlaybackPositionRepository.kt
@@ -1,13 +1,15 @@
 package com.calypsan.listenup.client.test.fake
 
 import com.calypsan.listenup.client.core.AppResult
+import com.calypsan.listenup.client.core.BookId
+import com.calypsan.listenup.client.core.Success
 import com.calypsan.listenup.client.domain.model.PlaybackPosition
 import com.calypsan.listenup.client.domain.repository.PlaybackPositionRepository
+import com.calypsan.listenup.client.domain.repository.PlaybackUpdate
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.map
-import com.calypsan.listenup.client.core.Success
 
 /**
  * In-memory fake of [PlaybackPositionRepository] backed by a [MutableStateFlow] of
@@ -114,4 +116,153 @@ class FakePlaybackPositionRepository(
         )
         return Success(Unit)
     }
+
+    /**
+     * Minimal in-memory variant dispatch. Mirrors the production repository's
+     * behavior closely enough to back seam-level tests but does not exercise
+     * Mutex/transaction semantics (the fake is single-threaded).
+     */
+    @Suppress("CyclomaticComplexMethod", "LongMethod")
+    override suspend fun savePlaybackState(
+        bookId: BookId,
+        update: PlaybackUpdate,
+    ): AppResult<Unit> {
+        val key = bookId.value
+        val now = nowMs()
+        val existing = state.value[key]
+        val merged: PlaybackPosition? =
+            when (update) {
+                is PlaybackUpdate.Position -> {
+                    (existing ?: blankPosition(key, now)).copy(
+                        positionMs = update.positionMs,
+                        updatedAtMs = now,
+                        lastPlayedAtMs = now,
+                        syncedAtMs = null,
+                    )
+                }
+
+                is PlaybackUpdate.Speed -> {
+                    (existing ?: blankPosition(key, now)).copy(
+                        positionMs = update.positionMs,
+                        playbackSpeed = update.speed,
+                        hasCustomSpeed = update.custom,
+                        updatedAtMs = now,
+                        lastPlayedAtMs = now,
+                        syncedAtMs = null,
+                    )
+                }
+
+                is PlaybackUpdate.SpeedReset -> {
+                    (existing ?: blankPosition(key, now)).copy(
+                        positionMs = update.positionMs,
+                        playbackSpeed = update.defaultSpeed,
+                        hasCustomSpeed = false,
+                        updatedAtMs = now,
+                        lastPlayedAtMs = now,
+                        syncedAtMs = null,
+                    )
+                }
+
+                is PlaybackUpdate.PlaybackStarted -> {
+                    (existing ?: blankPosition(key, now)).copy(
+                        positionMs = update.positionMs,
+                        playbackSpeed = update.speed,
+                        startedAtMs = existing?.startedAtMs ?: now,
+                        updatedAtMs = now,
+                        lastPlayedAtMs = now,
+                        syncedAtMs = null,
+                    )
+                }
+
+                is PlaybackUpdate.PlaybackPaused -> {
+                    (existing ?: blankPosition(key, now)).copy(
+                        positionMs = update.positionMs,
+                        updatedAtMs = now,
+                        lastPlayedAtMs = now,
+                        syncedAtMs = null,
+                    )
+                }
+
+                is PlaybackUpdate.PeriodicUpdate -> {
+                    (existing ?: blankPosition(key, now)).copy(
+                        positionMs = update.positionMs,
+                        updatedAtMs = now,
+                        lastPlayedAtMs = now,
+                        syncedAtMs = null,
+                    )
+                }
+
+                is PlaybackUpdate.BookFinished -> {
+                    (existing ?: blankPosition(key, now)).copy(
+                        positionMs = update.finalPositionMs,
+                        isFinished = true,
+                        finishedAtMs = existing?.finishedAtMs ?: now,
+                        startedAtMs = existing?.startedAtMs ?: now,
+                        updatedAtMs = now,
+                        lastPlayedAtMs = now,
+                        syncedAtMs = null,
+                    )
+                }
+
+                is PlaybackUpdate.CrossDeviceSync -> {
+                    // Fake doesn't reconcile SSE timestamps — defers to whatever
+                    // existing row is present.
+                    existing
+                }
+
+                is PlaybackUpdate.MarkComplete -> {
+                    (existing ?: blankPosition(key, now)).copy(
+                        isFinished = true,
+                        finishedAtMs = update.finishedAt ?: now,
+                        startedAtMs = update.startedAt ?: existing?.startedAtMs ?: now,
+                        updatedAtMs = now,
+                        syncedAtMs = null,
+                    )
+                }
+
+                PlaybackUpdate.DiscardProgress -> {
+                    existing?.copy(
+                        positionMs = 0L,
+                        isFinished = false,
+                        finishedAtMs = null,
+                        updatedAtMs = now,
+                        lastPlayedAtMs = now,
+                        syncedAtMs = null,
+                    )
+                }
+
+                PlaybackUpdate.Restart -> {
+                    existing?.copy(
+                        positionMs = 0L,
+                        isFinished = false,
+                        finishedAtMs = null,
+                        startedAtMs = now,
+                        updatedAtMs = now,
+                        lastPlayedAtMs = now,
+                        syncedAtMs = null,
+                    )
+                }
+            }
+        if (merged != null) {
+            state.value = state.value + (key to merged)
+        }
+        return Success(Unit)
+    }
+
+    private fun blankPosition(
+        bookId: String,
+        now: Long,
+    ): PlaybackPosition =
+        PlaybackPosition(
+            bookId = bookId,
+            positionMs = 0L,
+            playbackSpeed = 1.0f,
+            hasCustomSpeed = false,
+            updatedAtMs = now,
+            syncedAtMs = null,
+            lastPlayedAtMs = now,
+            isFinished = false,
+            finishedAtMs = null,
+            startedAtMs = null,
+        )
 }

--- a/shared/src/commonTest/kotlin/com/calypsan/listenup/client/voice/FakeRepositories.kt
+++ b/shared/src/commonTest/kotlin/com/calypsan/listenup/client/voice/FakeRepositories.kt
@@ -1,10 +1,12 @@
 package com.calypsan.listenup.client.voice
 
-import com.calypsan.listenup.client.core.BookId
 import com.calypsan.listenup.client.core.AppResult
+import com.calypsan.listenup.client.core.BookId
 import com.calypsan.listenup.client.core.SeriesId
 import com.calypsan.listenup.client.core.Success
 import com.calypsan.listenup.client.core.Timestamp
+import com.calypsan.listenup.client.data.local.db.AudioFileEntity
+import com.calypsan.listenup.client.data.local.db.BookEntity
 import com.calypsan.listenup.client.domain.model.BookContributor
 import com.calypsan.listenup.client.domain.model.BookDetail
 import com.calypsan.listenup.client.domain.model.BookListItem
@@ -141,6 +143,11 @@ class FakeBookRepository : BookRepository {
     override fun observeBookDetail(id: String): Flow<BookDetail?> = flowOf(null)
 
     override suspend fun getBookDetail(id: String): BookDetail? = null
+
+    override suspend fun upsertWithAudioFiles(
+        book: BookEntity,
+        audioFiles: List<AudioFileEntity>,
+    ): AppResult<Unit> = AppResult.Success(Unit)
 }
 
 // ========== Fake Series Repository ==========

--- a/shared/src/iosMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.ios.kt
+++ b/shared/src/iosMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.ios.kt
@@ -101,7 +101,6 @@ val iosPlaybackModule: Module =
         // Playback manager
         single {
             PlaybackManager(
-                transactionRunner = get(),
                 serverConfig = get(),
                 playbackPreferences = get(),
                 bookDao = get(),
@@ -116,6 +115,7 @@ val iosPlaybackModule: Module =
                 syncApi = get(),
                 deviceContext = get(),
                 scope = get(qualifier = named("playbackScope")),
+                bookRepository = get(),
             )
         }
 

--- a/shared/src/iosMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.ios.kt
+++ b/shared/src/iosMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.ios.kt
@@ -6,7 +6,6 @@ import com.calypsan.listenup.client.core.IODispatcher
 import com.calypsan.listenup.client.download.DownloadFileManager
 import com.calypsan.listenup.client.download.DownloadService
 import com.calypsan.listenup.client.download.AppleDownloadService
-import com.calypsan.listenup.client.data.sync.push.ListeningEventHandler
 import com.calypsan.listenup.client.playback.AudioTokenProvider
 import com.calypsan.listenup.client.playback.AppleAudioTokenProvider
 import com.calypsan.listenup.client.playback.AudioPlayer
@@ -80,13 +79,10 @@ val iosPlaybackModule: Module =
             ProgressTracker(
                 positionDao = get(),
                 downloadRepository = get(),
-                listeningEventDao = get(),
+                listeningEventRepository = get(),
                 syncApi = get(),
-                pendingOperationRepository = get(),
-                listeningEventHandler = get<ListeningEventHandler>(),
                 pushSyncOrchestrator = get(),
                 positionRepository = get(),
-                deviceId = get(qualifier = named("deviceId")),
                 scope = get(qualifier = named("playbackScope")),
             )
         }

--- a/shared/src/iosMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.ios.kt
+++ b/shared/src/iosMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.ios.kt
@@ -79,7 +79,7 @@ val iosPlaybackModule: Module =
         single {
             ProgressTracker(
                 positionDao = get(),
-                downloadDao = get(),
+                downloadRepository = get(),
                 listeningEventDao = get(),
                 syncApi = get(),
                 pendingOperationRepository = get(),

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/BookRepositoryImplTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/BookRepositoryImplTest.kt
@@ -6,10 +6,10 @@ import com.calypsan.listenup.client.core.BookId
 import com.calypsan.listenup.client.core.Timestamp
 import com.calypsan.listenup.client.data.local.db.AudioFileDao
 import com.calypsan.listenup.client.data.local.db.AudioFileEntity
+import com.calypsan.listenup.client.data.local.db.BookDao
 import com.calypsan.listenup.client.data.local.db.BookEntity
 import com.calypsan.listenup.client.data.local.db.BookGenreCrossRef
 import com.calypsan.listenup.client.data.local.db.BookTagCrossRef
-import com.calypsan.listenup.client.data.local.db.BookDao
 import com.calypsan.listenup.client.data.local.db.GenreEntity
 import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
 import com.calypsan.listenup.client.data.local.db.SyncState
@@ -20,11 +20,10 @@ import com.calypsan.listenup.client.data.remote.TagApiContract
 import com.calypsan.listenup.client.data.sync.SyncManagerContract
 import com.calypsan.listenup.client.domain.repository.ImageStorage
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
+import com.calypsan.listenup.client.test.db.passThroughTransactionRunner
 import dev.mokkery.MockMode
-import dev.mokkery.answering.calls
 import dev.mokkery.answering.returns
 import dev.mokkery.every
-import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verify.VerifyMode
@@ -69,14 +68,7 @@ class BookRepositoryImplTest {
     // Real audioFileDao + a pass-through TransactionRunner for the real-DB tests.
     // The upsertWithAudioFiles atomicity tests use mocks and live in a separate class below.
     private val audioFileDao = db.audioFileDao()
-    private val transactionRunner: TransactionRunner =
-        mock<TransactionRunner> {
-            everySuspend { atomically(any<suspend () -> Any>()) } calls { args ->
-                @Suppress("UNCHECKED_CAST")
-                val block = args.arg(0) as suspend () -> Any
-                block()
-            }
-        }
+    private val transactionRunner: TransactionRunner = passThroughTransactionRunner()
 
     private val repository =
         BookRepositoryImpl(
@@ -312,14 +304,7 @@ class BookRepositoryImplTest {
 class BookRepositoryImplUpsertWithAudioFilesTest {
     private val bookDao: BookDao = mock(MockMode.autoUnit)
     private val audioFileDao: AudioFileDao = mock(MockMode.autoUnit)
-    private val transactionRunner: TransactionRunner =
-        mock<TransactionRunner> {
-            everySuspend { atomically(any<suspend () -> Any>()) } calls { args ->
-                @Suppress("UNCHECKED_CAST")
-                val block = args.arg(0) as suspend () -> Any
-                block()
-            }
-        }
+    private val transactionRunner: TransactionRunner = passThroughTransactionRunner()
 
     private val imageStorage: ImageStorage =
         mock {

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/BookRepositoryImplTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/BookRepositoryImplTest.kt
@@ -1,24 +1,34 @@
 package com.calypsan.listenup.client.data.repository
 
 import app.cash.turbine.turbineScope
+import com.calypsan.listenup.client.core.AppResult
 import com.calypsan.listenup.client.core.BookId
 import com.calypsan.listenup.client.core.Timestamp
+import com.calypsan.listenup.client.data.local.db.AudioFileDao
+import com.calypsan.listenup.client.data.local.db.AudioFileEntity
 import com.calypsan.listenup.client.data.local.db.BookEntity
 import com.calypsan.listenup.client.data.local.db.BookGenreCrossRef
 import com.calypsan.listenup.client.data.local.db.BookTagCrossRef
+import com.calypsan.listenup.client.data.local.db.BookDao
 import com.calypsan.listenup.client.data.local.db.GenreEntity
 import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
 import com.calypsan.listenup.client.data.local.db.SyncState
 import com.calypsan.listenup.client.data.local.db.TagEntity
+import com.calypsan.listenup.client.data.local.db.TransactionRunner
 import com.calypsan.listenup.client.data.remote.GenreApiContract
 import com.calypsan.listenup.client.data.remote.TagApiContract
 import com.calypsan.listenup.client.data.sync.SyncManagerContract
 import com.calypsan.listenup.client.domain.repository.ImageStorage
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
+import dev.mokkery.MockMode
+import dev.mokkery.answering.calls
 import dev.mokkery.answering.returns
 import dev.mokkery.every
+import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
 import kotlinx.coroutines.test.runTest
 import kotlin.test.AfterTest
 import kotlin.test.Test
@@ -56,10 +66,24 @@ class BookRepositoryImplTest {
     private val genreRepository = GenreRepositoryImpl(genreDao, genreApi)
     private val tagRepository = TagRepositoryImpl(tagDao, tagApi)
 
+    // Real audioFileDao + a pass-through TransactionRunner for the real-DB tests.
+    // The upsertWithAudioFiles atomicity tests use mocks and live in a separate class below.
+    private val audioFileDao = db.audioFileDao()
+    private val transactionRunner: TransactionRunner =
+        mock<TransactionRunner> {
+            everySuspend { atomically(any<suspend () -> Any>()) } calls { args ->
+                @Suppress("UNCHECKED_CAST")
+                val block = args.arg(0) as suspend () -> Any
+                block()
+            }
+        }
+
     private val repository =
         BookRepositoryImpl(
             bookDao = bookDao,
             chapterDao = chapterDao,
+            audioFileDao = audioFileDao,
+            transactionRunner = transactionRunner,
             syncManager = syncManager,
             imageStorage = imageStorage,
             genreRepository = genreRepository,
@@ -276,5 +300,117 @@ class BookRepositoryImplTest {
             assertEquals("Warbreaker", result.title)
             assertEquals(listOf("Fantasy"), result.genres.map { it.name })
             assertEquals(listOf("magic-system"), result.tags.map { it.slug })
+        }
+}
+
+/**
+ * Mock-based tests for [BookRepositoryImpl.upsertWithAudioFiles].
+ *
+ * Uses mocked DAOs and [TransactionRunner] so each interaction can be
+ * verified independently from Room and from the real-DB tests above.
+ */
+class BookRepositoryImplUpsertWithAudioFilesTest {
+    private val bookDao: BookDao = mock(MockMode.autoUnit)
+    private val audioFileDao: AudioFileDao = mock(MockMode.autoUnit)
+    private val transactionRunner: TransactionRunner =
+        mock<TransactionRunner> {
+            everySuspend { atomically(any<suspend () -> Any>()) } calls { args ->
+                @Suppress("UNCHECKED_CAST")
+                val block = args.arg(0) as suspend () -> Any
+                block()
+            }
+        }
+
+    private val imageStorage: ImageStorage =
+        mock {
+            every { exists(any()) } returns false
+            every { getCoverPath(any()) } returns ""
+        }
+
+    private val repo =
+        BookRepositoryImpl(
+            bookDao = bookDao,
+            chapterDao = mock(MockMode.autoUnit),
+            audioFileDao = audioFileDao,
+            transactionRunner = transactionRunner,
+            syncManager = mock(MockMode.autoUnit),
+            imageStorage = imageStorage,
+            genreRepository = mock(MockMode.autoUnit),
+            tagRepository = mock(MockMode.autoUnit),
+        )
+
+    private fun makeBookEntity(
+        id: String,
+        title: String = "Book $id",
+    ): BookEntity {
+        val ts = Timestamp(1_700_000_000_000L)
+        return BookEntity(
+            id = BookId(id),
+            title = title,
+            sortTitle = title,
+            subtitle = null,
+            coverUrl = null,
+            coverBlurHash = null,
+            dominantColor = null,
+            darkMutedColor = null,
+            vibrantColor = null,
+            totalDuration = 0L,
+            description = null,
+            publishYear = null,
+            publisher = null,
+            language = null,
+            isbn = null,
+            asin = null,
+            abridged = false,
+            syncState = SyncState.SYNCED,
+            lastModified = ts,
+            serverVersion = ts,
+            createdAt = ts,
+            updatedAt = ts,
+        )
+    }
+
+    private fun makeAudioFileEntity(
+        id: String,
+        bookId: String,
+    ): AudioFileEntity =
+        AudioFileEntity(
+            bookId = BookId(bookId),
+            index = 0,
+            id = id,
+            filename = "chapter.m4b",
+            format = "m4b",
+            codec = "aac",
+            duration = 1_800_000L,
+            size = 45_000_000L,
+        )
+
+    @Test
+    fun `upsertWithAudioFiles writes book delete-and-upsert audio files inside one transaction`() =
+        runTest {
+            val book = makeBookEntity("book-1", "Title")
+            val audioFiles = listOf(makeAudioFileEntity("file-1", "book-1"))
+
+            val result = repo.upsertWithAudioFiles(book, audioFiles)
+
+            assertEquals(AppResult.Success(Unit), result)
+            verifySuspend(VerifyMode.exactly(1)) { transactionRunner.atomically(any<suspend () -> Any>()) }
+            verifySuspend(VerifyMode.exactly(1)) { bookDao.upsert(book) }
+            verifySuspend(VerifyMode.exactly(1)) { audioFileDao.deleteForBook("book-1") }
+            verifySuspend(VerifyMode.exactly(1)) { audioFileDao.upsertAll(audioFiles) }
+        }
+
+    @Test
+    fun `upsertWithAudioFiles with empty audio file list skips upsertAll`() =
+        runTest {
+            val book = makeBookEntity("book-2", "Empty Files")
+
+            val result = repo.upsertWithAudioFiles(book, emptyList())
+
+            assertEquals(AppResult.Success(Unit), result)
+            verifySuspend(VerifyMode.exactly(1)) { transactionRunner.atomically(any<suspend () -> Any>()) }
+            verifySuspend(VerifyMode.exactly(1)) { bookDao.upsert(book) }
+            verifySuspend(VerifyMode.exactly(1)) { audioFileDao.deleteForBook("book-2") }
+            verifySuspend(VerifyMode.exactly(0)) { audioFileDao.upsertAll(any()) }
         }
 }

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/DownloadRepositoryImplTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/DownloadRepositoryImplTest.kt
@@ -4,6 +4,8 @@ import app.cash.turbine.test
 import com.calypsan.listenup.client.core.AppResult
 import com.calypsan.listenup.client.core.BookId
 import com.calypsan.listenup.client.core.Timestamp
+import com.calypsan.listenup.client.data.local.db.AudioFileEntity
+import com.calypsan.listenup.client.data.local.db.BookEntity
 import com.calypsan.listenup.client.data.local.db.DownloadEntity
 import com.calypsan.listenup.client.data.local.db.DownloadState
 import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
@@ -205,4 +207,9 @@ private class FakeBookRepository : BookRepository {
     override fun observeBookDetail(id: String): Flow<BookDetail?> = flowOf(null)
 
     override suspend fun getBookDetail(id: String): BookDetail? = null
+
+    override suspend fun upsertWithAudioFiles(
+        book: BookEntity,
+        audioFiles: List<AudioFileEntity>,
+    ): AppResult<Unit> = AppResult.Success(Unit)
 }

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/DownloadRepositoryImplTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/DownloadRepositoryImplTest.kt
@@ -132,6 +132,11 @@ class DownloadRepositoryImplTest {
     @Test
     fun `deleteForBook removes all download rows for that book`() =
         runTest {
+            bookRepository.books =
+                listOf(
+                    fakeBook(id = "b1", title = "Deleted", authors = listOf("Author A")),
+                    fakeBook(id = "b2", title = "Remaining", authors = listOf("Author B")),
+                )
             downloadDao.insertAll(
                 listOf(
                     makeDownload(id = "f1", bookId = "b1", state = DownloadState.COMPLETED, bytes = 100_000L),
@@ -143,8 +148,6 @@ class DownloadRepositoryImplTest {
             sut.deleteForBook("b1")
 
             // b1 rows are gone; b2 row is untouched
-            bookRepository.books =
-                listOf(fakeBook(id = "b2", title = "Remaining", authors = listOf("Author B")))
             sut.observeDownloadedBooks().test {
                 val items = awaitItem()
                 assertEquals(1, items.size)

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/DownloadRepositoryImplTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/DownloadRepositoryImplTest.kt
@@ -130,6 +130,30 @@ class DownloadRepositoryImplTest {
         }
 
     @Test
+    fun `deleteForBook removes all download rows for that book`() =
+        runTest {
+            downloadDao.insertAll(
+                listOf(
+                    makeDownload(id = "f1", bookId = "b1", state = DownloadState.COMPLETED, bytes = 100_000L),
+                    makeDownload(id = "f2", bookId = "b1", state = DownloadState.QUEUED, bytes = 200_000L),
+                    makeDownload(id = "f3", bookId = "b2", state = DownloadState.COMPLETED, bytes = 300_000L),
+                ),
+            )
+
+            sut.deleteForBook("b1")
+
+            // b1 rows are gone; b2 row is untouched
+            bookRepository.books =
+                listOf(fakeBook(id = "b2", title = "Remaining", authors = listOf("Author B")))
+            sut.observeDownloadedBooks().test {
+                val items = awaitItem()
+                assertEquals(1, items.size)
+                assertEquals("b2", items.first().bookId)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
     fun `downloads whose book is missing from repository are silently dropped`() =
         runTest {
             bookRepository.books = emptyList()

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerFallbackFetchAtomicityTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerFallbackFetchAtomicityTest.kt
@@ -6,7 +6,6 @@ import com.calypsan.listenup.client.core.Success
 import com.calypsan.listenup.client.core.failureOf
 import com.calypsan.listenup.client.data.local.db.AudioFileEntity
 import com.calypsan.listenup.client.data.local.db.BookEntity
-import com.calypsan.listenup.client.data.local.db.DownloadDao
 import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
 import com.calypsan.listenup.client.data.local.db.ListeningEventDao
 import com.calypsan.listenup.client.data.local.db.PlaybackPositionDao
@@ -20,6 +19,7 @@ import com.calypsan.listenup.client.data.sync.push.PushSyncOrchestratorContract
 import com.calypsan.listenup.client.device.DeviceContext
 import com.calypsan.listenup.client.device.DeviceType
 import com.calypsan.listenup.client.domain.repository.BookRepository
+import com.calypsan.listenup.client.domain.repository.DownloadRepository
 import com.calypsan.listenup.client.domain.repository.PlaybackPositionRepository
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import dev.mokkery.answering.returns
@@ -88,7 +88,7 @@ class PlaybackManagerFallbackFetchAtomicityTest {
             val progressTracker =
                 ProgressTracker(
                     positionDao = mock<PlaybackPositionDao>(),
-                    downloadDao = mock<DownloadDao>(),
+                    downloadRepository = mock<DownloadRepository>(),
                     listeningEventDao = mock<ListeningEventDao>(),
                     syncApi = mock<SyncApiContract>(),
                     pendingOperationRepository = mock<PendingOperationRepositoryContract>(),
@@ -156,7 +156,7 @@ class PlaybackManagerFallbackFetchAtomicityTest {
             val progressTracker =
                 ProgressTracker(
                     positionDao = mock<PlaybackPositionDao>(),
-                    downloadDao = mock<DownloadDao>(),
+                    downloadRepository = mock<DownloadRepository>(),
                     listeningEventDao = mock<ListeningEventDao>(),
                     syncApi = mock<SyncApiContract>(),
                     pendingOperationRepository = mock<PendingOperationRepositoryContract>(),

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerFallbackFetchAtomicityTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerFallbackFetchAtomicityTest.kt
@@ -3,6 +3,7 @@ package com.calypsan.listenup.client.playback
 import com.calypsan.listenup.client.core.AppResult
 import com.calypsan.listenup.client.core.BookId
 import com.calypsan.listenup.client.core.Success
+import com.calypsan.listenup.client.core.failureOf
 import com.calypsan.listenup.client.data.local.db.AudioFileEntity
 import com.calypsan.listenup.client.data.local.db.BookEntity
 import com.calypsan.listenup.client.data.local.db.DownloadDao
@@ -32,6 +33,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.test.runTest
 import kotlin.test.AfterTest
 import kotlin.test.Test
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 /**
@@ -119,6 +121,74 @@ class PlaybackManagerFallbackFetchAtomicityTest {
             val result = playbackManager.fetchBookFromServer(BookId("book-rollback"))
 
             assertTrue(result, "fetchBookFromServer should return true on success")
+            verifySuspend(VerifyMode.exactly(1)) {
+                bookRepository.upsertWithAudioFiles(any<BookEntity>(), any<List<AudioFileEntity>>())
+            }
+        }
+
+    @Test
+    fun `fetchBookFromServer returns false when upsertWithAudioFiles returns Failure`() =
+        runTest {
+            val syncApi: SyncApiContract = mock()
+            val bookRepository: BookRepository = mock()
+
+            everySuspend { bookRepository.upsertWithAudioFiles(any(), any()) } returns
+                failureOf("persistence error")
+
+            everySuspend { syncApi.getBook(any()) } returns
+                Success(
+                    bookResponseWithAudioFiles(
+                        id = "book-fail",
+                        audioFiles =
+                            listOf(
+                                AudioFileResponse(
+                                    id = "af-1",
+                                    filename = "chapter01.m4b",
+                                    format = "m4b",
+                                    codec = "aac",
+                                    duration = 1_800_000L,
+                                    size = 45_000_000L,
+                                ),
+                            ),
+                    ),
+                )
+
+            val progressTracker =
+                ProgressTracker(
+                    positionDao = mock<PlaybackPositionDao>(),
+                    downloadDao = mock<DownloadDao>(),
+                    listeningEventDao = mock<ListeningEventDao>(),
+                    syncApi = mock<SyncApiContract>(),
+                    pendingOperationRepository = mock<PendingOperationRepositoryContract>(),
+                    listeningEventHandler = mock<OperationHandler<ListeningEventPayload>>(),
+                    pushSyncOrchestrator = mock<PushSyncOrchestratorContract>(),
+                    positionRepository = mock<PlaybackPositionRepository>(),
+                    deviceId = "test-device",
+                    scope = CoroutineScope(Job()),
+                )
+
+            val playbackManager =
+                PlaybackManager(
+                    serverConfig = mock(),
+                    playbackPreferences = mock(),
+                    bookDao = db.bookDao(),
+                    audioFileDao = db.audioFileDao(),
+                    chapterDao = db.chapterDao(),
+                    imageStorage = mock(),
+                    progressTracker = progressTracker,
+                    tokenProvider = mock(),
+                    deviceContext = DeviceContext(type = DeviceType.Phone),
+                    downloadService = mock(),
+                    playbackApi = null,
+                    capabilityDetector = null,
+                    syncApi = syncApi,
+                    scope = CoroutineScope(Job()),
+                    bookRepository = bookRepository,
+                )
+
+            val result = playbackManager.fetchBookFromServer(BookId("book-fail"))
+
+            assertFalse(result, "fetchBookFromServer should return false when persistence fails")
             verifySuspend(VerifyMode.exactly(1)) {
                 bookRepository.upsertWithAudioFiles(any<BookEntity>(), any<List<AudioFileEntity>>())
             }

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerFallbackFetchAtomicityTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerFallbackFetchAtomicityTest.kt
@@ -1,13 +1,14 @@
 package com.calypsan.listenup.client.playback
 
+import com.calypsan.listenup.client.core.AppResult
 import com.calypsan.listenup.client.core.BookId
 import com.calypsan.listenup.client.core.Success
-import com.calypsan.listenup.client.data.local.db.AudioFileDao
+import com.calypsan.listenup.client.data.local.db.AudioFileEntity
+import com.calypsan.listenup.client.data.local.db.BookEntity
 import com.calypsan.listenup.client.data.local.db.DownloadDao
 import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
 import com.calypsan.listenup.client.data.local.db.ListeningEventDao
 import com.calypsan.listenup.client.data.local.db.PlaybackPositionDao
-import com.calypsan.listenup.client.data.local.db.RoomTransactionRunner
 import com.calypsan.listenup.client.data.remote.SyncApiContract
 import com.calypsan.listenup.client.data.remote.model.AudioFileResponse
 import com.calypsan.listenup.client.data.remote.model.BookResponse
@@ -17,32 +18,32 @@ import com.calypsan.listenup.client.data.sync.push.PendingOperationRepositoryCon
 import com.calypsan.listenup.client.data.sync.push.PushSyncOrchestratorContract
 import com.calypsan.listenup.client.device.DeviceContext
 import com.calypsan.listenup.client.device.DeviceType
+import com.calypsan.listenup.client.domain.repository.BookRepository
 import com.calypsan.listenup.client.domain.repository.PlaybackPositionRepository
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import dev.mokkery.answering.returns
-import dev.mokkery.answering.throws
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.test.runTest
 import kotlin.test.AfterTest
 import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 /**
- * Proves [PlaybackManager.fetchBookFromServer] is atomic — when the audio-file
- * junction insert throws, the prior `bookDao.upsert` must roll back so the DB
- * never holds a book row with missing audio files from this refresh.
+ * Proves [PlaybackManager.fetchBookFromServer] delegates the write to
+ * [BookRepository.upsertWithAudioFiles], which owns the atomicity guarantee.
  *
- * Uses a real in-memory [ListenUpDatabase]; the audio-file DAO is mocked to
- * throw on insert, forcing the failure after the book upsert has landed inside
- * the atomically block.
+ * The actual rollback behaviour is exercised in [BookRepositoryImplTest].
+ * This test confirms the delegation wiring so the two tests together give
+ * full coverage of the data path.
  *
- * This is the regression coverage for the first atomically-wrapped write in
- * PlaybackManager. Landed as part of W4 Item B.
+ * Landed as part of W4 Item B (direct DAO writes); updated in W7 Phase B
+ * Task 3 to reflect the route-through-repo refactor (drift #9).
  */
 class PlaybackManagerFallbackFetchAtomicityTest {
     private val db: ListenUpDatabase = createInMemoryTestDatabase()
@@ -53,16 +54,12 @@ class PlaybackManagerFallbackFetchAtomicityTest {
     }
 
     @Test
-    fun `rollback when audio file insert throws`() =
+    fun `fetchBookFromServer delegates write to bookRepository upsertWithAudioFiles`() =
         runTest {
             val syncApi: SyncApiContract = mock()
-            val failingAudioFileDao: AudioFileDao = mock()
+            val bookRepository: BookRepository = mock()
 
-            // Stub the failing DAO: delete succeeds, upsert blows up mid-transaction
-            // (after bookDao.upsert has already written inside the atomically block).
-            everySuspend { failingAudioFileDao.deleteForBook(any()) } returns Unit
-            everySuspend { failingAudioFileDao.upsertAll(any()) } throws
-                RuntimeException("boom — audio file insert failed")
+            everySuspend { bookRepository.upsertWithAudioFiles(any(), any()) } returns AppResult.Success(Unit)
 
             everySuspend { syncApi.getBook(any()) } returns
                 Success(
@@ -102,11 +99,10 @@ class PlaybackManagerFallbackFetchAtomicityTest {
 
             val playbackManager =
                 PlaybackManager(
-                    transactionRunner = RoomTransactionRunner(db),
                     serverConfig = mock(),
                     playbackPreferences = mock(),
                     bookDao = db.bookDao(),
-                    audioFileDao = failingAudioFileDao,
+                    audioFileDao = db.audioFileDao(),
                     chapterDao = db.chapterDao(),
                     imageStorage = mock(),
                     progressTracker = progressTracker,
@@ -117,17 +113,15 @@ class PlaybackManagerFallbackFetchAtomicityTest {
                     capabilityDetector = null,
                     syncApi = syncApi,
                     scope = CoroutineScope(Job()),
+                    bookRepository = bookRepository,
                 )
 
-            assertFailsWith<RuntimeException> {
-                playbackManager.fetchBookFromServer(BookId("book-rollback"))
-            }
+            val result = playbackManager.fetchBookFromServer(BookId("book-rollback"))
 
-            assertEquals(
-                0,
-                db.bookDao().count(),
-                "bookDao.upsert must roll back when audio file insert throws",
-            )
+            assertTrue(result, "fetchBookFromServer should return true on success")
+            verifySuspend(VerifyMode.exactly(1)) {
+                bookRepository.upsertWithAudioFiles(any<BookEntity>(), any<List<AudioFileEntity>>())
+            }
         }
 
     /**

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerFallbackFetchAtomicityTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerFallbackFetchAtomicityTest.kt
@@ -7,19 +7,16 @@ import com.calypsan.listenup.client.core.failureOf
 import com.calypsan.listenup.client.data.local.db.AudioFileEntity
 import com.calypsan.listenup.client.data.local.db.BookEntity
 import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
-import com.calypsan.listenup.client.data.local.db.ListeningEventDao
 import com.calypsan.listenup.client.data.local.db.PlaybackPositionDao
 import com.calypsan.listenup.client.data.remote.SyncApiContract
 import com.calypsan.listenup.client.data.remote.model.AudioFileResponse
 import com.calypsan.listenup.client.data.remote.model.BookResponse
-import com.calypsan.listenup.client.data.sync.push.ListeningEventPayload
-import com.calypsan.listenup.client.data.sync.push.OperationHandler
-import com.calypsan.listenup.client.data.sync.push.PendingOperationRepositoryContract
 import com.calypsan.listenup.client.data.sync.push.PushSyncOrchestratorContract
 import com.calypsan.listenup.client.device.DeviceContext
 import com.calypsan.listenup.client.device.DeviceType
 import com.calypsan.listenup.client.domain.repository.BookRepository
 import com.calypsan.listenup.client.domain.repository.DownloadRepository
+import com.calypsan.listenup.client.domain.repository.ListeningEventRepository
 import com.calypsan.listenup.client.domain.repository.PlaybackPositionRepository
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import dev.mokkery.answering.returns
@@ -89,13 +86,10 @@ class PlaybackManagerFallbackFetchAtomicityTest {
                 ProgressTracker(
                     positionDao = mock<PlaybackPositionDao>(),
                     downloadRepository = mock<DownloadRepository>(),
-                    listeningEventDao = mock<ListeningEventDao>(),
+                    listeningEventRepository = mock<ListeningEventRepository>(),
                     syncApi = mock<SyncApiContract>(),
-                    pendingOperationRepository = mock<PendingOperationRepositoryContract>(),
-                    listeningEventHandler = mock<OperationHandler<ListeningEventPayload>>(),
                     pushSyncOrchestrator = mock<PushSyncOrchestratorContract>(),
                     positionRepository = mock<PlaybackPositionRepository>(),
-                    deviceId = "test-device",
                     scope = CoroutineScope(Job()),
                 )
 
@@ -157,13 +151,10 @@ class PlaybackManagerFallbackFetchAtomicityTest {
                 ProgressTracker(
                     positionDao = mock<PlaybackPositionDao>(),
                     downloadRepository = mock<DownloadRepository>(),
-                    listeningEventDao = mock<ListeningEventDao>(),
+                    listeningEventRepository = mock<ListeningEventRepository>(),
                     syncApi = mock<SyncApiContract>(),
-                    pendingOperationRepository = mock<PendingOperationRepositoryContract>(),
-                    listeningEventHandler = mock<OperationHandler<ListeningEventPayload>>(),
                     pushSyncOrchestrator = mock<PushSyncOrchestratorContract>(),
                     positionRepository = mock<PlaybackPositionRepository>(),
-                    deviceId = "test-device",
                     scope = CoroutineScope(Job()),
                 )
 

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerFallbackFetchTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerFallbackFetchTest.kt
@@ -14,12 +14,14 @@ import com.calypsan.listenup.client.data.local.db.SyncState
 import com.calypsan.listenup.client.data.remote.SyncApiContract
 import com.calypsan.listenup.client.data.remote.model.AudioFileResponse
 import com.calypsan.listenup.client.data.remote.model.BookResponse
+import com.calypsan.listenup.client.data.repository.BookRepositoryImpl
 import com.calypsan.listenup.client.data.sync.push.ListeningEventPayload
 import com.calypsan.listenup.client.data.sync.push.OperationHandler
 import com.calypsan.listenup.client.data.sync.push.PendingOperationRepositoryContract
 import com.calypsan.listenup.client.data.sync.push.PushSyncOrchestratorContract
 import com.calypsan.listenup.client.device.DeviceContext
 import com.calypsan.listenup.client.device.DeviceType
+import com.calypsan.listenup.client.domain.repository.BookRepository
 import com.calypsan.listenup.client.domain.repository.ImageStorage
 import com.calypsan.listenup.client.domain.repository.PlaybackPositionRepository
 import com.calypsan.listenup.client.domain.repository.PlaybackPreferences
@@ -193,8 +195,23 @@ class PlaybackManagerFallbackFetchTest {
                 scope = CoroutineScope(Job()),
             )
 
+        // Real BookRepositoryImpl backed by the same in-memory DB so that
+        // fetchBookFromServer's call to upsertWithAudioFiles actually writes
+        // to the DB and the junction assertion passes.
+        val txRunner = RoomTransactionRunner(db)
+        val bookRepository: BookRepository =
+            BookRepositoryImpl(
+                bookDao = db.bookDao(),
+                chapterDao = db.chapterDao(),
+                audioFileDao = db.audioFileDao(),
+                transactionRunner = txRunner,
+                syncManager = mock(),
+                imageStorage = imageStorage,
+                genreRepository = mock(),
+                tagRepository = mock(),
+            )
+
         return PlaybackManager(
-            transactionRunner = RoomTransactionRunner(db),
             serverConfig = serverConfig,
             playbackPreferences = playbackPreferences,
             bookDao = db.bookDao(),
@@ -209,6 +226,7 @@ class PlaybackManagerFallbackFetchTest {
             capabilityDetector = null,
             syncApi = syncApi,
             scope = CoroutineScope(Job()),
+            bookRepository = bookRepository,
         )
     }
 }

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerFallbackFetchTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerFallbackFetchTest.kt
@@ -6,7 +6,6 @@ import com.calypsan.listenup.client.core.Success
 import com.calypsan.listenup.client.core.Timestamp
 import com.calypsan.listenup.client.data.local.db.BookEntity
 import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
-import com.calypsan.listenup.client.data.local.db.ListeningEventDao
 import com.calypsan.listenup.client.data.local.db.PlaybackPositionDao
 import com.calypsan.listenup.client.data.local.db.RoomTransactionRunner
 import com.calypsan.listenup.client.data.local.db.SyncState
@@ -14,15 +13,13 @@ import com.calypsan.listenup.client.data.remote.SyncApiContract
 import com.calypsan.listenup.client.data.remote.model.AudioFileResponse
 import com.calypsan.listenup.client.data.remote.model.BookResponse
 import com.calypsan.listenup.client.data.repository.BookRepositoryImpl
-import com.calypsan.listenup.client.data.sync.push.ListeningEventPayload
-import com.calypsan.listenup.client.data.sync.push.OperationHandler
-import com.calypsan.listenup.client.data.sync.push.PendingOperationRepositoryContract
 import com.calypsan.listenup.client.data.sync.push.PushSyncOrchestratorContract
 import com.calypsan.listenup.client.device.DeviceContext
 import com.calypsan.listenup.client.device.DeviceType
 import com.calypsan.listenup.client.domain.repository.BookRepository
 import com.calypsan.listenup.client.domain.repository.DownloadRepository
 import com.calypsan.listenup.client.domain.repository.ImageStorage
+import com.calypsan.listenup.client.domain.repository.ListeningEventRepository
 import com.calypsan.listenup.client.domain.repository.PlaybackPositionRepository
 import com.calypsan.listenup.client.domain.repository.PlaybackPreferences
 import com.calypsan.listenup.client.domain.repository.ServerConfig
@@ -185,13 +182,10 @@ class PlaybackManagerFallbackFetchTest {
             ProgressTracker(
                 positionDao = positionDao,
                 downloadRepository = mock<DownloadRepository>(),
-                listeningEventDao = mock<ListeningEventDao>(),
+                listeningEventRepository = mock<ListeningEventRepository>(),
                 syncApi = mock<SyncApiContract>(),
-                pendingOperationRepository = mock<PendingOperationRepositoryContract>(),
-                listeningEventHandler = mock<OperationHandler<ListeningEventPayload>>(),
                 pushSyncOrchestrator = mock<PushSyncOrchestratorContract>(),
                 positionRepository = mock<PlaybackPositionRepository>(),
-                deviceId = "test-device",
                 scope = CoroutineScope(Job()),
             )
 

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerFallbackFetchTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerFallbackFetchTest.kt
@@ -5,7 +5,6 @@ import com.calypsan.listenup.client.core.ServerUrl
 import com.calypsan.listenup.client.core.Success
 import com.calypsan.listenup.client.core.Timestamp
 import com.calypsan.listenup.client.data.local.db.BookEntity
-import com.calypsan.listenup.client.data.local.db.DownloadDao
 import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
 import com.calypsan.listenup.client.data.local.db.ListeningEventDao
 import com.calypsan.listenup.client.data.local.db.PlaybackPositionDao
@@ -22,6 +21,7 @@ import com.calypsan.listenup.client.data.sync.push.PushSyncOrchestratorContract
 import com.calypsan.listenup.client.device.DeviceContext
 import com.calypsan.listenup.client.device.DeviceType
 import com.calypsan.listenup.client.domain.repository.BookRepository
+import com.calypsan.listenup.client.domain.repository.DownloadRepository
 import com.calypsan.listenup.client.domain.repository.ImageStorage
 import com.calypsan.listenup.client.domain.repository.PlaybackPositionRepository
 import com.calypsan.listenup.client.domain.repository.PlaybackPreferences
@@ -184,7 +184,7 @@ class PlaybackManagerFallbackFetchTest {
         val progressTracker =
             ProgressTracker(
                 positionDao = positionDao,
-                downloadDao = mock<DownloadDao>(),
+                downloadRepository = mock<DownloadRepository>(),
                 listeningEventDao = mock<ListeningEventDao>(),
                 syncApi = mock<SyncApiContract>(),
                 pendingOperationRepository = mock<PendingOperationRepositoryContract>(),

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerPrepareTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerPrepareTest.kt
@@ -6,19 +6,16 @@ import com.calypsan.listenup.client.core.Timestamp
 import com.calypsan.listenup.client.data.local.db.AudioFileEntity
 import com.calypsan.listenup.client.data.local.db.BookEntity
 import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
-import com.calypsan.listenup.client.data.local.db.ListeningEventDao
 import com.calypsan.listenup.client.data.local.db.PlaybackPositionDao
 import com.calypsan.listenup.client.data.local.db.SyncState
 import com.calypsan.listenup.client.data.remote.SyncApiContract
-import com.calypsan.listenup.client.data.sync.push.ListeningEventPayload
-import com.calypsan.listenup.client.data.sync.push.OperationHandler
-import com.calypsan.listenup.client.data.sync.push.PendingOperationRepositoryContract
 import com.calypsan.listenup.client.data.sync.push.PushSyncOrchestratorContract
 import com.calypsan.listenup.client.device.DeviceContext
 import com.calypsan.listenup.client.device.DeviceType
 import com.calypsan.listenup.client.domain.repository.BookRepository
 import com.calypsan.listenup.client.domain.repository.DownloadRepository
 import com.calypsan.listenup.client.domain.repository.ImageStorage
+import com.calypsan.listenup.client.domain.repository.ListeningEventRepository
 import com.calypsan.listenup.client.domain.repository.PlaybackPositionRepository
 import com.calypsan.listenup.client.domain.repository.PlaybackPreferences
 import com.calypsan.listenup.client.domain.repository.ServerConfig
@@ -154,13 +151,10 @@ class PlaybackManagerPrepareTest {
             ProgressTracker(
                 positionDao = positionDao,
                 downloadRepository = mock<DownloadRepository>(),
-                listeningEventDao = mock<ListeningEventDao>(),
+                listeningEventRepository = mock<ListeningEventRepository>(),
                 syncApi = mock<SyncApiContract>(),
-                pendingOperationRepository = mock<PendingOperationRepositoryContract>(),
-                listeningEventHandler = mock<OperationHandler<ListeningEventPayload>>(),
                 pushSyncOrchestrator = mock<PushSyncOrchestratorContract>(),
                 positionRepository = mock<PlaybackPositionRepository>(),
-                deviceId = "test-device",
                 scope = CoroutineScope(Job()),
             )
 

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerPrepareTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerPrepareTest.kt
@@ -5,7 +5,6 @@ import com.calypsan.listenup.client.core.ServerUrl
 import com.calypsan.listenup.client.core.Timestamp
 import com.calypsan.listenup.client.data.local.db.AudioFileEntity
 import com.calypsan.listenup.client.data.local.db.BookEntity
-import com.calypsan.listenup.client.data.local.db.DownloadDao
 import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
 import com.calypsan.listenup.client.data.local.db.ListeningEventDao
 import com.calypsan.listenup.client.data.local.db.PlaybackPositionDao
@@ -18,6 +17,7 @@ import com.calypsan.listenup.client.data.sync.push.PushSyncOrchestratorContract
 import com.calypsan.listenup.client.device.DeviceContext
 import com.calypsan.listenup.client.device.DeviceType
 import com.calypsan.listenup.client.domain.repository.BookRepository
+import com.calypsan.listenup.client.domain.repository.DownloadRepository
 import com.calypsan.listenup.client.domain.repository.ImageStorage
 import com.calypsan.listenup.client.domain.repository.PlaybackPositionRepository
 import com.calypsan.listenup.client.domain.repository.PlaybackPreferences
@@ -153,7 +153,7 @@ class PlaybackManagerPrepareTest {
         val progressTracker =
             ProgressTracker(
                 positionDao = positionDao,
-                downloadDao = mock<DownloadDao>(),
+                downloadRepository = mock<DownloadRepository>(),
                 listeningEventDao = mock<ListeningEventDao>(),
                 syncApi = mock<SyncApiContract>(),
                 pendingOperationRepository = mock<PendingOperationRepositoryContract>(),

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerPrepareTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerPrepareTest.kt
@@ -9,7 +9,6 @@ import com.calypsan.listenup.client.data.local.db.DownloadDao
 import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
 import com.calypsan.listenup.client.data.local.db.ListeningEventDao
 import com.calypsan.listenup.client.data.local.db.PlaybackPositionDao
-import com.calypsan.listenup.client.data.local.db.RoomTransactionRunner
 import com.calypsan.listenup.client.data.local.db.SyncState
 import com.calypsan.listenup.client.data.remote.SyncApiContract
 import com.calypsan.listenup.client.data.sync.push.ListeningEventPayload
@@ -18,6 +17,7 @@ import com.calypsan.listenup.client.data.sync.push.PendingOperationRepositoryCon
 import com.calypsan.listenup.client.data.sync.push.PushSyncOrchestratorContract
 import com.calypsan.listenup.client.device.DeviceContext
 import com.calypsan.listenup.client.device.DeviceType
+import com.calypsan.listenup.client.domain.repository.BookRepository
 import com.calypsan.listenup.client.domain.repository.ImageStorage
 import com.calypsan.listenup.client.domain.repository.PlaybackPositionRepository
 import com.calypsan.listenup.client.domain.repository.PlaybackPreferences
@@ -165,7 +165,6 @@ class PlaybackManagerPrepareTest {
             )
 
         return PlaybackManager(
-            transactionRunner = RoomTransactionRunner(db),
             serverConfig = serverConfig,
             playbackPreferences = playbackPreferences,
             bookDao = db.bookDao(),
@@ -180,6 +179,7 @@ class PlaybackManagerPrepareTest {
             capabilityDetector = null,
             syncApi = null,
             scope = CoroutineScope(Job()),
+            bookRepository = mock<BookRepository>(),
         )
     }
 }

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerSpeedTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerSpeedTest.kt
@@ -1,0 +1,324 @@
+package com.calypsan.listenup.client.playback
+
+import com.calypsan.listenup.client.core.BookId
+import com.calypsan.listenup.client.core.ServerUrl
+import com.calypsan.listenup.client.core.Timestamp
+import com.calypsan.listenup.client.data.local.db.AudioFileEntity
+import com.calypsan.listenup.client.data.local.db.BookEntity
+import com.calypsan.listenup.client.data.local.db.DownloadDao
+import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
+import com.calypsan.listenup.client.data.local.db.ListeningEventDao
+import com.calypsan.listenup.client.data.local.db.PlaybackPositionDao
+import com.calypsan.listenup.client.data.local.db.RoomTransactionRunner
+import com.calypsan.listenup.client.data.local.db.SyncState
+import com.calypsan.listenup.client.data.remote.SyncApiContract
+import com.calypsan.listenup.client.data.sync.push.ListeningEventPayload
+import com.calypsan.listenup.client.data.sync.push.OperationHandler
+import com.calypsan.listenup.client.data.sync.push.PendingOperationRepositoryContract
+import com.calypsan.listenup.client.data.sync.push.PushSyncOrchestratorContract
+import com.calypsan.listenup.client.device.DeviceContext
+import com.calypsan.listenup.client.device.DeviceType
+import com.calypsan.listenup.client.domain.repository.ImageStorage
+import com.calypsan.listenup.client.domain.repository.PlaybackPositionRepository
+import com.calypsan.listenup.client.domain.repository.PlaybackPreferences
+import com.calypsan.listenup.client.domain.repository.ServerConfig
+import com.calypsan.listenup.client.download.DownloadResult
+import com.calypsan.listenup.client.download.DownloadService
+import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verify
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.AfterTest
+import kotlin.test.Test
+
+/**
+ * Bug 3 regression tests for PlaybackManager speed paths.
+ *
+ * Pins three invariants:
+ * 1. onSpeedChanged invokes progressTracker.onSpeedChanged with the new speed
+ *    (was already correct, locked here against future regression).
+ * 2. startPlayback with effective speed 1.0f calls audioPlayer.setSpeed(1.0f)
+ *    even after the player was previously at non-1.0f speed (was suppressed
+ *    by the if (speed != 1.0f) guard at PlaybackManager:385-387).
+ * 3. onSpeedChanged writes per-book ONLY; never touches the global default
+ *    via playbackPreferences.setDefaultPlaybackSpeed (was double-writing
+ *    via scope.launch at PlaybackManager:471, conflating per-book and global).
+ *
+ * If any of these tests regress in the future, the corresponding W7 Phase A
+ * deletion was likely re-introduced. Investigate before "fixing" the test.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class PlaybackManagerSpeedTest {
+    private val db: ListenUpDatabase = createInMemoryTestDatabase()
+
+    @AfterTest
+    fun tearDown() {
+        db.close()
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 1 — progressTracker write is always invoked regardless of speed value
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `onSpeedChanged with 1_0f propagates progressTracker write`() =
+        runTest {
+            val positionDao: PlaybackPositionDao = mock()
+            everySuspend { positionDao.get(any()) } returns null
+            everySuspend { positionDao.save(any()) } returns Unit
+
+            val (manager, _) =
+                createPlaybackManagerWithScope(
+                    positionDao = positionDao,
+                )
+
+            manager.activateBook(BookId("book-1"))
+            manager.onSpeedChanged(1.0f)
+
+            // Drain the scope.launch inside ProgressTracker.onSpeedChanged
+            advanceUntilIdle()
+
+            verifySuspend(VerifyMode.exactly(1)) { positionDao.save(any()) }
+        }
+
+    // -------------------------------------------------------------------------
+    // Test 2 — startPlayback always calls setSpeed, even when speed == 1.0f
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `startPlayback with effective speed 1_0f calls audioPlayer setSpeed 1_0f`() =
+        runTest {
+            seedBookAndAudioFiles()
+
+            val playbackPreferences: PlaybackPreferences = mock()
+            everySuspend { playbackPreferences.getDefaultPlaybackSpeed() } returns 1.0f
+
+            val positionDao: PlaybackPositionDao = mock()
+            everySuspend { positionDao.get(any()) } returns null
+
+            val manager =
+                createPlaybackManager(
+                    playbackPreferences = playbackPreferences,
+                    positionDao = positionDao,
+                    // Use a detached scope so the positionMs.collect launch does not
+                    // keep the TestScope alive and block runTest completion.
+                    scope = CoroutineScope(Job()),
+                )
+
+            val result = manager.prepareForPlayback(BookId("book-1"))
+            checkNotNull(result) { "prepareForPlayback must succeed" }
+            manager.activateBook(BookId("book-1"))
+
+            val audioPlayer: AudioPlayer = mock()
+            everySuspend { audioPlayer.load(any()) } returns Unit
+            every { audioPlayer.positionMs } returns MutableStateFlow(0L)
+            every { audioPlayer.state } returns MutableStateFlow(PlaybackState.Idle)
+            every { audioPlayer.setSpeed(any()) } returns Unit
+            every { audioPlayer.play() } returns Unit
+
+            manager.startPlayback(
+                player = audioPlayer,
+                resumePositionMs = 0L,
+                resumeSpeed = 1.0f,
+            )
+
+            verify(VerifyMode.exactly(1)) { audioPlayer.setSpeed(1.0f) }
+        }
+
+    // -------------------------------------------------------------------------
+    // Test 3 — onSpeedChanged writes per-book ONLY; global default stays clean
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `onSpeedChanged does not call playbackPreferences setDefaultPlaybackSpeed`() =
+        runTest {
+            val playbackPreferences: PlaybackPreferences = mock()
+            everySuspend { playbackPreferences.getDefaultPlaybackSpeed() } returns 1.0f
+            everySuspend { playbackPreferences.setDefaultPlaybackSpeed(any()) } returns Unit
+
+            val positionDao: PlaybackPositionDao = mock()
+            everySuspend { positionDao.get(any()) } returns null
+            everySuspend { positionDao.save(any()) } returns Unit
+
+            val (manager, _) =
+                createPlaybackManagerWithScope(
+                    playbackPreferences = playbackPreferences,
+                    positionDao = positionDao,
+                )
+
+            manager.activateBook(BookId("book-1"))
+            manager.onSpeedChanged(2.0f)
+
+            // Drain all pending coroutines so any rogue setDefaultPlaybackSpeed call
+            // has had a chance to run before we assert it didn't.
+            advanceUntilIdle()
+
+            verifySuspend(VerifyMode.exactly(1)) { positionDao.save(any()) }
+            verifySuspend(VerifyMode.exactly(0)) { playbackPreferences.setDefaultPlaybackSpeed(any()) }
+        }
+
+    // =========================================================================
+    // Fixture helpers
+    // =========================================================================
+
+    /**
+     * Creates a [PlaybackManager] whose internal [CoroutineScope] is backed by the
+     * [TestScope] from [runTest]. Use this for tests that need [advanceUntilIdle]
+     * to drain coroutines launched inside [PlaybackManager] or [ProgressTracker].
+     *
+     * Returns both the manager and the [positionDao] mock so tests can assert
+     * on it.
+     */
+    private fun TestScope.createPlaybackManagerWithScope(
+        playbackPreferences: PlaybackPreferences = defaultPlaybackPreferences(),
+        positionDao: PlaybackPositionDao = defaultPositionDao(),
+    ): Pair<PlaybackManager, PlaybackPositionDao> {
+        val progressTrackerScope = CoroutineScope(coroutineContext)
+        val managerScope = CoroutineScope(coroutineContext)
+
+        val progressTracker =
+            buildProgressTracker(
+                positionDao = positionDao,
+                scope = progressTrackerScope,
+            )
+
+        val manager =
+            createPlaybackManager(
+                playbackPreferences = playbackPreferences,
+                positionDao = positionDao,
+                progressTracker = progressTracker,
+                scope = managerScope,
+            )
+
+        return manager to positionDao
+    }
+
+    private fun defaultPlaybackPreferences(): PlaybackPreferences {
+        val prefs: PlaybackPreferences = mock()
+        everySuspend { prefs.getDefaultPlaybackSpeed() } returns 1.0f
+        everySuspend { prefs.setDefaultPlaybackSpeed(any()) } returns Unit
+        return prefs
+    }
+
+    private fun defaultPositionDao(): PlaybackPositionDao {
+        val dao: PlaybackPositionDao = mock()
+        everySuspend { dao.get(any()) } returns null
+        everySuspend { dao.save(any()) } returns Unit
+        return dao
+    }
+
+    private fun buildProgressTracker(
+        positionDao: PlaybackPositionDao,
+        scope: CoroutineScope,
+    ): ProgressTracker =
+        ProgressTracker(
+            positionDao = positionDao,
+            downloadDao = mock<DownloadDao>(),
+            listeningEventDao = mock<ListeningEventDao>(),
+            syncApi = mock<SyncApiContract>(),
+            pendingOperationRepository = mock<PendingOperationRepositoryContract>(),
+            listeningEventHandler = mock<OperationHandler<ListeningEventPayload>>(),
+            pushSyncOrchestrator = mock<PushSyncOrchestratorContract>(),
+            positionRepository = mock<PlaybackPositionRepository>(),
+            deviceId = "test-device",
+            scope = scope,
+        )
+
+    private fun createPlaybackManager(
+        playbackPreferences: PlaybackPreferences = defaultPlaybackPreferences(),
+        positionDao: PlaybackPositionDao = defaultPositionDao(),
+        progressTracker: ProgressTracker =
+            buildProgressTracker(
+                positionDao = positionDao,
+                scope = CoroutineScope(Job()),
+            ),
+        scope: CoroutineScope = CoroutineScope(Job()),
+    ): PlaybackManager {
+        val tokenProvider: AudioTokenProvider = mock()
+        everySuspend { tokenProvider.prepareForPlayback() } returns Unit
+
+        val serverConfig: ServerConfig = mock()
+        everySuspend { serverConfig.getServerUrl() } returns ServerUrl("https://example.test")
+
+        val imageStorage: ImageStorage = mock()
+        every { imageStorage.exists(any()) } returns false
+
+        val downloadService: DownloadService = mock()
+        everySuspend { downloadService.getLocalPath(any()) } returns null
+        everySuspend { downloadService.wasExplicitlyDeleted(any()) } returns false
+        everySuspend { downloadService.downloadBook(any()) } returns DownloadResult.AlreadyDownloaded
+
+        return PlaybackManager(
+            transactionRunner = RoomTransactionRunner(db),
+            serverConfig = serverConfig,
+            playbackPreferences = playbackPreferences,
+            bookDao = db.bookDao(),
+            audioFileDao = db.audioFileDao(),
+            chapterDao = db.chapterDao(),
+            imageStorage = imageStorage,
+            progressTracker = progressTracker,
+            tokenProvider = tokenProvider,
+            deviceContext = DeviceContext(type = DeviceType.Phone),
+            downloadService = downloadService,
+            playbackApi = null,
+            capabilityDetector = null,
+            syncApi = null,
+            scope = scope,
+        )
+    }
+
+    private suspend fun seedBookAndAudioFiles() {
+        db.bookDao().upsert(
+            BookEntity(
+                id = BookId("book-1"),
+                title = "Test Book",
+                sortTitle = "Test Book",
+                subtitle = null,
+                coverUrl = null,
+                coverBlurHash = null,
+                dominantColor = null,
+                darkMutedColor = null,
+                vibrantColor = null,
+                totalDuration = 1_800_000L,
+                description = null,
+                publishYear = null,
+                publisher = null,
+                language = null,
+                isbn = null,
+                asin = null,
+                abridged = false,
+                syncState = SyncState.SYNCED,
+                lastModified = Timestamp(1L),
+                serverVersion = Timestamp(1L),
+                createdAt = Timestamp(1L),
+                updatedAt = Timestamp(1L),
+            ),
+        )
+        db.audioFileDao().upsertAll(
+            listOf(
+                AudioFileEntity(
+                    bookId = BookId("book-1"),
+                    index = 0,
+                    id = "af-0",
+                    filename = "chapter1.m4b",
+                    format = "m4b",
+                    codec = "aac",
+                    duration = 1_800_000L,
+                    size = 45_000_000L,
+                ),
+            ),
+        )
+    }
+}

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerSpeedTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerSpeedTest.kt
@@ -9,7 +9,6 @@ import com.calypsan.listenup.client.data.local.db.DownloadDao
 import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
 import com.calypsan.listenup.client.data.local.db.ListeningEventDao
 import com.calypsan.listenup.client.data.local.db.PlaybackPositionDao
-import com.calypsan.listenup.client.data.local.db.RoomTransactionRunner
 import com.calypsan.listenup.client.data.local.db.SyncState
 import com.calypsan.listenup.client.data.remote.SyncApiContract
 import com.calypsan.listenup.client.data.sync.push.ListeningEventPayload
@@ -18,6 +17,7 @@ import com.calypsan.listenup.client.data.sync.push.PendingOperationRepositoryCon
 import com.calypsan.listenup.client.data.sync.push.PushSyncOrchestratorContract
 import com.calypsan.listenup.client.device.DeviceContext
 import com.calypsan.listenup.client.device.DeviceType
+import com.calypsan.listenup.client.domain.repository.BookRepository
 import com.calypsan.listenup.client.domain.repository.ImageStorage
 import com.calypsan.listenup.client.domain.repository.PlaybackPositionRepository
 import com.calypsan.listenup.client.domain.repository.PlaybackPreferences
@@ -261,7 +261,6 @@ class PlaybackManagerSpeedTest {
         everySuspend { downloadService.downloadBook(any()) } returns DownloadResult.AlreadyDownloaded
 
         return PlaybackManager(
-            transactionRunner = RoomTransactionRunner(db),
             serverConfig = serverConfig,
             playbackPreferences = playbackPreferences,
             bookDao = db.bookDao(),
@@ -276,6 +275,7 @@ class PlaybackManagerSpeedTest {
             capabilityDetector = null,
             syncApi = null,
             scope = scope,
+            bookRepository = mock<BookRepository>(),
         )
     }
 

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerSpeedTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerSpeedTest.kt
@@ -6,13 +6,9 @@ import com.calypsan.listenup.client.core.Timestamp
 import com.calypsan.listenup.client.data.local.db.AudioFileEntity
 import com.calypsan.listenup.client.data.local.db.BookEntity
 import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
-import com.calypsan.listenup.client.data.local.db.ListeningEventDao
 import com.calypsan.listenup.client.data.local.db.PlaybackPositionDao
 import com.calypsan.listenup.client.data.local.db.SyncState
 import com.calypsan.listenup.client.data.remote.SyncApiContract
-import com.calypsan.listenup.client.data.sync.push.ListeningEventPayload
-import com.calypsan.listenup.client.data.sync.push.OperationHandler
-import com.calypsan.listenup.client.data.sync.push.PendingOperationRepositoryContract
 import com.calypsan.listenup.client.data.sync.push.PushSyncOrchestratorContract
 import com.calypsan.listenup.client.device.DeviceContext
 import com.calypsan.listenup.client.device.DeviceType
@@ -226,13 +222,10 @@ class PlaybackManagerSpeedTest {
         ProgressTracker(
             positionDao = positionDao,
             downloadRepository = mock<DownloadRepository>(),
-            listeningEventDao = mock<ListeningEventDao>(),
+            listeningEventRepository = mock<com.calypsan.listenup.client.domain.repository.ListeningEventRepository>(),
             syncApi = mock<SyncApiContract>(),
-            pendingOperationRepository = mock<PendingOperationRepositoryContract>(),
-            listeningEventHandler = mock<OperationHandler<ListeningEventPayload>>(),
             pushSyncOrchestrator = mock<PushSyncOrchestratorContract>(),
             positionRepository = mock<PlaybackPositionRepository>(),
-            deviceId = "test-device",
             scope = scope,
         )
 

--- a/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerSpeedTest.kt
+++ b/shared/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerSpeedTest.kt
@@ -5,7 +5,6 @@ import com.calypsan.listenup.client.core.ServerUrl
 import com.calypsan.listenup.client.core.Timestamp
 import com.calypsan.listenup.client.data.local.db.AudioFileEntity
 import com.calypsan.listenup.client.data.local.db.BookEntity
-import com.calypsan.listenup.client.data.local.db.DownloadDao
 import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
 import com.calypsan.listenup.client.data.local.db.ListeningEventDao
 import com.calypsan.listenup.client.data.local.db.PlaybackPositionDao
@@ -18,6 +17,7 @@ import com.calypsan.listenup.client.data.sync.push.PushSyncOrchestratorContract
 import com.calypsan.listenup.client.device.DeviceContext
 import com.calypsan.listenup.client.device.DeviceType
 import com.calypsan.listenup.client.domain.repository.BookRepository
+import com.calypsan.listenup.client.domain.repository.DownloadRepository
 import com.calypsan.listenup.client.domain.repository.ImageStorage
 import com.calypsan.listenup.client.domain.repository.PlaybackPositionRepository
 import com.calypsan.listenup.client.domain.repository.PlaybackPreferences
@@ -225,7 +225,7 @@ class PlaybackManagerSpeedTest {
     ): ProgressTracker =
         ProgressTracker(
             positionDao = positionDao,
-            downloadDao = mock<DownloadDao>(),
+            downloadRepository = mock<DownloadRepository>(),
             listeningEventDao = mock<ListeningEventDao>(),
             syncApi = mock<SyncApiContract>(),
             pendingOperationRepository = mock<PendingOperationRepositoryContract>(),

--- a/shared/src/macosMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.macos.kt
+++ b/shared/src/macosMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.macos.kt
@@ -100,7 +100,6 @@ val macosPlaybackModule: Module =
         // Playback manager
         single {
             PlaybackManager(
-                transactionRunner = get(),
                 serverConfig = get(),
                 playbackPreferences = get(),
                 bookDao = get(),
@@ -115,6 +114,7 @@ val macosPlaybackModule: Module =
                 syncApi = get(),
                 deviceContext = get(),
                 scope = get(qualifier = named("playbackScope")),
+                bookRepository = get(),
             )
         }
 

--- a/shared/src/macosMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.macos.kt
+++ b/shared/src/macosMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.macos.kt
@@ -78,7 +78,7 @@ val macosPlaybackModule: Module =
         single {
             ProgressTracker(
                 positionDao = get(),
-                downloadDao = get(),
+                downloadRepository = get(),
                 listeningEventDao = get(),
                 syncApi = get(),
                 pendingOperationRepository = get(),

--- a/shared/src/macosMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.macos.kt
+++ b/shared/src/macosMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.macos.kt
@@ -6,7 +6,6 @@ import com.calypsan.listenup.client.core.IODispatcher
 import com.calypsan.listenup.client.download.DownloadFileManager
 import com.calypsan.listenup.client.download.DownloadService
 import com.calypsan.listenup.client.download.AppleDownloadService
-import com.calypsan.listenup.client.data.sync.push.ListeningEventHandler
 import com.calypsan.listenup.client.playback.AudioTokenProvider
 import com.calypsan.listenup.client.playback.AppleAudioTokenProvider
 import com.calypsan.listenup.client.playback.AudioPlayer
@@ -79,13 +78,10 @@ val macosPlaybackModule: Module =
             ProgressTracker(
                 positionDao = get(),
                 downloadRepository = get(),
-                listeningEventDao = get(),
+                listeningEventRepository = get(),
                 syncApi = get(),
-                pendingOperationRepository = get(),
-                listeningEventHandler = get<ListeningEventHandler>(),
                 pushSyncOrchestrator = get(),
                 positionRepository = get(),
-                deviceId = get(qualifier = named("deviceId")),
                 scope = get(qualifier = named("playbackScope")),
             )
         }


### PR DESCRIPTION
## Summary

W7 Phase B closes drift rows #9, #10, #11 by introducing transactional repository ownership for the playback layer.

- New `PlaybackPositionRepository.savePlaybackState(bookId, update: PlaybackUpdate)` — single canonical entry point with 11-variant sealed hierarchy (8 player events from Finding 09 D6 + 3 user commands), per-book `Mutex` map for serialization, every variant handler runs inside `transactionRunner.atomically { }`. EM-R1 compliant via `suspendRunCatching`.
- New `ListeningEventRepository` extracted from `ProgressTracker.queueListeningEvent` — wraps DAO + pending-op writes in `atomically`. Two unsafe catches removed; misleading "Continue to queue for sync anyway" comment deleted. Position validation kept at the playback layer (the repo owns atomicity; `ProgressTracker` owns "what counts as a valid event").
- New `BookRepository.upsertWithAudioFiles(book, audioFiles)` (closes drift #9 — `PlaybackManager:694-697` rewired).
- New `DownloadRepository.deleteForBook(bookId)` (closes drift #10 — `ProgressTracker:524` rewired). Best-effort try/catch with `CancellationException` rethrow added at the call site.
- `markComplete` becomes a thin facade over `savePlaybackState(MarkComplete)`. Public signatures preserved.
- Shared `passThroughTransactionRunner()` test helper extracted.

## Behavior changes (please review)

1. **`markComplete` shifted from "try-syncApi-then-fallback-queue" to "always-queue (outbox)".** Architecturally cleaner; server still gets notified (sync engine drains the queue). Net observable outcome to callers identical.
2. **`BookFinished` handler preserves first `finishedAt` on re-finish** — first-completion timestamp is sticky. Inline contract comment added.
3. **`discardProgress` and `restartBook` are NOT facades** (Task 7 chose Option B). Converting would (a) drop server-sync entirely (no `OperationType.DISCARD_PROGRESS` / `OperationType.RESTART_BOOK` enum entries or handlers exist), and (b) for `discardProgress` change local-DB semantics from row-delete to row-reset. Deferred to W8 with infrastructure work — tracked as drift #17.

## Drift state

- **Closed:** #9 (PlaybackManager 3-write block), #10 (ProgressTracker downloadDao bypass), #11 (listening-event repo write surface).
- **Newly opened:** #17 (`discardProgress`/`restartBook` facade conversion deferred to W8 — needs new `OperationType` enum entries + handlers); #18 (`ProgressTracker:526` discards `AppResult<Unit>` from `markComplete()` — pre-existing, now meaningful post-facade).
- **W7 phase progress:** 2 of 5 phases done (A: Bug 3 + Build APK; B: this).

## Rebase note

This branch was cut from `w7-a-bug3-speed-and-build-apk` HEAD `8c1d78cc` because Phase A PR #259 was OPEN at branch creation. Rebase onto `main` once #259 merges.

## Spec / Plan

- Spec: `docs/superpowers/specs/2026-04-25-w7-b-playback-repos-design.md`
- Plan: `docs/superpowers/plans/2026-04-25-w7-b-playback-repos.md` (End-of-phase state appended)

## Test plan

- [x] `:shared:jvmTest` green at every commit
- [x] `spotlessCheck detekt` green at every commit
- [x] `:androidApp:assembleDebug` green at every commit
- [x] §M1 code-reviewer PASS
- [x] Per-variant tests for all 11 variants (`PlaybackUpdate`)
- [x] Per-book Mutex contention test (same-book serializes; different-books parallel)
- [x] AppResult.Failure propagation tested at all 3 new repo seams