### PR TITLE
fix(server): never re-home a book after a failed membership write

### DIFF
--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/CollectionServiceImpl.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/api/CollectionServiceImpl.kt
@@ -6,6 +6,7 @@ import com.calypsan.listenup.api.dto.CollectionSummary
 import com.calypsan.listenup.api.dto.SharePermission
 import com.calypsan.listenup.api.dto.auth.UserId
 import com.calypsan.listenup.api.dto.auth.UserRole
+import com.calypsan.listenup.api.error.AppError
 import com.calypsan.listenup.api.error.CollectionError
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.api.result.getOrElse
@@ -24,6 +25,7 @@ import com.calypsan.listenup.server.auth.toContract
 import com.calypsan.listenup.server.db.UserRoleColumn
 import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
 import com.calypsan.listenup.server.db.sqldelight.suspendTransaction
+import com.calypsan.listenup.server.logging.loggerFor
 import com.calypsan.listenup.server.services.BookRevisionTouch
 import com.calypsan.listenup.server.sync.ChangeBus
 import com.calypsan.listenup.server.sync.CollectionBookRepository
@@ -33,6 +35,8 @@ import kotlin.uuid.Uuid
 import kotlin.time.Clock
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+
+private val log = loggerFor<CollectionServiceImpl>()
 
 private const val LIST_BOOKS_MIN = 1
 private const val LIST_BOOKS_MAX = 1000
@@ -52,6 +56,48 @@ private const val BOOK_LOCK_STRIPES = 64
  * comfortably covers every realistic single collection mutation while capping the pathological case.
  */
 internal const val DELTA_MAX_BOOKS = 200
