### PR TITLE
✨ feat(shared): apply auto-rewind on in-session pause→resume

### DIFF
--- a/app/sharedLogic/src/androidHostTest/kotlin/com/calypsan/listenup/client/di/AndroidPlaybackModuleRecorderBindingTest.kt
+++ b/app/sharedLogic/src/androidHostTest/kotlin/com/calypsan/listenup/client/di/AndroidPlaybackModuleRecorderBindingTest.kt
@@ -1,15 +1,20 @@
 package com.calypsan.listenup.client.di
 
+import com.calypsan.listenup.client.domain.repository.LocalPreferences
 import com.calypsan.listenup.client.playback.PlaybackProgressReporter
 import com.calypsan.listenup.client.playback.ProgressTracker
 import com.calypsan.listenup.client.test.di.KoinTestRule
 import com.calypsan.listenup.client.test.fake.FakeDownloadRepository
 import com.calypsan.listenup.client.test.fake.FakePlaybackPositionRepository
 import com.calypsan.listenup.client.test.fake.FakeProgressTracker
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.mock
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.nulls.shouldBeNull
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
 import org.koin.dsl.module
 import org.koin.mp.KoinPlatform
 
@@ -40,6 +45,9 @@ class AndroidPlaybackModuleRecorderBindingTest :
                     )
                 }
                 single { CoroutineScope(SupervisorJob()) }
+                single<LocalPreferences> {
+                    mock { every { autoRewindEnabled } returns MutableStateFlow(false) }
+                }
             }
         val koinRule = KoinTestRule(listOf(fixtureModule, androidPlaybackModule))
 

--- a/app/sharedLogic/src/androidHostTest/kotlin/com/calypsan/listenup/client/di/KoinModuleVerifyTest.kt
+++ b/app/sharedLogic/src/androidHostTest/kotlin/com/calypsan/listenup/client/di/KoinModuleVerifyTest.kt
@@ -102,6 +102,7 @@ class KoinModuleVerifyTest :
                         CoroutineScope::class,
                         ServerConfig::class,
                         PlaybackPreferences::class,
+                        LocalPreferences::class,
                         BookDao::class,
                         AudioFileDao::class,
                         ChapterDao::class,

--- a/app/sharedLogic/src/androidMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.android.kt
+++ b/app/sharedLogic/src/androidMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.android.kt
@@ -28,6 +28,7 @@ val androidPlaybackModule: Module =
                 progressTracker = get(),
                 recorder = null,
                 scope = get(),
+                localPreferences = get(),
             )
         }
 

