### PR TITLE
🐛 fix(sharedUI): cast scallop shadows from a convex shape (ANR)

### DIFF
--- a/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/NoConcaveShapeShadowsRule.kt
+++ b/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/konsist/NoConcaveShapeShadowsRule.kt
@@ -1,0 +1,46 @@
+package com.calypsan.listenup.konsist
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Elevation shadows must never be cast from a concave shape.
+ *
+ * Skia tessellates elevation shadows on the RenderThread, and its concave path
+ * branch (`SkBaseShadowTessellator::computeConcaveShadow`) can spin for seconds
+ * per frame on shapes like `MaterialShapes.Cookie9Sided`. When that happens the
+ * main thread blocks in `syncAndDrawFrame`, input freezes, and the system ANRs
+ * the app — observed in production on the alphabet-scrollbar scrub bubble
+ * (app 0.8.1, Pixel 10 Pro XL). Clipping to a concave shape is fine; only the
+ * shadow tessellation is pathological. Cast the shadow from a convex stand-in
+ * (e.g. `CircleShape`) and clip to the decorative shape afterwards.
+ */
+class NoConcaveShapeShadowsRule :
+    FunSpec({
+        test("no Modifier.shadow call uses a concave shape") {
+            // `.shadow(` argument lists may span lines and contain one level of nested
+            // parens (e.g. `cookieScallopShape()`, `if (x) 8.dp else 4.dp`).
+            val shadowArgs = """\.shadow\((?:[^()]|\([^()]*\))*"""
+            // Direct: the concave shape source appears inline in the shadow call.
+            val direct = Regex("""$shadowArgs(?:cookieScallopShape|MaterialShapes\.)""")
+            // Indirect: `val x = cookieScallopShape()` (or MaterialShapes.*) captured
+            // into a local, then passed to `.shadow` as an argument VALUE. Matching the
+            // name only after `=`/`(`/`,` keeps the `shape =` argument LABEL from
+            // colliding with a local that happens to be named `shape`.
+            val concaveVal = Regex("""val\s+(\w+)\s*=\s*(?:cookieScallopShape\(|MaterialShapes\.)""")
+
+            fun usedAsShadowArg(name: String) = Regex("""$shadowArgs[=(,]\s*$name\s*[,)]""")
+
+            val offenders =
+                productionScope()
+                    .files
+                    .filter { file ->
+                        val text = file.text.replace(Regex("""\s+"""), " ")
+                        direct.containsMatchIn(text) ||
+                            concaveVal
+                                .findAll(text)
+                                .any { usedAsShadowArg(it.groupValues[1]).containsMatchIn(text) }
+                    }.map { it.path }
+            offenders shouldBe emptyList()
+        }
+    })

--- a/app/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/AlphabetScrollbar.kt
+++ b/app/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/design/components/AlphabetScrollbar.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -317,7 +318,10 @@ fun AlphabetScrollbar(
                                     y = (selectedLetterY - 36.dp.toPx()).toInt(),
                                 )
                             }.size(72.dp)
-                            .shadow(elevation = 12.dp, shape = cookieScallopShape())
+                            // Shadow must come from a convex shape: Skia's concave-shadow
+                            // tessellator can wedge the RenderThread for seconds on the
+                            // scallop path, freezing input until the system ANRs the app.
+                            .shadow(elevation = 12.dp, shape = CircleShape)
                             .clip(cookieScallopShape())
                             .background(MaterialTheme.colorScheme.primary),
                     contentAlignment = Alignment.Center,

--- a/app/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/library/BookCard.kt
+++ b/app/sharedUI/src/commonMain/kotlin/com/calypsan/listenup/client/features/library/BookCard.kt
@@ -492,18 +492,18 @@ private fun SelectionIndicator(
  */
 @Composable
 private fun CompletionBadge(modifier: Modifier = Modifier) {
-    val shape = cookieScallopShape()
-
     Box(
         modifier =
             modifier
                 .size(28.dp)
+                // Shadow must come from a convex shape: Skia's concave-shadow
+                // tessellator can wedge the RenderThread into an ANR on the scallop.
                 .shadow(
                     elevation = 3.dp,
-                    shape = shape,
+                    shape = CircleShape,
                 ).background(
                     color = MaterialTheme.colorScheme.tertiary,
-                    shape = shape,
+                    shape = cookieScallopShape(),
                 ),
         contentAlignment = Alignment.Center,
     ) {


### PR DESCRIPTION
## The bug

"Alphabet scrollbar crashes the app" (reported on 0.8.1, Pixel 10 Pro XL) is an **ANR, not a crash**: three dropbox reports show the main thread blocked in \`syncAndDrawFrame\` while the RenderThread spins at 100% CPU inside \`SkBaseShadowTessellator::computeConcaveShadow\` — Skia's concave-path shadow tessellator wedging on \`MaterialShapes.Cookie9Sided\`. Input freezes >5s and the system kills the app.

Two sites cast elevation shadows from that concave scallop:
- the alphabet-scrollbar scrub bubble (re-tessellated every animated frame while scrubbing — the reported repro)
- \`CompletionBadge\` on every finished book in the library grid (latent, always rendered)

## The fix

Cast the shadow from \`CircleShape\` (convex — cheap analytic path) and keep \`cookieScallopShape()\` for the visible clip/background silhouette. At these sizes the soft blur makes the shadow silhouettes visually indistinguishable.

## The guard

New Konsist rule \`NoConcaveShapeShadowsRule\` (CI-enforced) fails the build on any \`Modifier.shadow\` fed \`cookieScallopShape()\` / \`MaterialShapes.*\` — both inline and via a local \`val\`. Red/green proven: rule flags both pre-fix files, passes post-fix.

## Verification

- Headless desktop render (ImageComposeScene) of the fixed bubble under a real held touch press: composes and draws cleanly — scalloped bubble, centered letter, soft circular shadow, no artifacts.
- Full \`verifyLocal\` + \`:app:androidApp:assembleDebug\` green.
- On-device re-test lands with the 0.8.3 Play internal build (signature mismatch blocks sideloading over the Play install).