+
+/**
+ * Logs a discarded `collection_books` upsert [error] for [bookId]/[collectionId], tagged [op] —
+ * #1226's three call sites ([CollectionServiceImpl.setBookCollections],
+ * [CollectionServiceImpl.releaseBooks], the reconcile) that used to swallow this silently.
+ */
+private fun logFailedMembershipWrite(
+    op: String,
+    bookId: String,
+    collectionId: String,
+    error: AppError,
+) {
+    log.error { "$op: membership write failed for book=$bookId collection=$collectionId — $error" }
+}
+
+/**
+ * Logs that [op] skipped the ALL_BOOKS reconcile for [bookId] after a failed membership write
+ * above it — see [CollectionServiceImpl.setBookCollections] / [CollectionServiceImpl.releaseBooks].
+ */
+private fun logSkippedReconcile(
+    op: String,
+    bookId: String,
+) {
+    log.warn { "$op: skipping reconcile for book=$bookId after a failed membership write" }
+}
+
+/**
+ * Upserts [payload] via this repository, logging (tagged [op]) and returning `false` on a write
+ * failure instead of discarding the [AppResult] — #1226's single choke point for the three call
+ * sites in [CollectionServiceImpl] that used to swallow this silently.
+ */
+private suspend fun CollectionBookRepository.upsertOrLog(
+    op: String,
+    payload: CollectionBookSyncPayload,
+): Boolean {
+    val result = upsert(payload)
+    if (result is AppResult.Failure) {
+        logFailedMembershipWrite(op, payload.bookId, payload.collectionId, result.error)
+        return false
+    }
+    return true
+}
 
 /**
  * Builds the recipient-agnostic [AccessScope] naming the entities an access change touched, or
@@ -389,8 +435,14 @@ internal class CollectionServiceImpl(
             for (collectionId in removed) {
                 collectionBookRepo.softDelete(collectionId = collectionId, bookId = bookId.value)
             }
+            // A book whose membership write FAILED must never be reconciled below: reconcile derives
+            // ALL_BOOKS membership from the live junction rows, so a book that silently failed to join
+            // its intended (possibly private) collection would read back as an uncollected orphan and
+            // get re-homed into the everyone-visible ALL_BOOKS substrate — a silent access widening.
+            // Staying in limbo (unchanged) until the next mutation is the acceptable failure mode.
+            var hadFailedWrite = false
             for (collectionId in added) {
-                collectionBookRepo.upsert(
+                val payload =
                     CollectionBookSyncPayload(
                         id = Uuid.random().toString(),
                         collectionId = collectionId,
@@ -398,8 +450,8 @@ internal class CollectionServiceImpl(
                         createdAt = clock.now().toEpochMilliseconds(),
                         revision = 0L,
                         deletedAt = null,
-                    ),
-                )
+                    )
+                if (!collectionBookRepo.upsertOrLog("setBookCollections", payload)) hadFailedWrite = true
             }
 
             // Changing the book's collection set changes who can see the book. Every enumerable user
@@ -416,7 +468,12 @@ internal class CollectionServiceImpl(
             // Derive ALL_BOOKS from the resulting real set: in ALL_BOOKS iff no real membership remains
             // (and not held in INBOX). This drops a curated book out of the everyone-collection (the
             // #680/#730 leak) and re-homes an empty target set into ALL_BOOKS instead of orphaning it.
-            reconcileSystemMembership(bookId.value)
+            // Skipped when a write above failed — see [hadFailedWrite].
+            if (!hadFailedWrite) {
+                reconcileSystemMembership(bookId.value)
+            } else {
+                logSkippedReconcile("setBookCollections", bookId.value)
+            }
         }
         return AppResult.Success(Unit)
     }
@@ -722,12 +779,19 @@ internal class CollectionServiceImpl(
         // cannot nest inside a non-suspend SQLDelight transaction body. The pre-flight validation
         // above kept the release typed; a partial failure here is the same risk the prior outer
         // Exposed transaction carried, since it never took the SQLite write lock anyway.
+        //
+        // A book whose target write FAILS is recorded in [failedBookIds] and excluded from the
+        // reconcile pass below: the inbox tombstone can still have committed for that book, so
+        // reconcile would otherwise read back zero real memberships and re-home it into the
+        // everyone-visible ALL_BOOKS substrate — silently publishing a book meant for a private
+        // collection. Staying held/unchanged until the next mutation is the acceptable outcome.
+        val failedBookIds = mutableSetOf<String>()
         for ((bookId, targetCollectionIds) in assignments) {
             collectionBookRepo.softDelete(collectionId = inboxId, bookId = bookId)
             // Empty target → release to ALL_BOOKS so the book stays publicly visible.
             val resolvedTargets = targetCollectionIds.ifEmpty { listOfNotNull(allBooksId) }
             for (targetId in resolvedTargets) {
-                collectionBookRepo.upsert(
+                val payload =
                     CollectionBookSyncPayload(
                         id = Uuid.random().toString(),
                         collectionId = targetId,
@@ -735,8 +799,8 @@ internal class CollectionServiceImpl(
                         createdAt = clock.now().toEpochMilliseconds(),
                         revision = 0L,
                         deletedAt = null,
-                    ),
-                )
+                    )
+                if (!collectionBookRepo.upsertOrLog("releaseBooks", payload)) failedBookIds += bookId
             }
         }
 
@@ -753,8 +817,13 @@ internal class CollectionServiceImpl(
         // loop-invariant system-collection lookups across the whole release.
         // One book lock at a time — never two at once — so a bulk reconcile serialises against a
         // concurrent single-book mutation without any lock-ordering deadlock. See [bookLocks].
+        // Books with a failed membership write above are excluded — see [failedBookIds].
         val lookups = SystemMembershipLookups()
         for (bookId in assignments.keys) {
+            if (bookId in failedBookIds) {
+                logSkippedReconcile("releaseBooks", bookId)
+                continue
+            }
             bookLock(bookId).withLock { reconcileSystemMembership(bookId, lookups) }
         }
         return AppResult.Success(Unit)
@@ -845,7 +914,7 @@ internal class CollectionServiceImpl(
                         .getOrElse { return }
                         .id.value
                         .also { lookups.noteAllBooksCreated(libraryId, it) }
-            collectionBookRepo.upsert(
+            val payload =
                 CollectionBookSyncPayload(
                     id = Uuid.random().toString(),
                     collectionId = id,
@@ -853,8 +922,8 @@ internal class CollectionServiceImpl(
                     createdAt = clock.now().toEpochMilliseconds(),
                     revision = 0L,
                     deletedAt = null,
-                ),
-            )
+                )
+            if (!collectionBookRepo.upsertOrLog("reconcileSystemMembership", payload)) return
             notifyAccessChanged(listOf(id), listOf(bookId))
             bookRevisionTouch.touchRevision(BookId(bookId))
             return

--- a/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/CollectionBookRepository.kt
+++ b/server/src/commonMain/kotlin/com/calypsan/listenup/server/sync/CollectionBookRepository.kt
@@ -56,8 +56,11 @@ data class CollectionBookId(
  *  - [findBookIdsForCollection] — live book IDs for a collection
  *  - [findCollectionIdsForBook] — live collection IDs for a book
  *  - [countLiveForCollection] — count of live junction rows for a collection
+ *
+ * `open` so `jvmTest`'s `FaultInjectingCollectionBookRepository` can override [upsert] to simulate
+ * a membership-write DB fault (#1226) without a real transaction seam of its own.
  */