--- a/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerImpl.kt
+++ b/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerImpl.kt
@@ -164,6 +164,10 @@ internal class PlaybackManagerImpl(
     override fun activateBook(bookId: BookId) {
         currentBookId.value = bookId
         currentBookIdString.value = bookId.value
+        // A pause window left open by the PREVIOUS book must never leak a transition rewind
+        // onto this one's first play, stacking on top of the prepare-time offset already
+        // applied for THIS book — see PlaybackProgressReporter.resetAutoRewindWindow KDoc.
+        reporter.resetAutoRewindWindow()
     }
 
     /**
@@ -248,6 +252,16 @@ internal class PlaybackManagerImpl(
             player.seekTo(resumePositionMs)
         }
         currentPositionMs.value = resumePositionMs
+
+        // Auto-rewind-on-resume actuator (#1220) for the built-in-player (Desktop) path: the
+        // reporter owns the pause-window/ladder decision, but only this function has the
+        // AudioPlayer handle needed to actually seek. Re-registered every call so the closure
+        // always captures the CURRENT session's player, never a stale one from a prior book.
+        reporter.onAutoRewindSeek = { rewindMs ->
+            val newPositionMs = (currentPositionMs.value - rewindMs).coerceAtLeast(0L)
+            player.seekTo(newPositionMs)
+            updatePosition(newPositionMs)
+        }
 
         // Bridge player state and position back to PlaybackManager.
         // Both child launches are parented to playerObservationJob so a single
@@ -340,9 +354,22 @@ internal class PlaybackManagerImpl(
      * Update playing flag. Called by platform-specific event sources
      * (Android: MediaControllerHolder's Player.Listener; Desktop: PlaybackManager's
      * own AudioPlayer.state observation in startPlayback).
+     *
+     * The single shared isPlaying-transition seam for #1220's in-session auto-rewind: a
+     * Playing→Paused edge marks the pause moment ([PlaybackProgressReporter.notePlaybackPaused]),
+     * a Paused→Playing edge applies the graduated ladder for however long that pause lasted
+     * ([PlaybackProgressReporter.notePlaybackResumed]). Unconditional — unlike
+     * [setPlaybackState]'s persistence branches, these carry no persistence side effect, so they
+     * run the same way regardless of [persistTransitionsViaReporter] (see that reporter's KDoc for
+     * why Android is safe here too, and why iOS needs its own native wiring).
      */
     override fun setPlaying(playing: Boolean) {
+        val wasPlaying = isPlaying.value
         isPlaying.value = playing
+        when {
+            wasPlaying && !playing -> reporter.notePlaybackPaused()
+            !wasPlaying && playing -> reporter.notePlaybackResumed()
+        }
     }
 
     /**
@@ -488,6 +515,7 @@ internal class PlaybackManagerImpl(
         // buffering could leave downloads yielded until some later state change.
         playbackBandwidthCoordinator.setStreamingBuffering(false)
         playbackState.value = PlaybackState.Idle
+        reporter.resetAutoRewindWindow()
     }
 
     /**

--- a/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackProgressReporter.kt
+++ b/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackProgressReporter.kt
@@ -2,9 +2,11 @@ package com.calypsan.listenup.client.playback
 
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.client.domain.model.PlaybackPosition
+import com.calypsan.listenup.client.domain.repository.LocalPreferences
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import kotlin.time.Clock
 
 private val logger = KotlinLogging.logger {}
 
@@ -35,6 +37,18 @@ private val logger = KotlinLogging.logger {}
  * split the span — the span keeps its opening speed, which is metadata only; stats derive
  * listening time from wall-clock and content from positions, both accurate regardless.
  *
+ * **Also the in-session pause→resume auto-rewind seam (#1220).** [notePlaybackPaused] /
+ * [notePlaybackResumed] are a SEPARATE pair of methods from the trigger set above — they carry
+ * no persistence side effect of their own, so they are safe to call unconditionally from every
+ * platform's isPlaying-transition signal, even Android's (which opts OUT of routing
+ * [onPlaybackStarted]/[onPlaybackPaused] through this reporter — see [PlaybackManagerImpl]'s
+ * `persistTransitionsViaReporter`). [PlaybackManagerImpl.setPlaying] calls them on Android and
+ * Desktop. **iOS does not currently call them** — iOS's native `PlayerCoordinator` drives this
+ * reporter directly but only for the persisted trigger set; wiring `notePlaybackPaused` /
+ * `notePlaybackResumed` into its own play/pause transitions (plus registering
+ * [onAutoRewindSeek] and calling [resetAutoRewindWindow] at prepare/book-switch time) is
+ * outstanding native work, not yet done as of #1220.
+ *
  * @property progressTracker Position-persistence collaborator; always driven.
  * @property recorder Listening-event recorder; `null` on Android, non-null on
  *   iOS/Desktop/macOS. When `null`, every recording call is skipped and only [progressTracker]
@@ -42,11 +56,17 @@ private val logger = KotlinLogging.logger {}
  * @property scope Scope on which the recorder's suspend calls are launched, mirroring
  *   [ProgressTracker]'s own fire-and-forget style. Recording failures are non-fatal (the
  *   recorder logs and self-heals via orphan recovery), so they never block playback.
+ * @property localPreferences Read for `autoRewindEnabled` — the same user preference that
+ *   gates the prepare-time ladder in [PlaybackPreparer].
+ * @property nowMillis Injectable wall clock for the pause-window measurement, mirroring the
+ *   `nowMillis` seam already used by [PlaybackPreparer] / [ProgressTracker] / [SleepTimerManager].
  */
 class PlaybackProgressReporter(
     private val progressTracker: ProgressTracker,
     private val recorder: ListeningEventRecorder?,
     private val scope: CoroutineScope,
+    private val localPreferences: LocalPreferences,
+    private val nowMillis: () -> Long = { Clock.System.now().toEpochMilliseconds() },
 ) {
     /** Playback started or resumed: save the position and open a listening span. */
     fun onPlaybackStarted(
@@ -130,6 +150,57 @@ class PlaybackProgressReporter(
      * non-null on iOS/Desktop) — see `androidPlaybackModule` / `desktopPlaybackModule`.
      */
     internal fun recorderForTest(): ListeningEventRecorder? = recorder
+
+    // ── In-session pause→resume auto-rewind (#1220) ──────────────────────────────────────
+
+    /** Wall-clock ms when playback last paused, or `null` when not currently paused (or the
+     *  window was cleared by [resetAutoRewindWindow]). */
+    private var pausedAtMs: Long? = null
+
+    /**
+     * Seeks the active player back by `rewindMs` when [notePlaybackResumed] decides a rewind
+     * applies. A TRANSIENT seek, never a persisted position — see [autoRewindMs] KDoc for why.
+     * Registered by whichever platform glue owns the real player handle: Android's
+     * `PlaybackService` (via the shared `MediaLibrarySession` player), Desktop's
+     * [PlaybackManagerImpl.startPlayback] (via its local `AudioPlayer`). `null` until wired;
+     * a computed rewind with no actuator registered is silently a no-op.
+     */
+    var onAutoRewindSeek: ((rewindMs: Long) -> Unit)? = null
+
+    /**
+     * Playback paused: record the moment so [notePlaybackResumed] can measure how long the
+     * listener was away. See class KDoc for why this is safe to call unconditionally from every
+     * platform's isPlaying-transition signal, independent of the persisted trigger set.
+     */
+    fun notePlaybackPaused() {
+        pausedAtMs = nowMillis()
+    }
+
+    /**
+     * Playback resumed after an in-session pause: apply the same graduated [autoRewindMs] ladder
+     * used at prepare-time, backing playback up via [onAutoRewindSeek]. No-op when auto-rewind is
+     * disabled, the break was too short to earn a rung, no pause was recorded (including a window
+     * cleared by [resetAutoRewindWindow] — see there for why), or no actuator is registered.
+     */
+    fun notePlaybackResumed() {
+        val pausedAt = pausedAtMs ?: return
+        pausedAtMs = null
+        if (!localPreferences.autoRewindEnabled.value) return
+        val rewindMs = autoRewindMs(nowMillis() - pausedAt)
+        if (rewindMs > 0) {
+            onAutoRewindSeek?.invoke(rewindMs)
+        }
+    }
+
+    /**
+     * Clears the in-session pause window WITHOUT applying a rewind. Call when a book activates
+     * (or playback tears down) — otherwise a pause left open on the PREVIOUS book/session would
+     * leak a transition rewind onto the next book's first play, stacking on top of the
+     * prepare-time offset [PlaybackPreparer] already applied for that book.
+     */
+    fun resetAutoRewindWindow() {
+        pausedAtMs = null
+    }
 
     /** Resume position read at prepare time — pure position concern, no recording. */
     suspend fun getResumePosition(bookId: BookId): PlaybackPosition? = progressTracker.getResumePosition(bookId)

--- a/app/sharedLogic/src/iosMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.ios.kt
+++ b/app/sharedLogic/src/iosMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.ios.kt
@@ -105,6 +105,7 @@ internal val iosPlaybackModule: Module =
                 progressTracker = get(),
                 recorder = get(),
                 scope = get(qualifier = named(PLAYBACK_SCOPE)),
+                localPreferences = get(),
             )
         }
 

--- a/app/sharedLogic/src/jvmMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.jvm.kt
+++ b/app/sharedLogic/src/jvmMain/kotlin/com/calypsan/listenup/client/di/PlaybackModule.jvm.kt
@@ -27,6 +27,7 @@ val desktopPlaybackModule: Module =
                 progressTracker = get(),
                 recorder = get(),
                 scope = get(qualifier = named("playbackScope")),
+                localPreferences = get(),
             )
         }
 

