### PR TITLE
🐛 fix(server): dedupe same-book credits on contributor/series merge

### DIFF
--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/ContributorServiceImpl.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/ContributorServiceImpl.kt
@@ -189,12 +189,20 @@ internal class ContributorServiceImpl(
         }
 
         // Snapshot the affected books, then re-link junction rows source → target — both over
-        // the single SQLDelight connection, atomically in one mini-transaction. Capturing
-        // source.name into credited_as where it was NULL; books with an explicit override keep
-        // it (COALESCE).
+        // the single SQLDelight connection, atomically in one mini-transaction. A book that
+        // credits BOTH source and target in the same role (duplicate-author spellings from
+        // sloppy embedded metadata) would collide on the composite (book_id, contributor_id,
+        // role) PK when the relink re-points the source row onto the target's — so the
+        // colliding source rows are dropped first; the target's existing row (and its
+        // credited_as) survives untouched. Capturing source.name into credited_as where it was
+        // NULL; books with an explicit override keep it (COALESCE).
         val affectedBookIds =
             sqlTransaction(sqlDb) {
                 val ids = sqlDb.bookContributorsQueries.bookIdsForContributor(source.value).executeAsList()
+                sqlDb.bookContributorsQueries.deleteCollidingSourceContributorRows(
+                    to_id = target.value,
+                    from_id = source.value,
+                )
                 sqlDb.bookContributorsQueries.relinkContributorPreservingCredit(
                     source_name = sourcePayload.name,
                     to_id = target.value,

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/SeriesServiceImpl.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/SeriesServiceImpl.kt
@@ -157,10 +157,18 @@ internal class SeriesServiceImpl(
         }
 
         // Snapshot affected book IDs, then re-link all membership rows source → target — both
-        // over the single SQLDelight connection in one mini-transaction.
+        // over the single SQLDelight connection in one mini-transaction. A book already
+        // belonging to BOTH source and target series (duplicate series entries from sloppy
+        // embedded metadata) would collide on the composite (book_id, series_id) PK when the
+        // relink re-points the source row onto the target's — so the colliding source rows are
+        // dropped first; the target's existing membership row survives untouched.
         val affectedBookIds =
             sqlTransaction(sqlDb) {
                 val ids = sqlDb.bookSeriesMembershipsQueries.bookIdsForSeries(source.value).executeAsList()
+                sqlDb.bookSeriesMembershipsQueries.deleteCollidingSourceSeriesMemberships(
+                    to_id = target.value,
+                    from_id = source.value,
+                )
                 sqlDb.bookSeriesMembershipsQueries.relinkSeries(to_id = target.value, from_id = source.value)
                 ids
             }

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/BookContributors.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/BookContributors.sq
@@ -79,11 +79,32 @@ selectCreditedAs:
 SELECT credited_as FROM book_contributors
 WHERE book_id = :book_id AND contributor_id = :contributor_id;
 
+-- Same-book collision guard for mergeContributors (run BEFORE
+-- relinkContributorPreservingCredit). The composite PK is (book_id,
+-- contributor_id, role); a book that already credits :to_id in some role also
+-- carried by :from_id would collide when the relink UPDATE re-points the
+-- :from_id row onto that same (book_id, role) pair — exactly what duplicate
+-- author spellings ("George R.R. Martin" / "George R. R. Martin") produce from
+-- sloppy embedded metadata. The target row already displays the merged
+-- identity, so the source's colliding row is simply dropped; its credited_as
+-- (if any) is discarded rather than merged.
+deleteCollidingSourceContributorRows:
+DELETE FROM book_contributors
+WHERE contributor_id = :from_id
+  AND EXISTS (
+    SELECT 1 FROM book_contributors existing
+    WHERE existing.book_id = book_contributors.book_id
+      AND existing.contributor_id = :to_id
+      AND existing.role = book_contributors.role
+  );
+
 -- COALESCE credit-preserving relink (mergeContributors). Re-points every junction
 -- row from :from_id to :to_id, capturing the source contributor's display name
 -- into credited_as only where it was previously NULL — books already carrying an
 -- explicit credit keep it. Exposed's update DSL can't express
 -- `SET col = COALESCE(col, ?)`, so this is the typed home for that raw SQL.
+-- Must run AFTER deleteCollidingSourceContributorRows so no (book_id, role) pair
+-- carries both a source and a target row when this UPDATE re-points contributor_id.
 relinkContributorPreservingCredit:
 UPDATE book_contributors
 SET credited_as = COALESCE(credited_as, :source_name), contributor_id = :to_id

--- a/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/BookSeriesMemberships.sq
+++ b/server/src/commonMain/sqldelight/com/calypsan/listenup/server/db/sqldelight/BookSeriesMemberships.sq
@@ -51,9 +51,27 @@ DELETE FROM book_series_memberships WHERE book_id = :book_id;
 deleteAllForSeries:
 DELETE FROM book_series_memberships WHERE series_id = :series_id;
 
+-- Same-book collision guard for mergeSeries (run BEFORE relinkSeries). The
+-- composite PK is (book_id, series_id); a book already belonging to BOTH the
+-- merge source and the merge target series would collide when relinkSeries
+-- re-points the source row onto that same book_id — e.g. duplicate series
+-- entries ("The Expanse" / "Expanse Series") both attached to one book from
+-- sloppy embedded metadata. The target's existing membership row already
+-- reflects the merged identity, so the source's colliding row is simply
+-- dropped.
+deleteCollidingSourceSeriesMemberships:
+DELETE FROM book_series_memberships
+WHERE series_id = :from_id
+  AND EXISTS (
+    SELECT 1 FROM book_series_memberships existing
+    WHERE existing.book_id = book_series_memberships.book_id
+      AND existing.series_id = :to_id
+  );
+
 -- Re-links every membership row from :from_id to :to_id (mergeSeries). Unlike the
 -- contributor merge there is no credited_as equivalent — the canonical name change
--- IS the intended semantic.
+-- IS the intended semantic. Must run AFTER deleteCollidingSourceSeriesMemberships so
+-- no book_id carries both a source and a target row when this UPDATE re-points series_id.
 relinkSeries:
 UPDATE book_series_memberships SET series_id = :to_id WHERE series_id = :from_id;
 

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/ContributorServiceImplMergeTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/ContributorServiceImplMergeTest.kt
@@ -270,6 +270,155 @@ class ContributorServiceImplMergeTest :
             }
         }
 
