### PR TITLE
🐛 fix(androidApp): keep the kotlinx.rpc surface from R8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,12 @@ jobs:
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
         run: ./gradlew :app:androidApp:bundleRelease :app:androidApp:assembleRelease --no-daemon
 
+      # Gate the artifact before it can reach Play. kotlinx.rpc ships no consumer R8
+      # rules and resolves @Rpc services by interface name, so a missing keep rule
+      # silently produces a build that cannot reach ANY server. 0.8.0 shipped that way.
+      - name: Verify @Rpc surface survived R8
+        run: tools/scripts/verify-r8-rpc-surface.sh app/androidApp/build/outputs/apk/release/androidApp-release.apk
+
       - name: Upload to Google Play (internal, draft)
         uses: r0adkll/upload-google-play@e738b9dd8f2476ea806d921b64aacd24f34515a5 # v1
         with:

--- a/app/androidApp/proguard-rules.pro
+++ b/app/androidApp/proguard-rules.pro
@@ -17,8 +17,34 @@
 # serialization runtime bundles the keep rules for the generated $$serializer
 # classes, companions, and serializer() on every @Serializable type, so no
 # manual class keeps are required here.
--keepattributes *Annotation*, InnerClasses
+#
+# Signature is required by kotlinx.rpc (below), which reads generic return types
+# — AppResult<T>, Flow<T> — off the service interface to pick a deserializer.
+# Without it every RPC method erases to its raw type and decoding fails.
+-keepattributes *Annotation*, InnerClasses, Signature
 -dontnote kotlinx.serialization.AnnotationsKt
+
+# --- kotlinx.rpc ---
+# UNLIKE every other dependency here, kotlinx.rpc ships NO consumer keep rules
+# (verified against the 0.11.0 artifacts). Its client resolves each @Rpc service
+# by interface name to build the proxy, so R8 renaming them breaks EVERY RPC call
+# at proxy-construction time — before a socket is opened. The whole app surface is
+# RPC, so the app cannot reach any server at all; it surfaces as a generic
+# "couldn't verify the server" with zero network activity and, in a release build,
+# zero logs. Shipped in 0.8.0 (versionCode 2756) and reproduced on-device.
+#
+# These keeps are deliberately broader than this file's usual "narrowest possible"
+# policy, and the breadth is evidence-driven rather than defensive. Keeping only the
+# @Rpc interfaces was tried first and was NOT sufficient: the app still failed with no
+# socket opened. A DEX diff against a working debug build showed R8 had also stripped
+# the runtime that READS those interfaces — serviceDescriptorOf, rpcChannel,
+# RpcProxyCache, rpcResult were all present in debug and absent from release, leaving
+# only KrpcTransport. Keeping an interface is useless if the reflective machinery that
+# builds a proxy from it is gone, so the runtime and the generated per-service stubs
+# (which live alongside the interfaces in :contract) are kept too.
+-keep @kotlinx.rpc.annotations.Rpc interface * { *; }
+-keep class kotlinx.rpc.** { *; }
+-keep class com.calypsan.listenup.api.** { *; }
 
 # --- Ktor (OkHttp engine) ---
 # The authenticated client is built with a no-arg HttpClient { }, which resolves