--- a/app/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/di/DesktopPlaybackModuleRecorderBindingTest.kt
+++ b/app/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/di/DesktopPlaybackModuleRecorderBindingTest.kt
@@ -3,6 +3,7 @@ package com.calypsan.listenup.client.di
 import com.calypsan.listenup.api.dto.auth.DeviceInfo
 import com.calypsan.listenup.client.data.local.db.RoomTransactionRunner
 import com.calypsan.listenup.client.device.DeviceInfoProvider
+import com.calypsan.listenup.client.domain.repository.LocalPreferences
 import com.calypsan.listenup.client.playback.ListeningEventRecorder
 import com.calypsan.listenup.client.playback.PlaybackProgressReporter
 import com.calypsan.listenup.client.playback.ProgressTracker
@@ -11,10 +12,14 @@ import com.calypsan.listenup.client.test.di.KoinTestRule
 import com.calypsan.listenup.client.test.fake.FakeDownloadRepository
 import com.calypsan.listenup.client.test.fake.FakePlaybackPositionRepository
 import com.calypsan.listenup.client.test.fake.FakeProgressTracker
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.mock
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.nulls.shouldNotBeNull
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
 import org.koin.mp.KoinPlatform
@@ -55,6 +60,9 @@ class DesktopPlaybackModuleRecorderBindingTest :
                         }
                         single(qualifier = named("playbackScope")) { CoroutineScope(SupervisorJob()) }
                         single { recorder }
+                        single<LocalPreferences> {
+                            mock { every { autoRewindEnabled } returns MutableStateFlow(false) }
+                        }
                     }
                 val koinRule = KoinTestRule(listOf(fixtureModule, desktopPlaybackModule))
                 koinRule.setUp()