+        // ── Same-book collision (composite PK (book_id, contributor_id, role)) ─
+
+        test("mergeContributors dedupes when a book credits both source and target in the same role") {
+            withSqlDatabase {
+                val db = this
+                sql.seedTestLibraryAndFolder()
+                val deps = makeServiceAndDeps(db)
+                val service = deps.service
+                val contributorRepo = deps.contributorRepo
+                val bookRepo = deps.bookRepo
+                runTest {
+                    val sourceId = contributorRepo.resolveOrCreate("George R. R. Martin", sortName = null)
+                    val targetId = contributorRepo.resolveOrCreate("George R.R. Martin", sortName = null)
+
+                    // b1 credits BOTH spellings as author — the duplicate-spelling collision case.
+                    bookRepo.upsert(
+                        bookFixtureWithContributors(
+                            "b1",
+                            "A Game of Thrones",
+                            listOf(
+                                BookContributorPayload(
+                                    id = sourceId.value,
+                                    name = "George R. R. Martin",
+                                    sortName = null,
+                                    role = "author",
+                                    creditedAs = null,
+                                ),
+                                BookContributorPayload(
+                                    id = targetId.value,
+                                    name = "George R.R. Martin",
+                                    sortName = null,
+                                    role = "author",
+                                    creditedAs = null,
+                                ),
+                            ),
+                        ),
+                    )
+
+                    val result = service.mergeContributors(sourceId, targetId)
+
+                    result.shouldBeInstanceOf<AppResult.Success<Unit>>()
+                    readBookIdsForContributor(db, sourceId.value).shouldBeEmpty()
+                    bookContributorRowCount(db, "b1", targetId.value, "author") shouldBe 1
+                }
+            }
+        }
+
+        test("mergeContributors preserves both credits when source and target hold different roles on the same book") {
+            withSqlDatabase {
+                val db = this
+                sql.seedTestLibraryAndFolder()
+                val deps = makeServiceAndDeps(db)
+                val service = deps.service
+                val contributorRepo = deps.contributorRepo
+                val bookRepo = deps.bookRepo
+                runTest {
+                    val sourceId = contributorRepo.resolveOrCreate("Stephen King", sortName = null)
+                    val targetId = contributorRepo.resolveOrCreate("Narrator King", sortName = null)
+
+                    // b1: source credited as author, target credited as narrator — no PK collision.
+                    bookRepo.upsert(
+                        bookFixtureWithContributors(
+                            "b1",
+                            "It",
+                            listOf(
+                                BookContributorPayload(
+                                    id = sourceId.value,
+                                    name = "Stephen King",
+                                    sortName = null,
+                                    role = "author",
+                                    creditedAs = null,
+                                ),
+                                BookContributorPayload(
+                                    id = targetId.value,
+                                    name = "Narrator King",
+                                    sortName = null,
+                                    role = "narrator",
+                                    creditedAs = null,
+                                ),
+                            ),
+                        ),
+                    )
+
+                    val result = service.mergeContributors(sourceId, targetId)
+
+                    result.shouldBeInstanceOf<AppResult.Success<Unit>>()
+                    // Both roles survive on target — the relinked author credit and the
+                    // pre-existing narrator credit.
+                    bookContributorRowCount(db, "b1", targetId.value, "author") shouldBe 1
+                    bookContributorRowCount(db, "b1", targetId.value, "narrator") shouldBe 1
+                    creditedAsForRole(db, "b1", targetId.value, "author") shouldBe "Stephen King"
+                }
+            }
+        }
+
+        test("mergeContributors dedupes a colliding book while preserving creditedAs on a non-colliding book") {
+            withSqlDatabase {
+                val db = this
+                sql.seedTestLibraryAndFolder()
+                val deps = makeServiceAndDeps(db)
+                val service = deps.service
+                val contributorRepo = deps.contributorRepo
+                val bookRepo = deps.bookRepo
+                runTest {
+                    val sourceId = contributorRepo.resolveOrCreate("Richard Bachman", sortName = null)
+                    val targetId = contributorRepo.resolveOrCreate("Stephen King", sortName = null)
+
+                    // Book A: source and target both credited as author on the same book — collides.
+                    bookRepo.upsert(
+                        bookFixtureWithContributors(
+                            "book-a",
+                            "The Long Walk",
+                            listOf(
+                                BookContributorPayload(
+                                    id = sourceId.value,
+                                    name = "Richard Bachman",
+                                    sortName = null,
+                                    role = "author",
+                                    creditedAs = null,
+                                ),
+                                BookContributorPayload(
+                                    id = targetId.value,
+                                    name = "Stephen King",
+                                    sortName = null,
+                                    role = "author",
+                                    creditedAs = null,
+                                ),
+                            ),
+                            rootRelPath = "Bachman/TheLongWalk",
+                        ),
+                    )
+                    // Book B: only source credited — relinks normally, no collision.
+                    bookRepo.upsert(
+                        bookFixtureForMerge("book-b", "Thinner", sourceId, "Richard Bachman", rootRelPath = "Bachman/Thinner"),
+                    )
+
+                    val result = service.mergeContributors(sourceId, targetId)
+
+                    result.shouldBeInstanceOf<AppResult.Success<Unit>>()
+                    readBookIdsForContributor(db, sourceId.value).shouldBeEmpty()
+                    // Book A deduplicated to a single target row.
+                    bookContributorRowCount(db, "book-a", targetId.value, "author") shouldBe 1
+                    // Book B relinked normally, creditedAs captured from the source's name.
+                    bookContributorRowCount(db, "book-b", targetId.value, "author") shouldBe 1
+                    creditedAsFor(db, "book-b", targetId.value) shouldBe "Richard Bachman"
+                }
+            }
+        }
+
         // ── FTS reindex ────────────────────────────────────────────────────────
     })
 
