### PR TITLE
:bug: Quote FTS tokens so punctuated names match

### DIFF
--- a/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/common/QueryUtils.kt
+++ b/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/common/QueryUtils.kt
@@ -10,15 +10,17 @@ internal object QueryUtils {
     /** Maximum allowed query length. */
     const val MAX_QUERY_LENGTH = 100
 
-    /** Characters that have special meaning in FTS5 queries. */
-    private val FTS_SPECIAL_CHARS = Regex("[\"*():]")
-
     /**
      * Sanitize a user-provided search query.
      *
      * - Trims whitespace
-     * - Removes FTS5 special characters to prevent injection
      * - Limits length to prevent abuse
+     *
+     * Unlike an earlier version of this function, no characters are stripped here.
+     * FTS5 special characters (quotes, asterisks, parens, colons, punctuation like
+     * "." or "-") are made safe by [toFtsQuery]'s per-token quoting, not by removing
+     * them — stripping a "." out of "R.R." or a "'" out of "O'Brien" would corrupt
+     * the name the user is searching for.
      *
      * @param query Raw user input
      * @param maxLength Maximum allowed length (default 100)
@@ -30,16 +32,25 @@ internal object QueryUtils {
     ): String =
         query
             .trim()
-            .replace(FTS_SPECIAL_CHARS, "")
             .take(maxLength)
 
     /**
      * Convert a user query to FTS5 prefix-match syntax.
      *
-     * Each word gets a trailing asterisk for prefix matching:
-     * "brandon sanderson" -> "brandon* sanderson*"
+     * Each whitespace-separated token becomes a double-quoted FTS5 string literal
+     * with a trailing asterisk for prefix matching: "brandon sanderson" ->
+     * `"brandon"* "sanderson"*`. Multiple quoted terms are ANDed together implicitly,
+     * preserving the existing multi-token match semantics.
      *
-     * This enables "bran" to match "brandon" in search results.
+     * Quoting every token — rather than emitting it as a bareword — is what makes
+     * this safe for punctuated names. An FTS5 bareword may contain only ASCII
+     * alphanumerics, `_`, and codepoints above 127; a "." or "-" or "'" in a bareword
+     * aborts the query parser. Inside a quoted string those characters are just
+     * literal text, so "George R.R. Martin" becomes `"George"* "R.R."* "Martin"*`
+     * instead of failing with a syntax error. A literal `"` in the input is doubled
+     * per FTS5's escaping rule so the quoted string stays well-formed; a literal `*`
+     * typed by the user lands inside the quotes too, so it is matched as ordinary
+     * text rather than acting as a wildcard.
      *
      * @param query Sanitized query (should call [sanitize] first)
      * @return FTS5-formatted query with prefix matching
@@ -48,7 +59,14 @@ internal object QueryUtils {
         query
             .split(Regex("\\s+"))
             .filter { it.isNotBlank() }
-            .joinToString(" ") { "$it*" }
+            .joinToString(" ") { token -> quotePrefixTerm(token) }
+
+    /** Wraps [token] as a double-quoted FTS5 prefix term, doubling any embedded quote. */
+    private fun quotePrefixTerm(token: String): String {
+        val quote = '"'
+        val escaped = token.replace(quote.toString(), "$quote$quote")
+        return "$quote$escaped$quote*"
+    }
 
     /**
      * Convert to FTS5 query with sanitization in one step.

--- a/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/ContributorRepositoryTest.kt
+++ b/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/ContributorRepositoryTest.kt
@@ -115,14 +115,17 @@ class ContributorRepositoryTest :
             }
         }
 
-        test("a query with FTS special characters is sanitized and still searches locally") {
+        test("a query with FTS special characters is quoted per-token, not stripped") {
             runTest {
                 val searchDao = mock<SearchDao>(MockMode.autoUnit)
                 everySuspend { searchDao.searchContributors(any(), any()) } returns emptyList()
 
                 createRepository(searchDao).searchContributors("test*()\":")
 
-                verifySuspend { searchDao.searchContributors(any(), any()) }
+                // Punctuation is neutralized by per-token quoting (QueryUtils.toFtsQuery), not by
+                // stripping it out — a stripped-character query would corrupt punctuated names
+                // like "O'Brien" or "George R.R. Martin".
+                verifySuspend { searchDao.searchContributors("\"test*()\"\":\"*", any()) }
             }
         }
 

--- a/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/common/QueryUtilsTest.kt
+++ b/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/common/QueryUtilsTest.kt
@@ -1,0 +1,46 @@
+package com.calypsan.listenup.client.data.repository.common
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Unit tests for [QueryUtils.toFtsQuery]'s per-token quoting and escaping rules.
+ *
+ * [SearchTokenizerCharacterizationTest] (`:app:sharedLogic` jvmTest) proves these queries
+ * actually match punctuated names against real SQLite FTS5; these tests pin the exact string
+ * shape [QueryUtils.toFtsQuery] produces, independent of a database.
+ */
+class QueryUtilsTest :
+    FunSpec({
+
+        test("a single plain token is wrapped in quotes with a trailing prefix star") {
+            QueryUtils.toFtsQuery("brandon") shouldBe "\"brandon\"*"
+        }
+
+        test("multiple tokens each get their own quoted prefix term, ANDed by a space") {
+            QueryUtils.toFtsQuery("brandon sanderson") shouldBe "\"brandon\"* \"sanderson\"*"
+        }
+
+        test("punctuation inside a token is preserved literally, not stripped") {
+            QueryUtils.toFtsQuery("R.R.") shouldBe "\"R.R.\"*"
+            QueryUtils.toFtsQuery("O'Brien") shouldBe "\"O'Brien\"*"
+            QueryUtils.toFtsQuery("Anne-Marie") shouldBe "\"Anne-Marie\"*"
+        }
+
+        test("an embedded double quote is doubled per FTS5's escaping rule") {
+            QueryUtils.toFtsQuery("6\" record") shouldBe "\"6\"\"\"* \"record\"*"
+        }
+
+        test("a lone asterisk typed by the user lands inside the quotes as literal text") {
+            QueryUtils.toFtsQuery("*") shouldBe "\"*\"*"
+        }
+
+        test("multiple interior spaces collapse to one token boundary, matching prior behaviour") {
+            QueryUtils.toFtsQuery("brandon   sanderson") shouldBe "\"brandon\"* \"sanderson\"*"
+        }
+
+        test("blank input produces an empty query") {
+            QueryUtils.toFtsQuery("") shouldBe ""
+            QueryUtils.toFtsQuery("   ") shouldBe ""
+        }
+    })

--- a/app/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/SearchTokenizerCharacterizationTest.kt
+++ b/app/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/local/db/SearchTokenizerCharacterizationTest.kt
@@ -1,5 +1,6 @@
 package com.calypsan.listenup.client.data.local.db
 
+import com.calypsan.listenup.client.data.repository.common.QueryUtils
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.core.FolderId
@@ -7,6 +8,7 @@ import com.calypsan.listenup.core.LibraryId
 import com.calypsan.listenup.core.Timestamp
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
 
 /**
@@ -14,11 +16,11 @@ import io.kotest.matchers.shouldBe
  * test diff rather than as a user noticing their search got worse.
  *
  * These are characterization tests: they assert *current* behaviour, whatever it is. Their job is
- * to make a deliberate trade visible. The client indexes with `porter` (English stemming) today;
- * the server's `book_search` uses `unicode61 remove_diacritics 2`. Neither supports substring
- * matching, which is what `trigram` buys and what an audiobook library wants most — search intent
- * is dominated by titles, authors and narrators, where stemming does nothing and partial recall
- * ("undat" → *Foundation*) does a great deal.
+ * to make a deliberate trade visible. The client indexes with `trigram` today; the server's
+ * `book_search` uses `unicode61 remove_diacritics 2`. Neither supports English stemming, which is
+ * what `porter` bought and what `trigram` trades away in exchange for substring matching
+ * ("undat" → *Foundation*) — search intent is dominated by titles, authors and narrators, where
+ * stemming does nothing and partial recall does a great deal.
  *
  * Each test names which tokenizer it expects to satisfy it, so the pair reads as a ledger of the
  * trade rather than a set of assertions someone might "fix" in the wrong direction.
@@ -119,5 +121,78 @@ class SearchTokenizerCharacterizationTest :
             val hits = db.searchDao().searchBooks(query = "it")
 
             hits.shouldBeEmpty()
+        }
+
+        // ---- Punctuated names route through QueryUtils.toFtsQuery, not a raw bareword --------
+        //
+        // The trigram tokenizer itself has no trouble with "." or "'" or "-" — the bug lived
+        // entirely in how the client BUILT the MATCH query string. An unquoted bareword may only
+        // contain ASCII alphanumerics, `_`, and codepoints above 127; a "." in "R.R." or a "-" in
+        // "Anne-Marie" aborts FTS5's query parser before trigram ever sees the text. Quoting each
+        // token (QueryUtils.toFtsQuery's fix) makes the punctuation literal instead of a query
+        // parser error. These seed real punctuated names into books_fts and drive the query
+        // through the actual production query builder, so a regression here is a regression a
+        // user would hit.
+
+        suspend fun seedPunctuationFixtures(db: ListenUpDatabase) {
+            seedIndexedBook(db, id = "p1", title = "George R.R. Martin")
+            seedIndexedBook(db, id = "p2", title = "James S.A. Corey")
+            seedIndexedBook(db, id = "p3", title = "O'Brien")
+            seedIndexedBook(db, id = "p4", title = "Anne-Marie Duff")
+            seedIndexedBook(db, id = "p5", title = "Brandon Sanderson")
+        }
+
+        test("a name with embedded periods matches — FAILED before per-token quoting") {
+            val db = createInMemoryTestDatabase()
+            seedPunctuationFixtures(db)
+
+            val hits = db.searchDao().searchBooks(query = QueryUtils.toSanitizedFtsQuery("George R.R. Martin"))
+
+            hits.map { it.book.id.value } shouldContain "p1"
+        }
+
+        test("extra whitespace around the periods still matches — FAILED before per-token quoting") {
+            val db = createInMemoryTestDatabase()
+            seedPunctuationFixtures(db)
+
+            val hits = db.searchDao().searchBooks(query = QueryUtils.toSanitizedFtsQuery("George R. R. Martin"))
+
+            hits.map { it.book.id.value } shouldContain "p1"
+        }
+
+        test("a mid-typing partial name matches via prefix, periods and all") {
+            val db = createInMemoryTestDatabase()
+            seedPunctuationFixtures(db)
+
+            val hits = db.searchDao().searchBooks(query = QueryUtils.toSanitizedFtsQuery("George R."))
+
+            hits.map { it.book.id.value } shouldContain "p1"
+        }
+
+        test("an apostrophe in a surname matches") {
+            val db = createInMemoryTestDatabase()
+            seedPunctuationFixtures(db)
+
+            val hits = db.searchDao().searchBooks(query = QueryUtils.toSanitizedFtsQuery("O'Bri"))
+
+            hits.map { it.book.id.value } shouldContain "p3"
+        }
+
+        test("a hyphenated first name matches") {
+            val db = createInMemoryTestDatabase()
+            seedPunctuationFixtures(db)
+
+            val hits = db.searchDao().searchBooks(query = QueryUtils.toSanitizedFtsQuery("Anne-Marie"))
+
+            hits.map { it.book.id.value } shouldContain "p4"
+        }
+
+        test("plain-name prefix matching still works — regression guard") {
+            val db = createInMemoryTestDatabase()
+            seedPunctuationFixtures(db)
+
+            val hits = db.searchDao().searchBooks(query = QueryUtils.toSanitizedFtsQuery("Brandon Sander"))
+
+            hits.map { it.book.id.value } shouldContain "p5"
         }
     })


### PR DESCRIPTION
## Mechanism

`data/repository/common/QueryUtils.kt` built FTS5 MATCH queries by splitting on
whitespace and appending a trailing `*` per bareword: `George R.R. Martin` became
`George* R.R.* Martin*`. An FTS5 bareword may contain only ASCII alphanumerics,
`_`, and codepoints above 127 — a `.` (or `-`, `'`) in a bareword aborts the query
parser (`fts5: syntax error near "."`). The `SQLiteException` was swallowed in
`ContributorRepositoryImpl.searchLocal` (caught, warned, `emptyList()` returned),
so the UI silently showed zero results for any punctuated name — matching the
"Add" chip appearing in book-edit and users creating near-duplicate contributors.
The same query builder backs `SeriesRepositoryImpl` and the global
`SearchRepositoryImpl`, so global search broke identically.

`sanitize()`'s `FTS_SPECIAL_CHARS` regex stripped a handful of characters
(`"*():`) but not `.`/`-`/`'`, so it neither prevented nor explained the failure.

## Fix

`toFtsQuery` now emits each whitespace-separated token as a double-quoted FTS5
string literal with a trailing prefix star: `"George"* "R.R."* "Martin"*`.
Quoting makes every punctuation character literal instead of bareword syntax —
no more stripping games. Embedded `"` is doubled per FTS5's escaping rule.
`sanitize()` is now trim + length-limit only; quoting (not character removal)
is what makes the query FTS5-safe.

## Test evidence

- `SearchTokenizerCharacterizationTest` (real SQLite, real `tokenize='trigram'`
  tables): added cases for "George R.R. Martin" (exact and with extra spaces),
  "George R." (mid-typing), "O'Bri" → O'Brien, "Anne-Marie" → Duff, and a
  regression guard that "Brandon Sander" still matches Sanderson. Confirmed RED
  first — reverted the fix locally, reran, and the two full-name/extra-space
  cases (plus the apostrophe/hyphen cases) failed with `SQLiteException`
  (`10 tests completed, 5 failed`) before the fix; all 10 pass after. Also
  corrected a stale KDoc claim that the client indexes with `porter` — it's
  been `trigram` since the earlier tokenizer migration.
- `ContributorRepositoryTest`: updated the FTS-special-characters test to assert
  the new quoted query shape reaches the DAO instead of just verifying the call
  happened.
- New `QueryUtilsTest`: direct unit coverage of `toFtsQuery`'s escaping rules
  (single/multi token, embedded `"`, lone `*`, multiple interior spaces, blank
  input).

Ran the two touched specs individually (`--tests`-filtered, XML-verified —
`failures="0" errors="0"` for all three touched test classes) and the full
`:app:sharedLogic:jvmTest` suite (`BUILD SUCCESSFUL`). Also ran `spotlessCheck`
and `detekt` clean (detekt required a small refactor — extracted the quoting
into a `quotePrefixTerm` helper using a `Char` literal to avoid an escaped-string
lint finding).

## Test plan

- [x] `SearchTokenizerCharacterizationTest` green (10/10), RED confirmed pre-fix
- [x] `ContributorRepositoryTest` green (8/8)
- [x] `QueryUtilsTest` green (7/7)
- [x] Full `:app:sharedLogic:jvmTest` green
- [x] `spotlessCheck` + `detekt` clean