--- a/app/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerAutoRewindOnResumeTest.kt
+++ b/app/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerAutoRewindOnResumeTest.kt
@@ -1,0 +1,305 @@
+package com.calypsan.listenup.client.playback
+
+import com.calypsan.listenup.api.BookService
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.api.sync.BookSyncPayload
+import com.calypsan.listenup.client.data.local.db.AudioFileEntity
+import com.calypsan.listenup.client.data.local.db.BookEntity
+import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
+import com.calypsan.listenup.client.data.remote.RpcChannel
+import com.calypsan.listenup.client.data.remote.forTest
+import com.calypsan.listenup.client.data.sync.SyncDomainHandler
+import com.calypsan.listenup.client.device.DeviceContext
+import com.calypsan.listenup.client.device.DeviceType
+import com.calypsan.listenup.client.domain.model.DownloadOutcome
+import com.calypsan.listenup.client.domain.repository.ImageStorage
+import com.calypsan.listenup.client.domain.repository.LocalPreferences
+import com.calypsan.listenup.client.domain.repository.PlaybackPreferences
+import com.calypsan.listenup.client.domain.repository.ServerConfig
+import com.calypsan.listenup.client.download.DownloadService
+import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
+import com.calypsan.listenup.client.test.fake.FakePlaybackBandwidthCoordinator
+import com.calypsan.listenup.client.test.fake.FakePlayer
+import com.calypsan.listenup.core.BookId
+import com.calypsan.listenup.core.FolderId
+import com.calypsan.listenup.core.LibraryId
+import com.calypsan.listenup.core.ServerUrl
+import com.calypsan.listenup.core.Timestamp
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Regression tests for #1220: auto-rewind must also apply on in-session pause→resume, not
+ * only at prepare-time.
+ *
+ * [PlaybackManagerImpl.setPlaying] is the shared isPlaying-transition seam Android
+ * (`MediaControllerHolder.Player.Listener`) and Desktop (this class's own player-state
+ * observation in [PlaybackManagerImpl.startPlayback]) both funnel every Playing/Paused edge
+ * through. These tests cover the manager-level wiring — the seam fires
+ * [PlaybackProgressReporter.notePlaybackPaused] / [notePlaybackResumed] on real transitions,
+ * [PlaybackManagerImpl.activateBook] resets the pause window so a transition rewind never
+ * stacks on top of the prepare-time offset, and the built-in-player path registers a real
+ * seek actuator. See [PlaybackProgressReporterAutoRewindTest] for ladder-decision coverage.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class PlaybackManagerAutoRewindOnResumeTest :
+    FunSpec({
+        fun defaultPlaybackPreferences(): PlaybackPreferences {
+            val prefs: PlaybackPreferences = mock()
+            everySuspend { prefs.getDefaultPlaybackSpeed() } returns 1.0f
+            everySuspend { prefs.setDefaultPlaybackSpeed(any()) } returns Unit
+            return prefs
+        }
+
+        fun buildReporter(
+            autoRewindEnabled: Boolean,
+            nowMillis: () -> Long,
+            scope: CoroutineScope,
+        ): PlaybackProgressReporter {
+            val localPreferences: LocalPreferences = mock()
+            every { localPreferences.autoRewindEnabled } returns MutableStateFlow(autoRewindEnabled)
+            return PlaybackProgressReporter(
+                progressTracker = buildProgressTracker(scope = scope),
+                recorder = null,
+                scope = scope,
+                localPreferences = localPreferences,
+                nowMillis = nowMillis,
+            )
+        }
+
+        fun createManager(
+            db: ListenUpDatabase,
+            scope: CoroutineScope,
+            reporter: PlaybackProgressReporter,
+        ): PlaybackManager {
+            val tokenProvider: AudioTokenProvider = mock()
+            everySuspend { tokenProvider.prepareForPlayback() } returns Unit
+
+            val serverConfig: ServerConfig = mock()
+            everySuspend { serverConfig.getActiveUrl() } returns ServerUrl("https://example.test")
+
+            val imageStorage: ImageStorage = mock()
+            every { imageStorage.exists(any()) } returns false
+
+            val downloadService: DownloadService = mock()
+            everySuspend { downloadService.getLocalPath(any()) } returns null
+            everySuspend { downloadService.wasExplicitlyDeleted(any()) } returns false
+            everySuspend { downloadService.downloadBook(any()) } returns AppResult.Success(DownloadOutcome.AlreadyDownloaded)
+
+            val localPreferences: LocalPreferences = mock()
+            every { localPreferences.autoRewindEnabled } returns MutableStateFlow(false)
+
+            return PlaybackManagerImpl(
+                serverConfig = serverConfig,
+                playbackPreferences = defaultPlaybackPreferences(),
+                bookDao = db.bookDao(),
+                audioFileDao = db.audioFileDao(),
+                chapterDao = db.chapterDao(),
+                imageStorage = imageStorage,
+                progressTracker = buildProgressTracker(scope = scope),
+                reporter = reporter,
+                tokenProvider = tokenProvider,
+                deviceContext = DeviceContext(type = DeviceType.Phone),
+                downloadService = downloadService,
+                prepareRepository = testPlaybackPrepareRepository("af-0"),
+                channel = RpcChannel.forTest(mock<BookService>()),
+                scope = scope,
+                bookSyncDomainHandler = mock<SyncDomainHandler<BookSyncPayload>>(),
+                localPreferences = localPreferences,
+                playbackBandwidthCoordinator = FakePlaybackBandwidthCoordinator(),
+                persistTransitionsViaReporter = true,
+            )
+        }
+
+        suspend fun seedBook(db: ListenUpDatabase) {
+            db.bookDao().upsert(
+                BookEntity(
+                    id = BookId("book-1"),
+                    libraryId = LibraryId("test-library"),
+                    folderId = FolderId("test-folder"),
+                    title = "Test Book",
+                    sortTitle = "Test Book",
+                    subtitle = null,
+                    coverHash = null,
+                    totalDuration = 1_800_000L,
+                    description = null,
+                    publishYear = null,
+                    publisher = null,
+                    language = null,
+                    isbn = null,
+                    asin = null,
+                    abridged = false,
+                    createdAt = Timestamp(1L),
+                    updatedAt = Timestamp(1L),
+                ),
+            )
+            db.audioFileDao().upsertAll(
+                listOf(
+                    AudioFileEntity(
+                        bookId = BookId("book-1"),
+                        index = 0,
+                        id = "af-0",
+                        filename = "chapter0.mp3",
+                        format = "mp3",
+                        codec = "aac",
+                        duration = 1_800_000L,
+                        size = 1_000L,
+                    ),
+                ),
+            )
+        }
+
+        test("setPlaying(false) then setPlaying(true) after a long gap seeks via the registered actuator") {
+            val db = createInMemoryTestDatabase()
+            try {
+                runTest {
+                    val scope = CoroutineScope(coroutineContext + Job())
+                    var now = 0L
+                    val reporter = buildReporter(autoRewindEnabled = true, nowMillis = { now }, scope = scope)
+                    val manager = createManager(db, scope, reporter)
+                    var seekedMs: Long? = null
+                    reporter.onAutoRewindSeek = { seekedMs = it }
+
+                    manager.activateBook(BookId("book-1"))
+                    manager.setPlaying(true)
+                    manager.setPlaying(false)
+                    now += 2 * 3_600_000L
+                    manager.setPlaying(true)
+
+                    seekedMs shouldBe 15_000L
+                    scope.coroutineContext[Job]?.cancel()
+                }
+            } finally {
+                db.close()
+            }
+        }
+
+        test("a short pause does not seek") {
+            val db = createInMemoryTestDatabase()
+            try {
+                runTest {
+                    val scope = CoroutineScope(coroutineContext + Job())
+                    var now = 0L
+                    val reporter = buildReporter(autoRewindEnabled = true, nowMillis = { now }, scope = scope)
+                    val manager = createManager(db, scope, reporter)
+                    var seekedMs: Long? = null
+                    reporter.onAutoRewindSeek = { seekedMs = it }
+
+                    manager.activateBook(BookId("book-1"))
+                    manager.setPlaying(true)
+                    manager.setPlaying(false)
+                    now += 2_000L
+                    manager.setPlaying(true)
+
+                    seekedMs.shouldBeNull()
+                    scope.coroutineContext[Job]?.cancel()
+                }
+            } finally {
+                db.close()
+            }
+        }
+
+        test("activateBook resets the pause window so prepare-time rewind never stacks") {
+            val db = createInMemoryTestDatabase()
+            try {
+                runTest {
+                    val scope = CoroutineScope(coroutineContext + Job())
+                    var now = 0L
+                    val reporter = buildReporter(autoRewindEnabled = true, nowMillis = { now }, scope = scope)
+                    val manager = createManager(db, scope, reporter)
+
+                    // Book A pauses; a long time passes.
+                    manager.activateBook(BookId("book-A"))
+                    manager.setPlaying(true)
+                    manager.setPlaying(false)
+                    now += 2 * 86_400_000L
+
+                    // Book B activates (a fresh prepare) — its own rewind already happened via
+                    // PlaybackPreparer. The leftover pause window from book A must not ALSO
+                    // fire a transition rewind here.
+                    var seeks = 0
+                    reporter.onAutoRewindSeek = { seeks++ }
+                    manager.activateBook(BookId("book-1"))
+                    manager.setPlaying(true)
+
+                    seeks shouldBe 0
+                    scope.coroutineContext[Job]?.cancel()
+                }
+            } finally {
+                db.close()
+            }
+        }
+
+        test("clearPlayback resets the pause window") {
+            val db = createInMemoryTestDatabase()
+            try {
+                runTest {
+                    val scope = CoroutineScope(coroutineContext + Job())
+                    var now = 0L
+                    val reporter = buildReporter(autoRewindEnabled = true, nowMillis = { now }, scope = scope)
+                    val manager = createManager(db, scope, reporter)
+
+                    manager.activateBook(BookId("book-1"))
+                    manager.setPlaying(true)
+                    manager.setPlaying(false)
+                    now += 2 * 86_400_000L
+                    manager.clearPlayback()
+
+                    var seeks = 0
+                    reporter.onAutoRewindSeek = { seeks++ }
+                    manager.activateBook(BookId("book-1"))
+                    manager.setPlaying(true)
+
+                    seeks shouldBe 0
+                    scope.coroutineContext[Job]?.cancel()
+                }
+            } finally {
+                db.close()
+            }
+        }
+
+        test("the built-in-player path registers a working seek actuator on startPlayback") {
+            val db = createInMemoryTestDatabase()
+            try {
+                runTest {
+                    seedBook(db)
+                    val scope = CoroutineScope(coroutineContext + Job())
+                    var now = 0L
+                    val reporter = buildReporter(autoRewindEnabled = true, nowMillis = { now }, scope = scope)
+                    val manager = createManager(db, scope, reporter)
+
+                    val prepared = manager.prepareForPlayback(BookId("book-1"))
+                    checkNotNull(prepared) { "prepareForPlayback must succeed" }
+                    manager.activateBook(BookId("book-1"))
+
+                    val player = FakePlayer()
+                    manager.startPlayback(player = player, resumePositionMs = 100_000L, resumeSpeed = 1.0f)
+                    advanceUntilIdle() // player.play() -> Playing -> setPlaying(true) (no-op: window was just reset)
+
+                    manager.setPlaying(false)
+                    now += 2 * 3_600_000L
+                    manager.setPlaying(true)
+                    advanceUntilIdle()
+
+                    // 15s rung, backed off from the position at the moment of resume (100_000).
+                    manager.currentPositionMs.value shouldBe 85_000L
+
+                    scope.coroutineContext[Job]?.cancel()
+                }
+            } finally {
+                db.close()
+            }
+        }
+    })