@@ -375,6 +524,94 @@ private fun bookFixtureForMerge(
         createdAt = 0L,
         deletedAt = null,
     )
+
+/**
+ * Builds a [BookSyncPayload] with an arbitrary set of contributor credits — used by the
+ * same-book collision tests, which need more than one contributor row per book.
+ */
+private fun bookFixtureWithContributors(
+    id: String,
+    title: String,
+    contributors: List<BookContributorPayload>,
+    rootRelPath: String = "books/$id",
+): BookSyncPayload =
+    BookSyncPayload(
+        id = id,
+        libraryId = LibraryId("test-library"),
+        folderId = FolderId("test-folder"),
+        title = title,
+        sortTitle = title,
+        subtitle = null,
+        description = null,
+        publishYear = null,
+        publisher = null,
+        language = null,
+        isbn = null,
+        asin = null,
+        abridged = false,
+        explicit = false,
+        hasScanWarning = false,
+        totalDuration = 3_600_000L,
+        cover = null,
+        rootRelPath = rootRelPath,
+        inode = null,
+        scannedAt = 1_730_000_000_000L,
+        contributors = contributors,
+        series = emptyList(),
+        audioFiles =
+            listOf(
+                BookAudioFilePayload(
+                    id = "af-$id",
+                    index = 0,
+                    filename = "01.m4b",
+                    format = "m4b",
+                    codec = "aac",
+                    duration = 3_600_000L,
+                    size = 500_000_000L,
+                ),
+            ),
+        chapters =
+            listOf(
+                BookChapterPayload(id = "ch-$id", title = "Prologue", duration = 1_000_000L, startTime = 0L),
+            ),
+        revision = 0L,
+        updatedAt = 0L,
+        createdAt = 0L,
+        deletedAt = null,
+    )
+
+/** Count of `book_contributors` rows for (bookId, contributorId, role) — expected 0 or 1. */
+private suspend fun bookContributorRowCount(
+    db: SqlTestDatabases,
+    bookId: String,
+    contributorId: String,
+    role: String,
+): Int =
+    withContext(Dispatchers.IO) {
+        db.sql.bookContributorsQueries
+            .selectByBookIds(listOf(bookId))
+            .executeAsList()
+            .count { it.contributor_id == contributorId && it.role == role }
+    }
+
+/**
+ * Reads the `credited_as` column for the (bookId, contributorId, role) junction row —
+ * role-scoped, unlike [creditedAsFor], so it stays correct when a contributor holds more
+ * than one role on the same book (e.g. author + narrator after a merge).
+ */
+private suspend fun creditedAsForRole(
+    db: SqlTestDatabases,
+    bookId: String,
+    contributorId: String,
+    role: String,
+): String? =
+    withContext(Dispatchers.IO) {
+        db.sql.bookContributorsQueries
+            .selectByBookIds(listOf(bookId))
+            .executeAsList()
+            .firstOrNull { it.contributor_id == contributorId && it.role == role }
+            ?.credited_as
+    }
 
 /** Distinct book IDs currently linked to [contributorId] via any junction row. */
 private suspend fun readBookIdsForContributor(

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/SeriesServiceImplMergeTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/SeriesServiceImplMergeTest.kt
@@ -27,6 +27,7 @@ import com.calypsan.listenup.server.testing.seedTestLibraryAndFolder
 import com.calypsan.listenup.server.testing.withSqlDatabase
 import com.calypsan.listenup.server.testing.rootPrincipal
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -167,6 +168,73 @@ class SeriesServiceImplMergeTest :
             }
         }
 