-class CollectionBookRepository(
+open class CollectionBookRepository(
     db: ListenUpDatabase,
     bus: ChangeBus,
     registry: SyncRegistry,

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/CollectionMembershipWriteFailureTest.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/api/CollectionMembershipWriteFailureTest.kt
@@ -1,0 +1,189 @@
+package com.calypsan.listenup.server.api
+
+import com.calypsan.listenup.api.dto.auth.UserRole
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.core.CollectionId
+import com.calypsan.listenup.core.LibraryId
+import com.calypsan.listenup.server.db.UserRoleColumn
+import com.calypsan.listenup.server.testing.FaultInjectingCollectionBookRepository
+import com.calypsan.listenup.server.testing.actAs
+import com.calypsan.listenup.server.testing.collectionAccessHarness
+import com.calypsan.listenup.server.testing.grantAllBooks
+import com.calypsan.listenup.server.testing.junctionDiagnostic
+import com.calypsan.listenup.server.testing.seedTestBook
+import com.calypsan.listenup.server.testing.seedTestLibraryAndFolder
+import com.calypsan.listenup.server.testing.seedTestUser
+import com.calypsan.listenup.server.testing.withSqlDatabase
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Regression coverage for #1226: [CollectionServiceImpl] used to discard the [AppResult] returned
+ * by [com.calypsan.listenup.server.sync.CollectionBookRepository.upsert] in three places
+ * ([CollectionServiceImpl.setBookCollections], [CollectionServiceImpl.releaseBooks],
+ * `reconcileSystemMembership`), so a failed membership write was silently swallowed.
+ *
+ * The dangerous interleaving: an admin releases a held book into a *private* collection whose
+ * membership write fails (a DB fault) — the inbox tombstone still commits, so the end-of-release
+ * reconcile reads back zero real memberships and re-homes the book into the everyone-visible
+ * `ALL_BOOKS` substrate, silently widening a private book to every member while the call still
+ * reports [AppResult.Success]. These tests drive the real [CollectionServiceImpl] over a real
+ * Flyway-migrated in-memory SQLite db, with [FaultInjectingCollectionBookRepository] standing in
+ * for the real [com.calypsan.listenup.server.sync.CollectionBookRepository] to make one chosen
+ * `(collectionId, bookId)` write fail exactly like a real fault would — no row is written.
+ */
+class CollectionMembershipWriteFailureTest :
+    FunSpec({
+
+        test("releaseBooks: a failed private-collection write never re-homes the book to ALL_BOOKS") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestUser("admin", UserRoleColumn.ADMIN)
+                sql.seedTestUser("member")
+                sql.seedTestBook("book1")
+                runTest {
+                    // Set up the private target collection and a pre-existing ALL_BOOKS with a
+                    // granted member, using the harness's real (non-faulty) repo.
+                    val setup = collectionAccessHarness()
+                    val setupAdmin = setup.service.actAs("admin", UserRole.ADMIN)
+                    val privateCollection = setupAdmin.createCollection("test-library", "Private")
+                    require(privateCollection is AppResult.Success)
+                    val privateId = privateCollection.data.id.value
+
+                    val allBooks = setupAdmin.getOrCreateSystemCollection("test-library", SystemCollectionType.ALL_BOOKS)
+                    require(allBooks is AppResult.Success)
+                    val allBooksId = allBooks.data.id.value
+                    setup.grantAllBooks(allBooksId, "member")
+
+                    setupAdmin.addToInbox("book1", "test-library") shouldBe AppResult.Success(Unit)
+
+                    // Now build the harness whose collectionBookRepo fails exactly the
+                    // (privateId, book1) write — the release's target-collection upsert.
+                    val h =
+                        collectionAccessHarness { bus, registry ->
+                            FaultInjectingCollectionBookRepository(
+                                db = sql,
+                                bus = bus,
+                                registry = registry,
+                                driver = driver,
+                                failingPairs = setOf(privateId to "book1"),
+                            )
+                        }
+                    val admin = h.service.actAs("admin", UserRole.ADMIN)
+
+                    // The release still reports Success — the point of the bug: a swallowed write
+                    // failure never surfaces to the caller.
+                    admin.releaseBooks(
+                        LibraryId("test-library"),
+                        mapOf(BookId("book1") to listOf(CollectionId(privateId))),
+                    ) shouldBe AppResult.Success(Unit)
+
+                    // The dangerous outcome this test guards: the book must NOT have been re-homed
+                    // into ALL_BOOKS (which would make it visible to every member) despite its
+                    // intended private-collection write failing.
+                    h.bookAccessPolicy.canAccess("member", UserRole.MEMBER, "book1").shouldBeFalse()
+                    h.junctionDiagnostic("book1").let {
+                        it shouldNotContain allBooksId
+                        // The private write genuinely failed — no row for it either.
+                        it shouldNotContain privateId
+                    }
+                }
+            }
+        }
+
+        test("setBookCollections logs a failed add but still commits the other collections in the batch") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestUser("admin", UserRoleColumn.ADMIN)
+                sql.seedTestBook("book1")
+                runTest {
+                    val setup = collectionAccessHarness()
+                    val setupAdmin = setup.service.actAs("admin", UserRole.ADMIN)
+                    val okCollection = setupAdmin.createCollection("test-library", "OK")
+                    val failCollection = setupAdmin.createCollection("test-library", "FAIL")
+                    require(okCollection is AppResult.Success)
+                    require(failCollection is AppResult.Success)
+                    val okId = okCollection.data.id.value
+                    val failId = failCollection.data.id.value
+
+                    val h =
+                        collectionAccessHarness { bus, registry ->
+                            FaultInjectingCollectionBookRepository(
+                                db = sql,
+                                bus = bus,
+                                registry = registry,
+                                driver = driver,
+                                failingPairs = setOf(failId to "book1"),
+                            )
+                        }
+                    val admin = h.service.actAs("admin", UserRole.ADMIN)
+
+                    admin.setBookCollections(
+                        BookId("book1"),
+                        listOf(CollectionId(okId), CollectionId(failId)),
+                    ) shouldBe AppResult.Success(Unit)
+
+                    // The batch continues past the failed write: the other collection's add commits.
+                    h.junctionDiagnostic("book1").let {
+                        it shouldContain okId
+                        it shouldNotContain failId
+                    }
+                }
+            }
+        }
+
+        test("reconcileSystemMembership leaves the book's prior state when the ALL_BOOKS write fails") {
+            withSqlDatabase {
+                sql.seedTestLibraryAndFolder()
+                sql.seedTestUser("admin", UserRoleColumn.ADMIN)
+                sql.seedTestUser("member")
+                sql.seedTestBook("book1")
+                runTest {
+                    val setup = collectionAccessHarness()
+                    val setupAdmin = setup.service.actAs("admin", UserRole.ADMIN)
+                    val c = setupAdmin.createCollection("test-library", "C")
+                    require(c is AppResult.Success)
+
+                    val allBooks = setupAdmin.getOrCreateSystemCollection("test-library", SystemCollectionType.ALL_BOOKS)
+                    require(allBooks is AppResult.Success)
+                    val allBooksId = allBooks.data.id.value
+                    setup.grantAllBooks(allBooksId, "member")
+
+                    setupAdmin.addBookToCollection(c.data.id, BookId("book1")) shouldBe AppResult.Success(Unit)
+
+                    // The book's only real membership is about to be removed, which triggers
+                    // reconcile's "return to ALL_BOOKS" branch — fail exactly that write.
+                    val h =
+                        collectionAccessHarness { bus, registry ->
+                            FaultInjectingCollectionBookRepository(
+                                db = sql,
+                                bus = bus,
+                                registry = registry,
+                                driver = driver,
+                                failingPairs = setOf(allBooksId to "book1"),
+                            )
+                        }
+                    val admin = h.service.actAs("admin", UserRole.ADMIN)
+
+                    admin.removeBookFromCollection(c.data.id, BookId("book1")) shouldBe AppResult.Success(Unit)
+
+                    // The ALL_BOOKS write failed, so the book stays exactly where it was left by the
+                    // removal — orphaned, not re-homed — rather than a reconcile that half-applied.
+                    h.junctionDiagnostic("book1").let {
+                        it shouldNotContain allBooksId
+                        it shouldNotContain c.data.id.value
+                    }
+                    h.bookAccessPolicy.canAccess("member", UserRole.MEMBER, "book1").shouldBeFalse()
+                    // removeBookFromCollection bumps the revision once for the removal itself; the
+                    // failed reconcile write must NOT bump it a second time for a write that never
+                    // actually happened.
+                    h.revisionTouch.touched.count { it == "book1" } shouldBe 1
+                }
+            }
+        }
+    })

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/testing/CollectionAccessHarness.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/testing/CollectionAccessHarness.kt
@@ -74,12 +74,20 @@ fun principalFor(
  * Builds the shared [CollectionAccessHarness] over this migrated test db. The [bus] and
  * [SyncRegistry] are shared across every repo (matching production), so the collection service and
  * the book repo publish onto the same change bus.
+ *
+ * [collectionBookRepo] defaults to a real [CollectionBookRepository] over this db; a guard testing
+ * a failed membership write (e.g. #1226) supplies a [FaultInjectingCollectionBookRepository] built
+ * against the same `(bus, registry)` pair instead, so the rest of the graph is unchanged.
  */
-internal fun SqlTestDatabases.collectionAccessHarness(): CollectionAccessHarness {
+internal fun SqlTestDatabases.collectionAccessHarness(
+    collectionBookRepo: (bus: ChangeBus, registry: SyncRegistry) -> CollectionBookRepository = { bus, registry ->
+        CollectionBookRepository(db = sql, bus = bus, registry = registry, driver = driver)
+    },
+): CollectionAccessHarness {
     val bus = ChangeBus()
     val registry = SyncRegistry()
     val collectionRepo = CollectionRepository(db = sql, bus = bus, registry = registry, driver = driver)
-    val collectionBookRepo = CollectionBookRepository(db = sql, bus = bus, registry = registry, driver = driver)
+    val collectionBookRepo = collectionBookRepo(bus, registry)
     val grantRepo = CollectionGrantRepository(db = sql, bus = bus, registry = registry, driver = driver)
     val accessPolicy = CollectionAccessPolicy(collectionRepo, grantRepo)
     val revisionTouch = FakeBookRevisionTouch()

--- a/server/src/jvmTest/kotlin/com/calypsan/listenup/server/testing/FaultInjectingCollectionBookRepository.kt
+++ b/server/src/jvmTest/kotlin/com/calypsan/listenup/server/testing/FaultInjectingCollectionBookRepository.kt
@@ -1,0 +1,36 @@
+package com.calypsan.listenup.server.testing
+
+import app.cash.sqldelight.db.SqlDriver
+import com.calypsan.listenup.api.error.SyncError
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.api.sync.CollectionBookSyncPayload
+import com.calypsan.listenup.server.db.sqldelight.ListenUpDatabase
+import com.calypsan.listenup.server.sync.ChangeBus
+import com.calypsan.listenup.server.sync.CollectionBookRepository
+import com.calypsan.listenup.server.sync.SyncRegistry
+
+/**
+ * A [CollectionBookRepository] whose [upsert] fails for chosen `(collectionId, bookId)` pairs,
+ * delegating every other pair to the real write untouched. Simulates the DB fault #1226 describes
+ * — a membership write into a private collection failing mid `releaseBooks` / `setBookCollections`
+ * — without a fake transaction seam of its own: a failing pair never reaches the database, so the
+ * junction row is genuinely absent afterward, exactly as a real fault would leave it.
+ */
+class FaultInjectingCollectionBookRepository(
+    db: ListenUpDatabase,
+    bus: ChangeBus,
+    registry: SyncRegistry,
+    driver: SqlDriver,
+    private val failingPairs: Set<Pair<String, String>>,
+) : CollectionBookRepository(db = db, bus = bus, registry = registry, driver = driver) {
+    override suspend fun upsert(
+        value: CollectionBookSyncPayload,
+        clientOpId: String?,
+        userId: String?,
+    ): AppResult<CollectionBookSyncPayload> =
+        if (value.collectionId to value.bookId in failingPairs) {
+            AppResult.Failure(SyncError.PushFailed(debugInfo = "injected test failure"))
+        } else {
+            super.upsert(value, clientOpId, userId)
+        }
+}


### PR DESCRIPTION
## Summary

`CollectionServiceImpl` discarded the `AppResult` returned by `CollectionBookRepository.upsert(...)` in three places: `setBookCollections`, `releaseBooks`, and `reconcileSystemMembership`. A typed `Failure` (e.g. a DB fault) was silently swallowed.

The dangerous interleaving: an admin releases a held book into a *private* collection whose membership write fails. The inbox tombstone still commits, so the end-of-release reconcile reads back zero real memberships for that book and re-homes it into the everyone-visible `ALL_BOOKS` substrate — silently widening a private book to every member, while `releaseBooks` still reports `AppResult.Success`.

## Fix

- Every discarded `upsert` result is now checked. A failure is logged (book id + collection id + the typed error) through a shared `CollectionBookRepository.upsertOrLog` extension and a `logFailedMembershipWrite` helper — one choke point for all three former call sites.
- `releaseBooks`: a book whose target-collection write fails is recorded and **excluded** from the end-of-loop reconcile pass, so it can never be re-homed to `ALL_BOOKS` off a write that didn't actually happen. It stays in limbo (held/unchanged) instead — acceptable per the bug's own framing, unlike silent publication.
- `setBookCollections`: same guard — a failed add for one book skips that call's reconcile too, for the identical reason (single-book equivalent of the same danger).
- `reconcileSystemMembership`: its own ALL_BOOKS-resurrection upsert is now checked; on failure it logs and returns without the `notifyAccessChanged`/`touchRevision` calls that would otherwise misreport a write that never landed.
- No new `AppError` / contract types were added (would require an iOS Swift-Export regen we can't do from this box) — the existing return shapes (`AppResult.Success(Unit)`) are preserved; the failure surfaces only via logs for now. Honest propagation to the caller is deliberately deferred contract work.
- `CollectionBookRepository` is now `open` so `jvmTest`'s new `FaultInjectingCollectionBookRepository` can override `upsert` to simulate a DB fault for a chosen `(collectionId, bookId)` pair, without a fake transaction seam.

## Test plan

New `CollectionMembershipWriteFailureTest` (server jvmTest), TDD'd against the actual bug:
- [x] RED confirmed: reverting the fix reproduces exactly the issue's interleaving — `releaseBooks` into a private collection whose write fails ends with the book visible via `ALL_BOOKS` (`canAccess` wrongly `true`), and the reconcile branch double-bumps the book's revision. Verified by temporarily restoring `CollectionServiceImpl.kt` to `main` and re-running the suite (2/3 tests failed as expected).
- [x] GREEN with the fix: all 3 new tests pass — the release-into-private-with-fault case no longer re-homes to `ALL_BOOKS`; `setBookCollections` logs a failed add but still commits the other collection in the batch; a failed reconcile write leaves the book's prior state (no double revision touch).
- [x] Full `:server:jvmTest` — `BUILD SUCCESSFUL`, no failures/errors in any suite.
- [x] `spotlessCheck` and `detekt` (root) both pass.

Closes #1226

🤖 Generated with [Claude Code](https://claude.com/claude-code)