--- a/app/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerBufferingStateTest.kt
+++ b/app/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerBufferingStateTest.kt
@@ -85,7 +85,13 @@ class PlaybackManagerBufferingStateTest :
                 chapterDao = db.chapterDao(),
                 imageStorage = imageStorage,
                 progressTracker = progressTracker,
-                reporter = PlaybackProgressReporter(progressTracker, recorder = null, scope = scope),
+                reporter =
+                    PlaybackProgressReporter(
+                        progressTracker,
+                        recorder = null,
+                        scope = scope,
+                        localPreferences = localPreferences,
+                    ),
                 tokenProvider = tokenProvider,
                 deviceContext = DeviceContext(type = DeviceType.Phone),
                 downloadService = downloadService,

--- a/app/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerFallbackFetchTest.kt
+++ b/app/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerFallbackFetchTest.kt
@@ -159,7 +159,13 @@ class PlaybackManagerFallbackFetchTest :
                 chapterDao = db.chapterDao(),
                 imageStorage = imageStorage,
                 progressTracker = progressTracker,
-                reporter = PlaybackProgressReporter(progressTracker, recorder = null, scope = CoroutineScope(Job())),
+                reporter =
+                    PlaybackProgressReporter(
+                        progressTracker,
+                        recorder = null,
+                        scope = CoroutineScope(Job()),
+                        localPreferences = localPreferences,
+                    ),
                 tokenProvider = tokenProvider,
                 deviceContext = DeviceContext(type = DeviceType.Phone),
                 downloadService = downloadService,