+        // ── Same-book collision (composite PK (book_id, series_id)) ─────────────
+
+        test("mergeSeries dedupes when a book already belongs to both source and target series") {
+            withSqlDatabase {
+                val dbs = this
+                sql.seedTestLibraryAndFolder()
+                val deps = makeMergeSeriesServiceAndDeps(dbs)
+                runTest {
+                    val sourceId = deps.seriesRepo.resolveOrCreate("The Expanse")
+                    val targetId = deps.seriesRepo.resolveOrCreate("Expanse Series")
+
+                    // b1 belongs to BOTH series entries — the duplicate-series collision case.
+                    deps.bookRepo.upsert(
+                        bookFixtureForSeriesMergeWithMemberships(
+                            "b1",
+                            "Leviathan Wakes",
+                            listOf(
+                                BookSeriesPayload(id = sourceId.value, name = "The Expanse", sequence = "1"),
+                                BookSeriesPayload(id = targetId.value, name = "Expanse Series", sequence = "1"),
+                            ),
+                        ),
+                    )
+
+                    val result = deps.service.mergeSeries(sourceId, targetId)
+
+                    result.shouldBeInstanceOf<AppResult.Success<Unit>>()
+                    bookIdsForSeriesInTest(dbs, sourceId.value).shouldBeEmpty()
+                    bookIdsForSeriesInTest(dbs, targetId.value) shouldBe listOf("b1")
+                }
+            }
+        }
+
+        test("mergeSeries dedupes a colliding book while relinking a non-colliding book normally") {
+            withSqlDatabase {
+                val dbs = this
+                sql.seedTestLibraryAndFolder()
+                val deps = makeMergeSeriesServiceAndDeps(dbs)
+                runTest {
+                    val sourceId = deps.seriesRepo.resolveOrCreate("Source Series")
+                    val targetId = deps.seriesRepo.resolveOrCreate("Target Series")
+
+                    // Book A belongs to both — collides.
+                    deps.bookRepo.upsert(
+                        bookFixtureForSeriesMergeWithMemberships(
+                            "book-a",
+                            "Book A",
+                            listOf(
+                                BookSeriesPayload(id = sourceId.value, name = "Source Series", sequence = "1"),
+                                BookSeriesPayload(id = targetId.value, name = "Target Series", sequence = "1"),
+                            ),
+                            rootRelPath = "books/book-a",
+                        ),
+                    )
+                    // Book B belongs only to source — relinks normally.
+                    deps.bookRepo.upsert(
+                        bookFixtureForSeriesMerge("book-b", "Book B", sourceId, rootRelPath = "books/book-b"),
+                    )
+
+                    val result = deps.service.mergeSeries(sourceId, targetId)
+
+                    result.shouldBeInstanceOf<AppResult.Success<Unit>>()
+                    bookIdsForSeriesInTest(dbs, sourceId.value).shouldBeEmpty()
+                    bookIdsForSeriesInTest(dbs, targetId.value) shouldBe listOf("book-a", "book-b")
+                }
+            }
+        }
+
         // ── FTS reindex ────────────────────────────────────────────────────────
     })
 