--- a/app/sharedUI/src/commonMain/composeResources/files/aboutlibraries.json
+++ b/app/sharedUI/src/commonMain/composeResources/files/aboutlibraries.json
@@ -2138,10 +2138,10 @@
         },
         {
             "uniqueId": "androidx.navigation3:navigation3-runtime-android",
-            "artifactVersion": "1.1.4",
+            "artifactVersion": "1.1.5",
             "name": "Androidx Navigation 3 Runtime",
             "description": "Provides the building blocks for a Compose first Navigation solution that easily supports extensions.",
-            "website": "https://developer.android.com/jetpack/androidx/releases/navigation3#1.1.4",
+            "website": "https://developer.android.com/jetpack/androidx/releases/navigation3#1.1.5",
             "developers": [
                 {
                     "name": "The Android Open Source Project"
@@ -2163,10 +2163,10 @@
         },
         {
             "uniqueId": "androidx.navigation3:navigation3-ui-android",
-            "artifactVersion": "1.1.4",
+            "artifactVersion": "1.1.5",
             "name": "Androidx Navigation 3 UI",
             "description": "Provides a Navigation3 display that uses the building blocks from runtime to create a higher level solution.",
-            "website": "https://developer.android.com/jetpack/androidx/releases/navigation3#1.1.4",
+            "website": "https://developer.android.com/jetpack/androidx/releases/navigation3#1.1.5",
             "developers": [
                 {
                     "name": "The Android Open Source Project"
@@ -2351,10 +2351,10 @@
         },
         {
             "uniqueId": "androidx.room3:room3-common-jvm",
-            "artifactVersion": "3.0.0",
+            "artifactVersion": "3.0.1",
             "name": "Room-Common",
             "description": "Android Room-Common",
-            "website": "https://developer.android.com/jetpack/androidx/releases/room3#3.0.0",
+            "website": "https://developer.android.com/jetpack/androidx/releases/room3#3.0.1",
             "developers": [
                 {
                     "name": "The Android Open Source Project"
@@ -2376,10 +2376,10 @@
         },
         {
             "uniqueId": "androidx.room3:room3-runtime-android",
-            "artifactVersion": "3.0.0",
+            "artifactVersion": "3.0.1",
             "name": "Room-Runtime",
             "description": "Android Room-Runtime",
-            "website": "https://developer.android.com/jetpack/androidx/releases/room3#3.0.0",
+            "website": "https://developer.android.com/jetpack/androidx/releases/room3#3.0.1",
             "developers": [
                 {
                     "name": "The Android Open Source Project"
@@ -3592,7 +3592,7 @@
         },
         {
             "uniqueId": "io.ktor:ktor-client-auth-jvm",
-            "artifactVersion": "3.5.1",
+            "artifactVersion": "3.5.2",
             "name": "ktor-client-auth",
             "description": "Ktor is a framework for quickly creating web applications in Kotlin with minimal effort.",
             "website": "https://github.com/ktorio/ktor",
@@ -3614,7 +3614,7 @@
         },
         {
             "uniqueId": "io.ktor:ktor-client-content-negotiation-jvm",
-            "artifactVersion": "3.5.1",
+            "artifactVersion": "3.5.2",
             "name": "ktor-client-content-negotiation",
             "description": "Ktor is a framework for quickly creating web applications in Kotlin with minimal effort.",
             "website": "https://github.com/ktorio/ktor",
@@ -3658,7 +3658,7 @@
         },
         {
             "uniqueId": "io.ktor:ktor-client-darwin",
-            "artifactVersion": "3.5.1",
+            "artifactVersion": "3.5.2",
             "name": "ktor-client-darwin",
             "description": "Ktor is a framework for quickly creating web applications in Kotlin with minimal effort.",
             "website": "https://github.com/ktorio/ktor",
@@ -3680,7 +3680,7 @@
         },
         {
             "uniqueId": "io.ktor:ktor-client-logging-jvm",
-            "artifactVersion": "3.5.1",
+            "artifactVersion": "3.5.2",
             "name": "ktor-client-logging",
             "description": "Ktor is a framework for quickly creating web applications in Kotlin with minimal effort.",
             "website": "https://github.com/ktorio/ktor",
@@ -3702,7 +3702,7 @@
         },
         {
             "uniqueId": "io.ktor:ktor-client-okhttp-jvm",
-            "artifactVersion": "3.5.1",
+            "artifactVersion": "3.5.2",
             "name": "ktor-client-okhttp",
             "description": "Ktor is a framework for quickly creating web applications in Kotlin with minimal effort.",
             "website": "https://github.com/ktorio/ktor",
@@ -3856,7 +3856,7 @@
         },
         {
             "uniqueId": "io.ktor:ktor-network-tls",
-            "artifactVersion": "3.5.1",
+            "artifactVersion": "3.5.2",
             "name": "ktor-network-tls",
             "description": "Ktor is a framework for quickly creating web applications in Kotlin with minimal effort.",
             "website": "https://github.com/ktorio/ktor",
@@ -3900,7 +3900,7 @@
         },
         {
             "uniqueId": "io.ktor:ktor-serialization-kotlinx-json-jvm",
-            "artifactVersion": "3.5.1",
+            "artifactVersion": "3.5.2",
             "name": "ktor-serialization-kotlinx-json",
             "description": "Ktor is a framework for quickly creating web applications in Kotlin with minimal effort.",
             "website": "https://github.com/ktorio/ktor",
@@ -3922,7 +3922,7 @@
         },
         {
             "uniqueId": "io.ktor:ktor-serialization-kotlinx-jvm",
-            "artifactVersion": "3.5.1",
+            "artifactVersion": "3.5.2",
             "name": "ktor-serialization-kotlinx",
             "description": "Ktor is a framework for quickly creating web applications in Kotlin with minimal effort.",
             "website": "https://github.com/ktorio/ktor",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,8 +3,8 @@ android-compileSdk = "37"
 android-minSdk = "33"
 android-targetSdk = "37"
 agp = "9.3.1"
-androidx-benchmark = "1.5.0-alpha07"
-androidx-baselineprofile = "1.5.0-alpha07"
+androidx-benchmark = "1.5.0-beta01"
+androidx-baselineprofile = "1.5.0-beta01"
 androidx-profileinstaller = "1.4.1"
 androidx-test-ext-junit = "1.3.0"
 androidx-test-uiautomator = "2.4.0"
@@ -12,7 +12,7 @@ androidx-activity = "1.13.0"
 androidx-lifecycle = "2.11.0"
 androidx-window = "1.5.1"
 androidx-lifecycle-viewmodel-navigation3 = "2.11.0"
-androidx-navigation3 = "1.1.4"
+androidx-navigation3 = "1.1.5"
 androidx-graphics-shapes = "1.1.0"
 androidx-material-icons = "1.7.8"
 androidx-compose-ui-test = "1.11.4"
@@ -26,7 +26,7 @@ compose-material3 = "1.11.0-alpha07"
 kotlin = "2.4.10"
 ksp = "2.3.10"
 mokkery = "3.4.2"
-ktor = "3.5.1"
+ktor = "3.5.2"
 # DEV CHANNEL — resolved from the `kxrpc-grpc` redirector (see settings.gradle.kts). Migrate to
 # kotlinx-rpc 0.11.x stable on Maven Central once it ships with the KRPC-560 fix, then delete the
 # `kxrpc-grpc` redirector entries in settings.gradle.kts. Part of the Swift Export upgrade UNIT above.
@@ -45,7 +45,7 @@ slf4j = "2.0.18"
 # Room 3 — group `androidx.room3`, artifacts `room3-*`, plugin id `androidx.room3`.
 # Room 3 is a deliberate break from 2.x (coroutines-only DAOs, SQLiteDriver-only, KSP-only,
 # Kotlin-only codegen), which is why the coordinates changed rather than the version bumping.
-room = "3.0.0"
+room = "3.0.1"
 # androidx.sqlite 2.7.0 is Room 3.0.0's pairing release (both shipped 2026-07-01) and adds the
 # js/wasmJs targets plus sqlite-web's WebWorkerSQLiteDriver.
 room-sqlite = "2.7.0"
@@ -58,7 +58,7 @@ aboutlibraries = "15.0.4"
 
 
 # Desktop
-logback = "1.6.0"
+logback = "1.6.1"
 jmdns = "3.6.3"
 javacpp = "1.5.13"
 ffmpeg-javacpp = "8.0.1-1.5.13"
@@ -70,7 +70,7 @@ material3-adaptive-multiplatform = "1.2.0"
 
 # Quality Tool
 detekt = "2.0.0-alpha.5"
-spotless = "8.8.0"
+spotless = "8.9.0"
 ktlint = "1.8.0" # Used by Spotless plugin at runtime
 kover = "0.9.9"
 atomicfu = "0.33.0"

--- a/tools/scripts/verify-r8-rpc-surface.sh
+++ b/tools/scripts/verify-r8-rpc-surface.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Assert every @Rpc service interface survives R8 in a built Android artifact.
+#
+# WHY THIS EXISTS
+# kotlinx.rpc ships NO consumer ProGuard/R8 rules of its own (verified against the
+# 0.11.0 artifacts), unlike Compose, Room, Ktor, Koin and kotlinx.serialization. Its
+# client resolves each @Rpc service by interface name to build the proxy, so if R8
+# renames them the app cannot open a single RPC call — and because the whole app
+# surface is RPC, it cannot reach any server at all.
+#
+# That failure is invisible to every other gate: it only affects `release` (where
+# isMinifyEnabled = true), it throws before a socket is opened, it is caught and
+# mapped to a generic AppError, and release builds strip logging. ListenUp 0.8.0
+# (versionCode 2756) shipped to Play in exactly that state — no tester could get
+# past the "Connect to Server" screen.
+#
+# Usage: verify-r8-rpc-surface.sh <path-to-.apk-or-.aab>
+set -euo pipefail
+
+ARTIFACT="${1:-}"
+if [[ -z "$ARTIFACT" || ! -f "$ARTIFACT" ]]; then
+    echo "usage: $(basename "$0") <path-to-.apk-or-.aab>" >&2
+    exit 2
+fi
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+API_DIR="$REPO_ROOT/contract/src/commonMain/kotlin/com/calypsan/listenup/api"
+
+# Source of truth: the interfaces actually annotated @Rpc, so the gate tracks the
+# contract instead of a list that rots.
+mapfile -t SERVICES < <(grep -rl '^@Rpc' "$API_DIR" --include='*.kt' | xargs -r -n1 basename | sed 's/\.kt$//' | sort -u)
+
+if [[ ${#SERVICES[@]} -eq 0 ]]; then
+    echo "FAIL: found no @Rpc interfaces under $API_DIR — has the contract moved?" >&2
+    exit 1
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+unzip -q -o "$ARTIFACT" '*.dex' -d "$WORK" 2>/dev/null || true
+
+shopt -s globstar nullglob
+DEX_FILES=("$WORK"/**/*.dex)
+if [[ ${#DEX_FILES[@]} -eq 0 ]]; then
+    echo "FAIL: no .dex found in $ARTIFACT" >&2
+    exit 1
+fi
+
+DEX_STRINGS="$WORK/strings.txt"
+strings "${DEX_FILES[@]}" > "$DEX_STRINGS"
+
+missing=()
+for svc in "${SERVICES[@]}"; do
+    # DEX stores types as descriptors: Lcom/calypsan/listenup/api/BookService;
+    if ! grep -q "com/calypsan/listenup/api/${svc}" "$DEX_STRINGS"; then
+        missing+=("$svc")
+    fi
+done
+
+if [[ ${#missing[@]} -gt 0 ]]; then
+    cat >&2 <<EOF
+FAIL: R8 stripped or renamed ${#missing[@]} of ${#SERVICES[@]} @Rpc service interfaces.
+
+Missing from $(basename "$ARTIFACT"):
+$(printf '  - %s\n' "${missing[@]}")
+
+The app will fail EVERY server connection with a generic error and no network
+activity. Check that app/androidApp/proguard-rules.pro still contains:
+
+    -keep @kotlinx.rpc.annotations.Rpc interface * { *; }
+EOF
+    exit 1
+fi
+
+# Keeping the interfaces is NOT sufficient, and checking only for them gave a FALSE
+# GREEN on a build that still could not open a socket. R8 had also stripped the
+# reflective runtime that builds a proxy FROM those interfaces. Measured on real
+# artifacts: a broken build carried 1 kotlinx/rpc class path and no serviceDescriptorOf;
+# a verified-working one carried 103 and had it. The floor is deliberately well below
+# 103 so ordinary dependency churn doesn't trip it, but far above the broken value.
+MIN_RPC_RUNTIME_CLASSES=20
+runtime_classes=$(grep -oE "kotlinx/rpc/[a-zA-Z0-9/_]+" "$DEX_STRINGS" | sort -u | wc -l)
+has_descriptor=$(grep -c "serviceDescriptorOf" "$DEX_STRINGS" || true)
+
+if [[ "$runtime_classes" -lt "$MIN_RPC_RUNTIME_CLASSES" || "$has_descriptor" -eq 0 ]]; then
+    cat >&2 <<EOF
+FAIL: the @Rpc interfaces survived but the kotlinx.rpc RUNTIME did not.
+
+  kotlinx/rpc class paths : $runtime_classes (need >= $MIN_RPC_RUNTIME_CLASSES)
+  serviceDescriptorOf     : $([[ "$has_descriptor" -gt 0 ]] && echo present || echo MISSING)
+
+An interface R8 cannot build a proxy from is as useless as one it renamed — the app
+still fails every connection with no network activity. Check that
+app/androidApp/proguard-rules.pro still contains:
+
+    -keep class kotlinx.rpc.** { *; }
+    -keep class com.calypsan.listenup.api.** { *; }
+EOF
+    exit 1
+fi
+
+echo "OK: ${#SERVICES[@]} @Rpc interfaces + kotlinx.rpc runtime ($runtime_classes classes, serviceDescriptorOf present) in $(basename "$ARTIFACT")"


### PR DESCRIPTION
0.8.0 (versionCode 2756) is the first build with `isMinifyEnabled = true`, and it shipped to Play **unable to reach any server at all**. No tester could get past the "Connect to Server" screen.

## Cause

kotlinx.rpc ships **no consumer R8 rules** — unlike kotlinx.serialization, room-runtime, koin-android and media3, all of which do. R8 renamed all 26 `@Rpc` service interfaces *and* stripped the kotlinx.rpc runtime. The client resolves services reflectively by interface name, so proxy construction throws **before a socket is opened**.

Every symptom pointed away from the cause: identical failure on LAN and remote (it never reaches transport), mDNS discovery still works via the system `NsdManager` so the UI shows the server "Online" (that badge reads the mDNS TXT `version=`, not a network call), and it surfaces as the generic `ServerConnectError.VerificationFailed` — the `else` branch of `mapFailure`. Release builds emit no logcat output, so there was nothing to read.

**The diagnostic that ends the search is sampling sockets during a connect attempt.** No socket opened ⇒ the failure is pre-transport, and the network, VPN, DNS, TLS, proxy and permissions are all irrelevant.

## Fix

Keeping only the interfaces was tried first and was **not** sufficient — still no socket. A DEX diff against a working debug build showed R8 had also removed the machinery that reads them: `serviceDescriptorOf` absent, and 1 `kotlinx/rpc` class path versus 103 in debug. Hence the runtime and the generated per-service stubs are kept too. `Signature` is added to `-keepattributes` because kotlinx.rpc reads generic return types (`AppResult<T>`, `Flow<T>`) off the interface to pick a deserializer.

The breadth is deliberate and documented in the file, against its usual narrowest-possible policy.

## Verification

On-device, **minified** release build on a Pixel:

- Discovery → server selected → **Create Admin Account** reached
- Server logged `GET /api/rpc/public -> 101 (66389ms)`

| Artifact | `verify-r8-rpc-surface.sh` |
|---|---|
| Shipped 0.8.0 | `FAIL — 26 of 26 interfaces missing` |
| This branch | `OK — 26 interfaces + 103 runtime classes + serviceDescriptorOf` |

## Gate

`tools/scripts/verify-r8-rpc-surface.sh` runs in `release.yml` between the build and the Play upload. It enumerates `@Rpc` interfaces from `:contract` rather than a hardcoded list, and asserts the runtime survived as well — an earlier version checked only interface names and **gave a false green on a still-broken build**.

## Dependency bumps

ktor 3.5.1→3.5.2, room 3.0.0→3.0.1, navigation3 1.1.4→1.1.5, benchmark/baselineprofile alpha07→beta01, logback 1.6.0→1.6.1, spotless 8.8.0→8.9.0. All patch or alpha→beta; Kotlin and KSP unchanged, so no coupled-toolchain risk. `aboutlibraries.json` regenerated via `:app:sharedUI:exportLibraryDefinitions`. The release APK was rebuilt and re-gated against these — R8 behaviour is unchanged.

## Gates

`verifyLocal` green. One flake en route (`DemoProfileBootTest`, `InvalidCredentials` after a 5s retry window — async demo-seed racing login under full-gate load); passed clean on an isolated `:server:jvmTest` re-run, 2790 tests.