--- a/app/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerPositionTransitionTest.kt
+++ b/app/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerPositionTransitionTest.kt
@@ -100,7 +100,13 @@ class PlaybackManagerPositionTransitionTest :
                 chapterDao = db.chapterDao(),
                 imageStorage = imageStorage,
                 progressTracker = progressTracker,
-                reporter = PlaybackProgressReporter(progressTracker, recorder = null, scope = scope),
+                reporter =
+                    PlaybackProgressReporter(
+                        progressTracker,
+                        recorder = null,
+                        scope = scope,
+                        localPreferences = localPreferences,
+                    ),
                 tokenProvider = tokenProvider,
                 deviceContext = DeviceContext(type = DeviceType.Phone),
                 downloadService = downloadService,

--- a/app/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerPrepareTest.kt
+++ b/app/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerPrepareTest.kt
@@ -115,7 +115,13 @@ class PlaybackManagerPrepareTest :
                 chapterDao = db.chapterDao(),
                 imageStorage = imageStorage,
                 progressTracker = progressTracker,
-                reporter = PlaybackProgressReporter(progressTracker, recorder = null, scope = CoroutineScope(Job())),
+                reporter =
+                    PlaybackProgressReporter(
+                        progressTracker,
+                        recorder = null,
+                        scope = CoroutineScope(Job()),
+                        localPreferences = localPreferences,
+                    ),
                 tokenProvider = tokenProvider,
                 deviceContext = DeviceContext(type = DeviceType.Phone),
                 downloadService = downloadService,

--- a/app/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerSpeedTest.kt
+++ b/app/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackManagerSpeedTest.kt
@@ -100,7 +100,13 @@ class PlaybackManagerSpeedTest :
                 chapterDao = db.chapterDao(),
                 imageStorage = imageStorage,
                 progressTracker = progressTracker,
-                reporter = PlaybackProgressReporter(progressTracker, recorder = null, scope = scope),
+                reporter =
+                    PlaybackProgressReporter(
+                        progressTracker,
+                        recorder = null,
+                        scope = scope,
+                        localPreferences = localPreferences,
+                    ),
                 tokenProvider = tokenProvider,
                 deviceContext = DeviceContext(type = DeviceType.Phone),
                 downloadService = downloadService,