@@ -244,6 +312,61 @@ private fun bookFixtureForSeriesMerge(
                     sequence = sequence,
                 ),
             ),
+        audioFiles =
+            listOf(
+                BookAudioFilePayload(
+                    id = "af-$id",
+                    index = 0,
+                    filename = "01.m4b",
+                    format = "m4b",
+                    codec = "aac",
+                    duration = 3_600_000L,
+                    size = 500_000_000L,
+                ),
+            ),
+        chapters =
+            listOf(
+                BookChapterPayload(id = "ch-$id", title = "Prologue", duration = 1_000_000L, startTime = 0L),
+            ),
+        revision = 0L,
+        updatedAt = 0L,
+        createdAt = 0L,
+        deletedAt = null,
+    )
+
+/**
+ * Builds a [BookSyncPayload] with an arbitrary set of series memberships — used by the
+ * same-book collision tests, which need more than one series entry per book.
+ */
+private fun bookFixtureForSeriesMergeWithMemberships(
+    id: String,
+    title: String,
+    seriesEntries: List<BookSeriesPayload>,
+    rootRelPath: String = "books/$id",
+): BookSyncPayload =
+    BookSyncPayload(
+        id = id,
+        libraryId = LibraryId("test-library"),
+        folderId = FolderId("test-folder"),
+        title = title,
+        sortTitle = title,
+        subtitle = null,
+        description = null,
+        publishYear = null,
+        publisher = null,
+        language = null,
+        isbn = null,
+        asin = null,
+        abridged = false,
+        explicit = false,
+        hasScanWarning = false,
+        totalDuration = 3_600_000L,
+        cover = null,
+        rootRelPath = rootRelPath,
+        inode = null,
+        scannedAt = 1_730_000_000_000L,
+        contributors = emptyList(),
+        series = seriesEntries,
         audioFiles =
             listOf(
                 BookAudioFilePayload(


### PR DESCRIPTION
## Mechanism

`book_contributors`' PK is `(book_id, contributor_id, role)`. `relinkContributorPreservingCredit` (mergeContributors' junction relink) has no conflict handling: `UPDATE book_contributors SET contributor_id = :to_id WHERE contributor_id = :from_id`. When a single book credits BOTH the merge source and the merge target in the same role — exactly what duplicate-author spellings like "George R.R. Martin" / "George R. R. Martin" produce from sloppy embedded metadata — the UPDATE collides on the composite PK and the whole merge throws a `SQLITE_CONSTRAINT_PRIMARYKEY` exception instead of returning `AppResult`.

`book_series_memberships` has the identical shape: PK `(book_id, series_id)`, and `relinkSeries` has the same unguarded `UPDATE`. A book already belonging to both the source and target series (e.g. duplicate series entries "The Expanse" / "Expanse Series") collides the same way.

## Fix

Added a collision-guard DELETE that runs before each relink UPDATE, inside the existing `sqlTransaction`:
- `BookContributors.sq`: `deleteCollidingSourceContributorRows` drops a source row when a `(book_id, role)` pair already has a target row.
- `BookSeriesMemberships.sq`: `deleteCollidingSourceSeriesMemberships` drops a source membership when the book already belongs to the target series.

In both cases the target's existing row (and its `credited_as`, if any) survives untouched — the surviving contributor/series IS the displayed identity. Non-colliding source rows continue to relink exactly as before, `credited_as` preserved via `COALESCE`.

`ContributorServiceImpl.mergeCore` and `SeriesServiceImpl.mergeCore` call the new delete query immediately before the existing relink query, both inside the pre-existing `sqlTransaction` block.

## Test evidence

TDD: wrote the new tests first against the unfixed code (temporarily reverted the fix), confirmed RED — `SQLITE_CONSTRAINT_PRIMARYKEY` on the colliding-book tests. Reapplied the fix, confirmed GREEN.

- `ContributorServiceImplMergeTest`: 11/11 passing (`tests="11" skipped="0" failures="0" errors="0"`) — 3 new tests: same-book-same-role collision dedupes to one row, different-role credits on the same book both survive untouched, and a mixed case (one colliding book + one non-colliding book with `credited_as` preservation).
- `SeriesServiceImplMergeTest`: 8/8 passing (`tests="8" skipped="0" failures="0" errors="0"`) — 2 new tests: same-book collision dedupes, and a mixed colliding/non-colliding case.
- Full `:server:jvmTest`: BUILD SUCCESSFUL, 2796 tests / 0 failures / 0 errors.
- `spotlessCheck` and `detekt`: both green.

## Concerns

None — the series-merge shape was confirmed to collide identically to the contributor case, so it's fixed in the same PR per the task brief.