### PR TITLE
:bug: Fix zombie NowPlayingViewModel (frozen mini player after store clear)

### DIFF
--- a/app/sharedLogic/src/androidHostTest/kotlin/com/calypsan/listenup/client/di/KoinModuleVerifyTest.kt
+++ b/app/sharedLogic/src/androidHostTest/kotlin/com/calypsan/listenup/client/di/KoinModuleVerifyTest.kt
@@ -68,7 +68,8 @@ class KoinModuleVerifyTest :
             )
         }
 
-        // Verify [playbackPresentationModule] — the single shared playback VM is bound as `single`.
+        // Verify [playbackPresentationModule] — NowPlayingViewModel is bound as `factory`, plus its
+        // two process-lifetime collaborators (PlaybackControllerActivator, NowPlayingSheetState).
         // This module was previously not covered by module.verify().
         //
         // `extraTypes` enumerates cross-module dependencies that other Koin modules satisfy.

--- a/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/PlaybackPresentationModule.kt
+++ b/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/di/PlaybackPresentationModule.kt
@@ -1,30 +1,48 @@
 package com.calypsan.listenup.client.di
 
+import com.calypsan.listenup.client.playback.PlaybackControllerActivator
+import com.calypsan.listenup.client.presentation.nowplaying.NowPlayingSheetState
 import com.calypsan.listenup.client.presentation.nowplaying.NowPlayingViewModel
 import org.koin.dsl.module
 
 /**
  * Koin module providing the playback presentation layer.
  *
- * Currently exposes [NowPlayingViewModel] as the single playback VM consumed by
- * Android, Desktop, and iOS.
+ * Exposes [NowPlayingViewModel] — the playback VM consumed by Android and Desktop (iOS drives
+ * playback through its own native `PlayerCoordinator`, not this module) — plus the two
+ * process-lifetime collaborators that let it be a plain `factory` like every other ViewModel:
  *
- * Bound as `single` — the deliberate, documented exception to the "VMs are `factory`" rule (the
- * guard test `no ViewModel is registered as a Koin singleton` allows exactly this one). Its `init`
- * acquires a process-singleton playback controller (`playbackController.acquire()`) and it has two
- * `koinViewModel()` consumers in separate nav stores (the shell mini-player and the document
- * viewer), so a `factory` would create two instances and double-acquire the controller. (The earlier
- * rationale here cited `LibraryViewModel` as a `single` precedent; that is stale — `LibraryViewModel`
- * is now a `factory`, because a singleton VM zombies when its owning store is cleared.) The correct
- * end state is to extract the controller acquisition into a singleton service so this VM can become a
- * pure `factory` projection too — tracked in `docs/superpowers/followups.md`.
+ * - [PlaybackControllerActivator] (`createdAtStart = true`) acquires the `PlaybackController`
+ *   connection once at Koin startup. This used to happen in `NowPlayingViewModel.init`, which
+ *   forced the VM itself to be a `single` — the app's one documented exception to the "VMs are
+ *   `factory`" rule — because a `factory` would create a fresh instance (and double-acquire the
+ *   controller) at each of its two `koinViewModel()` consumers (the shell mini-player and the
+ *   document viewer). Extracting acquisition here removes that constraint entirely.
+ * - [NowPlayingSheetState] holds the sheet's expand/collapse `StateFlow` so every VM instance —
+ *   now one per owning store — reads and writes the SAME expansion state, rather than each
+ *   instance owning its own (which would desync the shell and document-viewer sheets).
+ *
+ * Binding [NowPlayingViewModel] as a `single` was the proximate cause of a zombie-VM bug: when
+ * either owning `ViewModelStore` cleared (an overnight Activity destroy with the process
+ * retained; popping the document viewer), `onCleared()` permanently cancelled the singleton's
+ * `viewModelScope`, and Koin kept re-serving that same dead instance forever — frozen play/pause
+ * icon, a back-swipe that fell through to the screen behind the sheet, and a mini player that
+ * never came back. As a plain `factory`, a store clearing kills only that store's VM instance;
+ * the next `koinViewModel()` call builds a fresh one over the live singletons above, so playback
+ * command state, expansion state, and the controller connection are all correct by construction.
  *
  * `viewModelOf` is not used because it ships in `koin-compose-viewmodel`, which is not on the
  * shared classpath; `factory { }` is the commonMain equivalent.
  */
 internal val playbackPresentationModule =
     module {
-        single {
+        single { NowPlayingSheetState() }
+
+        single(createdAtStart = true) {
+            PlaybackControllerActivator(playbackController = get())
+        }
+
+        factory {
             NowPlayingViewModel(
                 playbackManager = get(),
                 bookRepository = get(),
@@ -35,6 +53,7 @@ internal val playbackPresentationModule =
                 documentRepository = get(),
                 downloadRepository = get(),
                 playbackPositionRepository = get(),
+                sheetState = get(),
             )
         }
     }

--- a/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackControllerActivator.kt
+++ b/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackControllerActivator.kt
@@ -1,0 +1,28 @@
+package com.calypsan.listenup.client.playback
+
+/**
+ * Acquires the process-lifetime [PlaybackController] connection at Koin startup.
+ *
+ * Bound `single(createdAtStart = true)` in `playbackPresentationModule`, so [PlaybackController.acquire]
+ * runs exactly once per process, independent of any ViewModelStore. This used to live in
+ * `NowPlayingViewModel.init`, which forced that ViewModel to be a Koin `single` — the only
+ * ViewModel in the app not scoped per-store — because a `factory` VM would double-acquire across
+ * its two `koinViewModel()` consumers (the shell mini-player and the document viewer). Acquiring
+ * here instead lets [com.calypsan.listenup.client.presentation.nowplaying.NowPlayingViewModel] be
+ * a plain `factory` like every other ViewModel, closing the zombie-VM hazard: previously, when
+ * either owning store cleared, `onCleared()` permanently cancelled the singleton's
+ * `viewModelScope`, and Koin kept re-serving the same dead instance forever (frozen play/pause
+ * icon, dead back-swipe, a mini player that never reappeared).
+ *
+ * [PlaybackController.acquire] is refcounted and idempotent on Android (see
+ * `MediaControllerHolder`) and a no-op on Desktop/Apple, so acquiring once here — with no matching
+ * `release()` — is safe: the connection is established on first acquire and held for the
+ * process's lifetime, which is exactly the intended lifecycle.
+ */
+internal class PlaybackControllerActivator(
+    playbackController: PlaybackController,
+) {
+    init {
+        playbackController.acquire()
+    }
+}

--- a/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackManager.kt
+++ b/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackManager.kt
@@ -109,6 +109,15 @@ interface PlaybackManager :
      */
     fun onSpeedReset(defaultSpeed: Float)
 
+    /**
+     * Clear a latched [playbackError] immediately.
+     *
+     * Called by the VM when the user re-initiates play/resume, so the mini player reappears
+     * right away instead of waiting for the async Playing-state confirmation (which also clears
+     * it, in [PlaybackManagerImpl.setPlaybackState]) to arrive from the platform player.
+     */
+    fun clearError()
+
     // ====================================================================
     // Nested types
     //

--- a/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerImpl.kt
+++ b/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerImpl.kt
@@ -512,7 +512,7 @@ internal class PlaybackManagerImpl(
      * Clear the current playback error.
      * Called when user dismisses the error or error condition is resolved.
      */
-    fun clearError() {
+    override fun clearError() {
         playbackError.value = null
     }
 

--- a/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingSheetState.kt
+++ b/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingSheetState.kt
@@ -1,0 +1,32 @@
+package com.calypsan.listenup.client.presentation.nowplaying
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Process-lifetime holder for the Now Playing sheet's expand/collapse state.
+ *
+ * [NowPlayingViewModel] is a Koin `factory` — each `koinViewModel()` call site (the shell
+ * mini-player's Activity-scoped store, the document viewer's nav-entry-scoped store) is served
+ * its own instance. Expansion state must be visible to every one of them, so it lives here
+ * instead of on the VM: a `factory`-scoped `MutableStateFlow` would desync the moment either
+ * owning store is cleared and a fresh VM is served in its place — the new instance would start
+ * collapsed even though the sheet was showing full-screen a moment ago from the other owner's
+ * perspective.
+ *
+ * Bound as a Koin `single`. Starting collapsed on process start (and surviving Activity
+ * recreation within a live process, since the singleton outlives any one Activity) is
+ * deliberate — a fresh process should never open straight to the full-screen player.
+ */
+internal class NowPlayingSheetState {
+    val isExpanded: StateFlow<Boolean>
+        field = MutableStateFlow(false)
+
+    fun expand() {
+        isExpanded.value = true
+    }
+
+    fun collapse() {
+        isExpanded.value = false
+    }
+}

--- a/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingViewModel.kt
+++ b/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingViewModel.kt
@@ -61,12 +61,16 @@ private val logger = KotlinLogging.logger {}
  *
  * All command-side operations route through [PlaybackController].
  *
- * Lifecycle: Bound as a Koin `single` — survives recomposition
- * and lives for the process lifetime. `init { playbackController.acquire() }` establishes
- * the MediaController connection on first resolution and holds it for the process;
- * `onCleared` never fires, so a matching `release()` would be dead code. The
- * PlaybackController object's Koin singleton lifetime does **not** establish the
- * connection — only `acquire()` does.
+ * Lifecycle: a plain Koin `factory` — `koinViewModel()` scopes a fresh instance to each owning
+ * `ViewModelStore` (the shell's Activity-scoped store and the document viewer's nav-entry-scoped
+ * store), exactly like every other ViewModel. The two process-lifetime pieces that used to force
+ * this VM into being the app's sole `single` ViewModel now live outside it:
+ * [PlaybackController] acquisition happens once at Koin startup via
+ * `PlaybackControllerActivator`, and expand/collapse state lives in [sheetState] so every
+ * instance reads and writes the same expansion flag. A store clearing only cancels that store's
+ * instance; the next `koinViewModel()` builds a fresh one over these live singletons, so playback
+ * command state, expansion state, and the controller connection are all correct immediately —
+ * no re-served zombie instance with a permanently-cancelled `viewModelScope`.
  *
  * Exposes ~25 distinct, intent-named user actions (transport, chapter, speed,
  * sleep-timer, sheet visibility), each mapping to a single UI affordance; merging
@@ -74,7 +78,7 @@ private val logger = KotlinLogging.logger {}
  * the narrow [Suppress] (replaces the former file-level suppression).
  */
 @Suppress("TooManyFunctions")
-class NowPlayingViewModel(
+class NowPlayingViewModel internal constructor(
     private val playbackManager: PlaybackManager,
     private val bookRepository: BookRepository,
     private val sleepTimerManager: SleepTimerManager,
@@ -84,18 +88,14 @@ class NowPlayingViewModel(
     private val documentRepository: DocumentRepository,
     private val downloadRepository: DownloadRepository,
     private val playbackPositionRepository: PlaybackPositionRepository,
+    private val sheetState: NowPlayingSheetState,
 ) : ViewModel() {
     private companion object {
         const val FADE_DURATION_MS = 3000L
         const val SUBSCRIPTION_TIMEOUT_MS = 5_000L
     }
 
-    init {
-        playbackController.acquire()
-    }
-
     private val overlayFlow = MutableStateFlow<NowPlayingOverlay>(NowPlayingOverlay.None)
-    private val isExpandedFlow = MutableStateFlow(false)
 
     private val _navActions = Channel<NowPlayingNavAction>(Channel.BUFFERED)
 
@@ -175,7 +175,7 @@ class NowPlayingViewModel(
         combine(
             nowPlayingState,
             overlayFlow,
-            isExpandedFlow,
+            sheetState.isExpanded,
             sleepTimerManager.state,
         ) { state, overlay, isExpanded, sleepTimer ->
             NowPlayingScreenState(
@@ -191,7 +191,11 @@ class NowPlayingViewModel(
                 NowPlayingScreenState(
                     state = NowPlayingState.Idle,
                     overlay = NowPlayingOverlay.None,
-                    isExpanded = false,
+                    // Read the live singleton's current value (not a hardcoded false) so a fresh
+                    // VM instance's screenState.value is correct even before the combine above
+                    // has had a chance to emit — e.g. a second koinViewModel() instance created
+                    // while the sheet is already expanded from the first instance's perspective.
+                    isExpanded = sheetState.isExpanded.value,
                     sleepTimerState = sleepTimerManager.state.value,
                 ),
         )
@@ -340,11 +344,11 @@ class NowPlayingViewModel(
     // === UI ephemera setters ===
 
     fun expand() {
-        isExpandedFlow.value = true
+        sheetState.expand()
     }
 
     fun collapse() {
-        isExpandedFlow.value = false
+        sheetState.collapse()
     }
 
     fun showChapterPicker() {

--- a/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingViewModel.kt
+++ b/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingViewModel.kt
@@ -458,6 +458,10 @@ class NowPlayingViewModel internal constructor(
         if (playbackManager.isPlaying.value) {
             playbackController.pause()
         } else {
+            // Clear any latched error synchronously so the mini player (hidden while
+            // NowPlayingState is Error) reappears the instant the user resumes, rather than
+            // waiting for the async Playing-state confirmation from the platform player.
+            playbackManager.clearError()
             playbackController.play()
         }
     }

--- a/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/playback/PlaybackControllerActivatorTest.kt
+++ b/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/playback/PlaybackControllerActivatorTest.kt
@@ -1,0 +1,22 @@
+package com.calypsan.listenup.client.playback
+
+import com.calypsan.listenup.client.test.fake.FakePlaybackController
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * [PlaybackControllerActivator] is the process-lifetime replacement for the
+ * `playbackController.acquire()` call that used to live in `NowPlayingViewModel.init` — the reason
+ * that ViewModel had to be a Koin `single` instead of a `factory`. This is the RED-first
+ * regression: acquisition must happen exactly once, independent of any ViewModel at all.
+ */
+class PlaybackControllerActivatorTest :
+    FunSpec({
+        test("construction acquires the PlaybackController exactly once") {
+            val controller = FakePlaybackController()
+
+            PlaybackControllerActivator(playbackController = controller)
+
+            controller.acquireCount shouldBe 1
+        }
+    })

--- a/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingProgressIsolationTest.kt
+++ b/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingProgressIsolationTest.kt
@@ -67,7 +67,6 @@ class NowPlayingProgressIsolationTest :
             everySuspend { bookRepository.getBookListItem(any()) } returns sampleBook()
             every { bookRepository.observeIsBookLive(any()) } returns flowOf(true)
             every { documentRepository.observeDocuments(any()) } returns flowOf(emptyList())
-            every { playbackController.acquire() } returns Unit
             return NowPlayingViewModel(
                 playbackManager = fakePm,
                 bookRepository = bookRepository,
@@ -82,6 +81,7 @@ class NowPlayingProgressIsolationTest :
                 playbackPositionRepository =
                     com.calypsan.listenup.client.test.fake
                         .FakePlaybackPositionRepository(),
+                sheetState = NowPlayingSheetState(),
             )
         }
 

--- a/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingSheetStateTest.kt
+++ b/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingSheetStateTest.kt
@@ -1,0 +1,26 @@
+package com.calypsan.listenup.client.presentation.nowplaying
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * [NowPlayingSheetState] is the singleton that replaced [NowPlayingViewModel]'s per-instance
+ * `isExpandedFlow` — the piece that let a `factory`-scoped VM still present one shared expansion
+ * flag across every `koinViewModel()` consumer.
+ */
+class NowPlayingSheetStateTest :
+    FunSpec({
+        test("starts collapsed") {
+            NowPlayingSheetState().isExpanded.value shouldBe false
+        }
+
+        test("expand and collapse update the shared flow") {
+            val state = NowPlayingSheetState()
+
+            state.expand()
+            state.isExpanded.value shouldBe true
+
+            state.collapse()
+            state.isExpanded.value shouldBe false
+        }
+    })

--- a/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingTeardownTest.kt
+++ b/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingTeardownTest.kt
@@ -85,7 +85,6 @@ class NowPlayingTeardownTest :
             val playbackPreferences: PlaybackPreferences = mock()
             val networkMonitor: NetworkMonitor = mock()
             val documentRepository: DocumentRepository = mock()
-            every { playbackController.acquire() } returns Unit
             every { playbackController.stop() } returns Unit
             every { playbackPreferences.observeDefaultPlaybackSpeed() } returns flowOf(1.0f)
             everySuspend { playbackPreferences.getDefaultPlaybackSpeed() } returns 1.0f
@@ -100,6 +99,7 @@ class NowPlayingTeardownTest :
                 documentRepository = documentRepository,
                 downloadRepository = downloadRepository,
                 playbackPositionRepository = positionRepository,
+                sheetState = NowPlayingSheetState(),
             )
         }
 

--- a/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingViewModelTest.kt
+++ b/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingViewModelTest.kt
@@ -384,6 +384,30 @@ class NowPlayingViewModelTest :
             }
         }
 
+        test("playPause when paused clears a latched playback error before resuming") {
+            runTest(testDispatcher) {
+                // Regression: PlaybackManagerImpl.clearError() had no callers, so a latched
+                // transient error demoted NowPlayingState to Error (hiding the mini player) until
+                // the async Playing-state confirmation arrived — or forever, if it never did.
+                // playPause's play-branch must clear it synchronously.
+                val fixture = TestFixture()
+                every { fixture.playbackController.play() } returns Unit
+                fixture.fakePm.isPlayingFlow.value = false
+                fixture.fakePm.playbackErrorFlow.value =
+                    PlaybackErrorUiState(message = "Network unavailable", isRecoverable = true, timestampMs = 1_000L)
+
+                val vm = fixture.newVm()
+                vm.playPause()
+                advanceUntilIdle()
+
+                fixture.fakePm.clearErrorCalls shouldBe 1
+                withClue("expected playbackError cleared before/with play(); got: ${fixture.fakePm.playbackErrorFlow.value}") {
+                    fixture.fakePm.playbackErrorFlow.value shouldBe null
+                }
+                verify(VerifyMode.exactly(1)) { fixture.playbackController.play() }
+            }
+        }
+
         // ========== Skip/seek ==========
 
         test("skipForward at speed 1_5 advances by speed-multiplied delta and clamps to total") {

--- a/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingViewModelTest.kt
+++ b/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/presentation/nowplaying/NowPlayingViewModelTest.kt
@@ -2,7 +2,12 @@ package com.calypsan.listenup.client.presentation.nowplaying
 
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.core.FolderId
+import com.calypsan.listenup.core.LibraryId
+import com.calypsan.listenup.core.Timestamp
+import com.calypsan.listenup.client.domain.model.BookContributor
 import com.calypsan.listenup.client.domain.model.BookDocument
+import com.calypsan.listenup.client.domain.model.BookListItem
 import com.calypsan.listenup.client.domain.model.Chapter
 import com.calypsan.listenup.client.domain.playback.PlaybackTimeline
 import com.calypsan.listenup.client.domain.repository.BookRepository
@@ -72,6 +77,7 @@ class NowPlayingViewModelTest :
             val networkMonitor: NetworkMonitor = mock()
             val documentRepository: DocumentRepository = mock()
             val sleepTimerManager: SleepTimerManager = SleepTimerManager(CoroutineScope(Job()))
+            val sheetState = NowPlayingSheetState()
 
             init {
                 // Default: networkMonitor.isOnline() returns true. Tests override to false where needed.
@@ -87,10 +93,6 @@ class NowPlayingViewModelTest :
                 every { bookRepository.observeIsBookLive(any()) } returns flowOf(true)
                 // Default: documentRepository.observeDocuments returns empty list (no documents).
                 every { documentRepository.observeDocuments(any()) } returns flowOf(emptyList())
-                // NowPlayingViewModel's init block calls playbackController.acquire() to
-                // establish the MediaController connection. Mokkery is strict by default
-                // and would raise CallNotMockedException without this stub.
-                every { playbackController.acquire() } returns Unit
             }
 
             fun newVm(): NowPlayingViewModel =
@@ -108,10 +110,25 @@ class NowPlayingViewModelTest :
                     playbackPositionRepository =
                         com.calypsan.listenup.client.test.fake
                             .FakePlaybackPositionRepository(),
+                    sheetState = sheetState,
                 )
         }
 
         // ========== Helpers ==========
+
+        fun sampleBook(bookId: BookId): BookListItem =
+            BookListItem(
+                id = bookId,
+                libraryId = LibraryId("lib"),
+                folderId = FolderId("folder"),
+                title = "Sample Book",
+                authors = listOf(BookContributor(id = "a1", name = "Author", roles = listOf("Author"))),
+                narrators = emptyList(),
+                duration = 100_000L,
+                coverPath = null,
+                addedAt = Timestamp(epochMillis = 1L),
+                updatedAt = Timestamp(epochMillis = 1L),
+            )
 
         fun stubPrepareResult(bookId: BookId): PrepareResult =
             PrepareResult(
@@ -178,18 +195,69 @@ class NowPlayingViewModelTest :
             Dispatchers.resetMain()
         }
 
-        // ========== lifecycle regression ==========
+        // ========== lifecycle regression (zombie-VM fix) ==========
 
-        test("init acquires the PlaybackController so MediaController connects") {
-            val fixture = TestFixture()
+        test("a fresh VM instance over the same singletons reflects live isPlaying changes") {
+            runTest(testDispatcher) {
+                // Regression for the zombie-VM bug: NowPlayingViewModel used to be a Koin `single`,
+                // so when its owning ViewModelStore cleared, onCleared() permanently cancelled its
+                // viewModelScope and Koin kept re-serving that same dead instance — its
+                // stateIn(WhileSubscribed) projections frozen forever. Now a `factory`, a "store
+                // clear" is simulated by simply building a SECOND instance from the same
+                // singletons (fakePm, sheetState) — as koinViewModel() would after the first
+                // instance's store cleared. The new instance must reflect live state immediately,
+                // proving there is no per-instance state left to zombie.
+                val fixture = TestFixture()
+                val bookId = BookId("book-1")
+                everySuspend { fixture.bookRepository.getBookListItem(any()) } returns sampleBook(bookId)
+                fixture.fakePm.activateBook(bookId)
 
-            fixture.newVm()
+                val firstInstance = fixture.newVm()
+                backgroundScope.launch { firstInstance.screenState.collect {} }
+                advanceUntilIdle()
 
-            // A refactor mistakenly removed acquire/release from the
-            // VM under the assumption that Koin-singleton lifetime obviated the call.
-            // It does not — only acquire() triggers MediaControllerHolder.connect().
-            // Without this call, every in-app playback command is a silent no-op.
-            verify(VerifyMode.exactly(1)) { fixture.playbackController.acquire() }
+                val secondInstance = fixture.newVm()
+                backgroundScope.launch { secondInstance.screenState.collect {} }
+                advanceUntilIdle()
+
+                fixture.fakePm.isPlayingFlow.value = true
+                advanceUntilIdle()
+                withClue("second instance must reflect live isPlaying=true from the shared PlaybackManager") {
+                    val state = secondInstance.screenState.value.state
+                    (state is NowPlayingState.Active && state.isPlaying) shouldBe true
+                }
+            }
+        }
+
+        test("collapse() on one instance is observed via a second instance's shared sheet state") {
+            runTest(testDispatcher) {
+                val fixture = TestFixture()
+                fixture.fakePm.activateBook(BookId("book-1"))
+
+                val firstInstance = fixture.newVm()
+                backgroundScope.launch { firstInstance.screenState.collect {} }
+                advanceUntilIdle()
+                firstInstance.expand()
+                advanceUntilIdle()
+                withClue("precondition: expanded via the first instance") {
+                    firstInstance.screenState.value.isExpanded shouldBe true
+                }
+
+                // Second instance (simulating a fresh koinViewModel() after a store clear) must
+                // see the SAME expansion state — it is not per-instance anymore.
+                val secondInstance = fixture.newVm()
+                backgroundScope.launch { secondInstance.screenState.collect {} }
+                advanceUntilIdle()
+                withClue("second instance must start out expanded — shared sheet state, not per-instance") {
+                    secondInstance.screenState.value.isExpanded shouldBe true
+                }
+
+                secondInstance.collapse()
+                advanceUntilIdle()
+                withClue("collapse() on the second instance must propagate back to the first instance") {
+                    firstInstance.screenState.value.isExpanded shouldBe false
+                }
+            }
         }
 
         // ========== playBook ==========

--- a/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/test/fake/FakePlaybackManager.kt
+++ b/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/test/fake/FakePlaybackManager.kt
@@ -77,6 +77,7 @@ class FakePlaybackManager : PlaybackManager {
     val startPlaybackCalls: MutableList<StartPlaybackCall> = mutableListOf()
     val reportedErrors: MutableList<PlaybackErrorUiState> = mutableListOf()
     var clearPlaybackCalls: Int = 0
+    var clearErrorCalls: Int = 0
     val setPlayingCalls: MutableList<Boolean> = mutableListOf()
     val setBufferingCalls: MutableList<Boolean> = mutableListOf()
     val setPlaybackStateCalls: MutableList<PlaybackState> = mutableListOf()
@@ -175,5 +176,10 @@ class FakePlaybackManager : PlaybackManager {
         isRecoverable: Boolean,
     ) {
         reportedErrors += PlaybackErrorUiState(message = message, isRecoverable = isRecoverable, timestampMs = 0L)
+    }
+
+    override fun clearError() {
+        clearErrorCalls += 1
+        playbackErrorFlow.value = null
     }
 }

--- a/app/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/di/e2e/ClientKoinGraphE2ETest.kt
+++ b/app/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/di/e2e/ClientKoinGraphE2ETest.kt
@@ -109,13 +109,14 @@ class ClientKoinGraphE2ETest :
             // ABS-import flow (2026-07-21): its observeRoster() collector died with the cleared
             // store and never re-ran. This pins the invariant the libraryPresentationModule comment
             // documents but nothing enforced.
-            // The one justified exception: NowPlayingViewModel's init acquires a process-singleton
-            // playback controller (playbackController.acquire()) and it has two koinViewModel()
-            // consumers in separate nav stores (the shell mini-player + the document viewer), so a
-            // factory would double-acquire. Making it a factory needs the acquisition extracted into
-            // a singleton service first — tracked in docs/superpowers/followups.md. Every other VM
-            // must be a factory.
-            val allowedSingletonViewModels = setOf("NowPlayingViewModel")
+            // No exceptions: NowPlayingViewModel was the one justified holdout (its init acquired a
+            // process-singleton playback controller via playbackController.acquire(), and it has two
+            // koinViewModel() consumers in separate nav stores — the shell mini-player + the document
+            // viewer — so a factory would have double-acquired). The acquisition now lives in
+            // PlaybackControllerActivator (a `single(createdAtStart = true)` in
+            // playbackPresentationModule) and expand/collapse state lives in NowPlayingSheetState, so
+            // NowPlayingViewModel is a plain factory like every other VM. Every VM must be a factory.
+            val allowedSingletonViewModels = emptySet<String>()
 
             @OptIn(KoinInternalApi::class)
             val singletonViewModels =


### PR DESCRIPTION
## Root cause

`NowPlayingViewModel` was bound as a Koin `single` — the app's one documented exception to the "VMs are `factory`" rule — because its `init` acquired the process-lifetime `PlaybackController` connection (`playbackController.acquire()`), and it has two `koinViewModel()` consumers in separate `ViewModelStore`s (the shell mini-player's Activity-scoped store, the document viewer's nav-entry-scoped store). A `factory` would have created two instances and double-acquired the controller.

The `single` binding is the actual bug. When either owning store clears — an overnight Activity destroy with the process retained, or popping the document viewer — `onCleared()` permanently cancels the singleton's `viewModelScope`, and Koin keeps re-serving that same dead instance forever. Its `stateIn(viewModelScope, WhileSubscribed(5s))` projections (`screenState`, `progress`) freeze at their last snapshot, while the command path (`playPause()` → the live `PlaybackManagerImpl` singleton → `MediaControllerHolder`) keeps working underneath. This one fact explains four user-visible symptoms:

- Frozen play/pause icon — taps resume audio, but the icon never updates
- Back-swipe on the full-screen player falls through to the nav stack behind the sheet
- The mini player is permanently hidden after the zombie sets in
- All of the above persist until the process is killed and restarted

## Fix

- Extracted controller acquisition into `PlaybackControllerActivator`, a `single(createdAtStart = true)` in `playbackPresentationModule` that acquires the connection once at Koin startup, independent of any ViewModel.
- Extracted the sheet's expand/collapse state into `NowPlayingSheetState`, a `single` so every VM instance (now one per owning store) reads and writes the same expansion flag.
- `NowPlayingViewModel` is now a plain `factory`, like every other ViewModel. A store clearing kills only that store's instance; the next `koinViewModel()` builds a fresh one over the live singletons above, so playback command state, expansion state, and the controller connection are correct immediately.
- Un-grandfathered the `ClientKoinGraphE2ETest` architecture test ("no ViewModel is registered as a Koin singleton") — there are no exceptions left.

## Secondary bug fixed in the same PR

`PlaybackManagerImpl.clearError()` had no callers. A transient stream error latched into `playbackError` permanently demoted `mapToNowPlayingState` to `Error` (hiding the mini player) until the async Playing-state confirmation arrived from the platform player — or forever, if it never did. `playPause()`'s play-branch now calls `clearError()` synchronously so the mini player reappears the instant the user resumes.

## Tests

- `PlaybackControllerActivatorTest` — construction acquires the controller exactly once.
- `NowPlayingSheetStateTest` — starts collapsed; expand/collapse update the shared flow.
- `NowPlayingViewModelTest`:
  - Regression: a second VM instance built over the same singletons (simulating a fresh `koinViewModel()` after a store clear) reflects live `isPlaying` changes immediately.
  - Regression: `collapse()` on one instance propagates to a second instance via the shared sheet state.
  - `clearError()` wiring: a latched error clears when `playPause()` resumes playback.
- `ClientKoinGraphE2ETest` "no ViewModel is registered as a Koin singleton" — green with zero exceptions.

Evidence: `:app:sharedLogic:jvmTest` full suite green (572 test classes, 0 failures/errors). `:app:sharedUI:compileAndroidMain` green — no call-site changes needed (`NowPlayingViewModel`'s public API is unchanged). `:app:sharedLogic:testAndroidHostTest` `KoinModuleVerifyTest` green (6/6). `spotlessCheck` and `detekt` clean. `:app:desktopApp:compileKotlin` green (desktop also loads `playbackPresentationModule`).