--- a/app/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackProgressReporterAutoRewindTest.kt
+++ b/app/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackProgressReporterAutoRewindTest.kt
@@ -1,0 +1,169 @@
+package com.calypsan.listenup.client.playback
+
+import com.calypsan.listenup.client.domain.repository.DownloadRepository
+import com.calypsan.listenup.client.domain.repository.LocalPreferences
+import com.calypsan.listenup.client.test.fake.FakePlaybackPositionRepository
+import com.calypsan.listenup.client.test.fake.FakeProgressTracker
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.mock
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+
+/**
+ * Regression tests for #1220: auto-rewind must also apply on in-session pause→resume, not
+ * only at prepare-time (see [PlaybackPreparer.resumeStartPositionMs] / [autoRewindMs]).
+ *
+ * [PlaybackProgressReporter.notePlaybackPaused] / [notePlaybackResumed] are the shared decision
+ * point for the ladder itself — reused verbatim from [autoRewindMs], never forked. Manager-level
+ * wiring (the real [PlaybackManagerImpl.setPlaying] seam, [PlaybackManagerImpl.activateBook]'s
+ * reset, the built-in-player actuator) is covered separately in
+ * [PlaybackManagerAutoRewindOnResumeTest].
+ */
+class PlaybackProgressReporterAutoRewindTest :
+    FunSpec({
+
+        fun buildReporter(
+            autoRewindEnabled: Boolean = true,
+            nowMillis: () -> Long,
+        ): Pair<PlaybackProgressReporter, FakeProgressTracker> {
+            val tracker =
+                FakeProgressTracker(
+                    downloadRepository = mock<DownloadRepository>(),
+                    positionRepository = FakePlaybackPositionRepository(),
+                    scope = CoroutineScope(Job()),
+                )
+            val localPreferences: LocalPreferences = mock()
+            every { localPreferences.autoRewindEnabled } returns MutableStateFlow(autoRewindEnabled)
+            val reporter =
+                PlaybackProgressReporter(
+                    progressTracker = tracker,
+                    recorder = null,
+                    scope = CoroutineScope(Job()),
+                    localPreferences = localPreferences,
+                    nowMillis = nowMillis,
+                )
+            return reporter to tracker
+        }
+
+        // ── ladder decision at the seam ──────────────────────────────────────────────────
+
+        test("pausing three minutes then resuming applies the short-break rung") {
+            var now = 0L
+            val (reporter, _) = buildReporter(nowMillis = { now })
+            var seekedMs: Long? = null
+            reporter.onAutoRewindSeek = { seekedMs = it }
+
+            reporter.notePlaybackPaused()
+            now += 3 * 60_000L
+            reporter.notePlaybackResumed()
+
+            seekedMs shouldBe 5_000L
+        }
+
+        test("pausing two seconds then resuming does not rewind") {
+            var now = 0L
+            val (reporter, _) = buildReporter(nowMillis = { now })
+            var seekedMs: Long? = null
+            reporter.onAutoRewindSeek = { seekedMs = it }
+
+            reporter.notePlaybackPaused()
+            now += 2_000L
+            reporter.notePlaybackResumed()
+
+            seekedMs.shouldBeNull()
+        }
+
+        test("auto-rewind disabled never seeks, however long the pause") {
+            var now = 0L
+            val (reporter, _) = buildReporter(autoRewindEnabled = false, nowMillis = { now })
+            var seekedMs: Long? = null
+            reporter.onAutoRewindSeek = { seekedMs = it }
+
+            reporter.notePlaybackPaused()
+            now += 2 * 86_400_000L
+            reporter.notePlaybackResumed()
+
+            seekedMs.shouldBeNull()
+        }
+
+        test("resuming without ever pausing does not seek") {
+            var now = 0L
+            val (reporter, _) = buildReporter(nowMillis = { now })
+            var seeks = 0
+            reporter.onAutoRewindSeek = { seeks++ }
+
+            reporter.notePlaybackResumed()
+
+            seeks shouldBe 0
+        }
+
+        // ── no stacking with the prepare-time rewind ─────────────────────────────────────
+
+        test("resetAutoRewindWindow suppresses a stale pause from a previous book/session") {
+            var now = 0L
+            val (reporter, _) = buildReporter(nowMillis = { now })
+            var seeks = 0
+            reporter.onAutoRewindSeek = { seeks++ }
+
+            // Book A pauses; a long time passes.
+            reporter.notePlaybackPaused()
+            now += 2 * 86_400_000L
+
+            // Book B activates — its own prepare-time rewind already ran via PlaybackPreparer.
+            // The stale window from book A must not ALSO fire a transition rewind here.
+            reporter.resetAutoRewindWindow()
+            reporter.notePlaybackResumed()
+
+            seeks shouldBe 0
+        }
+
+        test("repeated pause/resume cycles apply the ladder independently, never compounding") {
+            var now = 0L
+            val (reporter, _) = buildReporter(nowMillis = { now })
+            val seeks = mutableListOf<Long>()
+            reporter.onAutoRewindSeek = { seeks += it }
+
+            reporter.notePlaybackPaused()
+            now += 90 * 60_000L // 90 min away -> hour-to-day rung
+            reporter.notePlaybackResumed()
+
+            reporter.notePlaybackPaused()
+            now += 30_000L // 30s away -> no rung
+            reporter.notePlaybackResumed()
+
+            reporter.notePlaybackPaused()
+            now += 10 * 60_000L // 10 min away -> short-break rung
+            reporter.notePlaybackResumed()
+
+            seeks shouldBe listOf(15_000L, 5_000L)
+        }
+
+        // ── never persisted ───────────────────────────────────────────────────────────────
+
+        test("the transition rewind never flows into position or listening-event persistence") {
+            var now = 0L
+            val (reporter, tracker) = buildReporter(nowMillis = { now })
+            reporter.onAutoRewindSeek = { }
+
+            reporter.notePlaybackPaused()
+            now += 2 * 86_400_000L
+            reporter.notePlaybackResumed()
+
+            tracker.onPlaybackStartedCalls shouldBe emptyList()
+            tracker.onPlaybackPausedCalls shouldBe emptyList()
+        }
+
+        test("a computed rewind with no actuator registered is a silent no-op") {
+            var now = 0L
+            val (reporter, _) = buildReporter(nowMillis = { now })
+            // onAutoRewindSeek left null (default) — must not throw.
+            reporter.notePlaybackPaused()
+            now += 2 * 86_400_000L
+            reporter.notePlaybackResumed()
+        }
+    })

--- a/app/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackProgressReporterTest.kt
+++ b/app/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/playback/PlaybackProgressReporterTest.kt
@@ -13,10 +13,12 @@ import com.calypsan.listenup.client.data.sync.domains.OpKind
 import com.calypsan.listenup.client.data.sync.domains.OutboxChannels
 import com.calypsan.listenup.client.device.DeviceInfoProvider
 import com.calypsan.listenup.client.domain.repository.DownloadRepository
+import com.calypsan.listenup.client.domain.repository.LocalPreferences
 import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
 import com.calypsan.listenup.client.test.fake.FakePlaybackPositionRepository
 import com.calypsan.listenup.client.test.fake.FakeProgressTracker
 import dev.mokkery.answering.returns
+import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
@@ -24,6 +26,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -198,7 +201,16 @@ private suspend fun withReporterFixture(
                 scope = scope,
             )
 
-        val reporter = PlaybackProgressReporter(tracker, recorder, scope)
+        val localPreferences: LocalPreferences = mock()
+        every { localPreferences.autoRewindEnabled } returns MutableStateFlow(false)
+        val reporter =
+            PlaybackProgressReporter(
+                tracker,
+                recorder,
+                scope,
+                localPreferences = localPreferences,
+                nowMillis = { now },
+            )
 
         block(reporter, db, captured, tracker) { now = it }
     } finally {

--- a/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
+++ b/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
@@ -104,6 +104,7 @@ class PlaybackService : MediaLibraryService() {
 
     // Inject dependencies
     private val playbackManager: PlaybackManager by inject()
+    private val reporter: PlaybackProgressReporter by inject()
     private val progressTracker: ProgressTracker by inject()
     private val listeningEventRecorder: com.calypsan.listenup.client.playback.ListeningEventRecorder by inject()
     private val positionRepository: PlaybackPositionRepository by inject()
@@ -164,6 +165,27 @@ class PlaybackService : MediaLibraryService() {
         playbackManager.onChapterChanged = { chapterInfo ->
             logger.debug { "Chapter changed: ${chapterInfo.title}" }
             updateNotificationForChapter(chapterInfo)
+        }
+
+        // Auto-rewind-on-resume actuator (#1220): PlaybackManagerImpl.setPlaying feeds every
+        // Playing/Paused transition (from the Player.Listener below, via MediaControllerHolder)
+        // into the reporter, which owns the pause-window/ladder decision and calls back here
+        // with a relative rewind once one applies. Mirrors COMMAND_SKIP_BACK_30's book-relative
+        // seek — routes to the active session player so it also seeks correctly while casting.
+        reporter.onAutoRewindSeek = { rewindMs ->
+            val p = mediaLibrarySession?.player ?: player
+            if (p != null) {
+                val timeline = playbackManager.currentTimeline.value
+                val newPosition = (getBookRelativePosition() - rewindMs).coerceAtLeast(0)
+                if (timeline != null) {
+                    val resolved = timeline.resolve(newPosition)
+                    p.seekTo(resolved.mediaItemIndex, resolved.positionInFileMs)
+                } else {
+                    p.seekTo((p.currentPosition - rewindMs).coerceAtLeast(0))
+                }
+                playbackManager.updatePosition(newPosition)
+                logger.debug { "Auto-rewind on resume: backed up ${rewindMs}ms to ${newPosition}ms" }
+            }
         }
     }
 
@@ -482,6 +504,7 @@ class PlaybackService : MediaLibraryService() {
 
         // Clear chapter change callback to avoid memory leaks
         playbackManager.onChapterChanged = null
+        reporter.onAutoRewindSeek = null
 
         // Release session before player — the session holds a reference to the player.
         // player?.release() runs unconditionally so the native decoder is freed even


### PR DESCRIPTION
Closes #1220.

Auto-rewind previously fired only from `PlaybackPreparer` at prepare time, so it covered cold start and switching books but not the more frequent case: pausing an already-prepared book and coming back to it later in the same session.

## The seam

The issue's blocker was that the pause→play transition is owned by a different component on each platform. Rather than three call sites, this routes them all through the one they already share: `PlaybackManagerImpl.setPlaying()`, which Android (`MediaControllerHolder`'s `Player.Listener`) and Desktop (the built-in player's state observation) both already funnel every Playing/Paused edge through.

`PlaybackProgressReporter` gains `notePlaybackPaused()` / `notePlaybackResumed()` — deliberately a **separate pair** from the persisted trigger set, carrying no persistence side effect of their own, so they are safe to call unconditionally even on Android, which opts out of routing `onPlaybackStarted`/`onPlaybackPaused` through this reporter (`persistTransitionsViaReporter = false`).

The reporter owns the decision; platform glue owns the actuation via `onAutoRewindSeek`:

- **Android** — `PlaybackService`, seeking through `PlaybackTimeline.resolve` so it stays correct while casting (mirrors `COMMAND_SKIP_BACK_30`).
- **Desktop** — `PlaybackManagerImpl.startPlayback`, re-registered per session so the closure never captures a stale player.
- **iOS** — not wired. `PlayerCoordinator` needs its own native calls; unregistered is a documented silent no-op, not a crash. Called out in the KDoc as outstanding.

## Constraints from the issue, all preserved

- **Ladder not forked** — both paths call `autoRewindMs()`. Its first rung is `< 1 min → 0`, so ExoPlayer's transient `isPlaying = false` during seeks and buffering can't produce a spurious rewind.
- **No stacking with the prepare-time offset** — `resetAutoRewindWindow()` on `activateBook` and `clearPlayback`, so a pause window left open on a previous book can't leak a transition rewind onto the next book's first play.
- **Never a persisted position** — the rewind path touches in-memory state only; a test asserts the progress tracker sees no writes.
- **Honours `LocalPreferences.autoRewindEnabled`.**

## Tests

13 new cases across the two seams — ladder decisions, the disabled preference, resume-without-pause, both reset paths, repeated cycles not compounding, no-actuator-registered, and the built-in-player path seeking for real. `KoinModuleVerifyTest` gains `LocalPreferences` in `androidPlaybackModule`'s `extraTypes` (it's owned by `settingsModule`).

`./gradlew verifyLocal` green.