### PR TITLE
✨ feat(sharedUI): chapter-scoped system playback surfaces (Android Auto, notification, lock screen)

### DIFF
--- a/app/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/AndroidPlaybackControllerTest.kt
+++ b/app/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/AndroidPlaybackControllerTest.kt
@@ -14,8 +14,14 @@ import kotlinx.coroutines.test.runTest
  *
  * 1. acquire/release delegate to [ControllerHolder]
  * 2. isReady mirrors holder.isConnected
- * 3. All command methods are silent no-ops when controller is null (no crash)
- * 4. resolveQueuePosition index and offset arithmetic
+ * 3. All command methods are silent no-ops when controller is null (no crash) — including
+ *    [AndroidPlaybackController.seekTo], which now sends a `SEEK_TO_BOOK_POSITION` custom
+ *    command rather than resolving a cached queue; the null-controller guard fires first either
+ *    way, so no separate coverage of the custom-command send itself lives here (it's adapter
+ *    glue over a non-instantiable [MediaController], the same reasoning as `ChapterWindowPlayer`'s
+ *    "No androidHostTest for this class" KDoc).
+ * 4. resolveQueuePosition index and offset arithmetic (now [AndroidPlaybackController.setMediaQueue]'s
+ *    sole caller — see [AndroidPlaybackController.seekTo]'s KDoc for why seeks no longer use it)
  */
 class AndroidPlaybackControllerTest :
     FunSpec({
@@ -130,7 +136,8 @@ class AndroidPlaybackControllerTest :
 
         // ---------------------------------------------------------------------------
         // resolveQueuePosition — pure arithmetic, no Media3 needed
-        // Used by both setMediaQueue and seekTo call sites.
+        // Used by setMediaQueue only — seekTo rides the SEEK_TO_BOOK_POSITION custom
+        // command instead (see AndroidPlaybackController.seekTo's KDoc).
         // ---------------------------------------------------------------------------
 
         test("resolveQueuePosition returns 0 0 for empty item list") {
@@ -187,15 +194,6 @@ class AndroidPlaybackControllerTest :
             // Total duration = 150_000. seekTo(200_000) — past end.
             // Should return (1, 90_000L) — LAST item's durationMs, not controller.duration
             sut.resolveQueuePosition(items, 200_000L) shouldBe (1 to 90_000L)
-        }
-
-        test("seekTo with empty cached queue does not throw and falls back gracefully") {
-            val holder = FakeControllerHolder() // controller is always null
-            val sut = AndroidPlaybackController(holder)
-
-            // No setMediaQueue call — cachedQueue is empty. Controller is null so the
-            // null-check fires first; either way the call must not throw.
-            sut.seekTo(5_000L)
         }
     })
 

--- a/app/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/ChapterWindowTest.kt
+++ b/app/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/ChapterWindowTest.kt
@@ -209,27 +209,27 @@ class ChapterWindowTest :
         }
 
         context("hasPreviousChapter / hasNextChapter") {
-            test("first chapter has no previous chapter") {
+            test("first chapter still reports a previous chapter — restart-current is always available") {
                 val window = currentChapterWindow(threeChapters, bookPositionMs = 0L, totalDurationMs)
-                hasPreviousChapter(threeChapters, window) shouldBe false
+                hasPreviousChapter() shouldBe true
                 hasNextChapter(threeChapters, window) shouldBe true
             }
 
             test("middle chapter has both a previous and a next chapter") {
                 val window = currentChapterWindow(threeChapters, bookPositionMs = 150_000L, totalDurationMs)
-                hasPreviousChapter(threeChapters, window) shouldBe true
+                hasPreviousChapter() shouldBe true
                 hasNextChapter(threeChapters, window) shouldBe true
             }
 
-            test("last chapter has no next chapter") {
+            test("last chapter still reports a previous chapter; has no next chapter") {
                 val window = currentChapterWindow(threeChapters, bookPositionMs = 260_000L, totalDurationMs)
-                hasPreviousChapter(threeChapters, window) shouldBe true
+                hasPreviousChapter() shouldBe true
                 hasNextChapter(threeChapters, window) shouldBe false
             }
 
-            test("chapterless book has neither") {
+            test("chapterless book still reports a previous window (restart-the-book) but no next") {
                 val window = currentChapterWindow(emptyList(), bookPositionMs = 50_000L, totalDurationMs)
-                hasPreviousChapter(emptyList(), window) shouldBe false
+                hasPreviousChapter() shouldBe true
                 hasNextChapter(emptyList(), window) shouldBe false
             }
         }

--- a/app/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/ChapterWindowTest.kt
+++ b/app/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/ChapterWindowTest.kt
@@ -1,0 +1,236 @@
+package com.calypsan.listenup.client.playback
+
+import com.calypsan.listenup.client.domain.model.Chapter
+import com.calypsan.listenup.client.domain.playback.PlaybackTimeline
+import com.calypsan.listenup.client.domain.playback.TimelineFileInput
+import com.calypsan.listenup.core.BookId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+private fun chapter(
+    id: String,
+    title: String,
+    startTime: Long,
+    duration: Long,
+) = Chapter(id = id, title = title, duration = duration, startTime = startTime)
+
+/**
+ * Pure chapter-window-math tests for [currentChapterWindow], [seekTargetToBookPosition],
+ * [previousChapterTarget], and [nextChapterTarget].
+ *
+ * The Media3-aware companion [ChapterWindowPlayer] is exercised on a real device (its
+ * constructor requires a live `Looper`, unavailable in this Robolectric-free host-test
+ * lane — see the note on [ChapterWindowPlayer] itself); all the actual chapter-window
+ * logic lives here so it can be verified without that runtime, mirroring the
+ * [controllerTrustOf] / [ControllerGatingTest] split.
+ */
+class ChapterWindowTest :
+    FunSpec({
+
+        val threeChapters =
+            listOf(
+                chapter("c1", "Chapter One", startTime = 0L, duration = 100_000L),
+                chapter("c2", "Chapter Two", startTime = 100_000L, duration = 150_000L),
+                chapter("c3", "Chapter Three", startTime = 250_000L, duration = 50_000L),
+            )
+        val totalDurationMs = 300_000L
+
+        context("currentChapterWindow") {
+            test("position at the very start of the book resolves to chapter 0") {
+                val window = currentChapterWindow(threeChapters, bookPositionMs = 0L, totalDurationMs)
+                window.chapterIndex shouldBe 0
+                window.windowStartMs shouldBe 0L
+                window.windowDurationMs shouldBe 100_000L
+                window.positionInWindowMs shouldBe 0L
+            }
+
+            test("mid-chapter position resolves relative position within that chapter") {
+                val window = currentChapterWindow(threeChapters, bookPositionMs = 150_000L, totalDurationMs)
+                window.chapterIndex shouldBe 1
+                window.windowStartMs shouldBe 100_000L
+                window.windowDurationMs shouldBe 150_000L
+                window.positionInWindowMs shouldBe 50_000L
+            }
+
+            test("position exactly on a chapter boundary resolves to the new chapter, not the old one") {
+                val window = currentChapterWindow(threeChapters, bookPositionMs = 100_000L, totalDurationMs)
+                window.chapterIndex shouldBe 1
+                window.positionInWindowMs shouldBe 0L
+            }
+
+            test("last chapter's window duration runs to the end of the book") {
+                val window = currentChapterWindow(threeChapters, bookPositionMs = 260_000L, totalDurationMs)
+                window.chapterIndex shouldBe 2
+                window.windowStartMs shouldBe 250_000L
+                window.windowDurationMs shouldBe 50_000L
+                window.positionInWindowMs shouldBe 10_000L
+            }
+
+            test("position past the last chapter's end clamps into that chapter's window") {
+                val window = currentChapterWindow(threeChapters, bookPositionMs = 500_000L, totalDurationMs)
+                window.chapterIndex shouldBe 2
+                window.positionInWindowMs shouldBe window.windowDurationMs
+            }
+
+            test("position before the first chapter's start (non-zero first chapter) clamps to window start") {
+                val chapters = listOf(chapter("c1", "Intro skipped", startTime = 5_000L, duration = 95_000L))
+                val window = currentChapterWindow(chapters, bookPositionMs = 0L, totalBookDurationMs = 100_000L)
+                window.chapterIndex shouldBe 0
+                window.positionInWindowMs shouldBe 0L
+            }
+
+            test("chapterless book presents the whole book as a single window") {
+                val window = currentChapterWindow(emptyList(), bookPositionMs = 42_000L, totalDurationMs)
+                window.chapterIndex shouldBe -1
+                window.windowStartMs shouldBe 0L
+                window.windowDurationMs shouldBe totalDurationMs
+                window.positionInWindowMs shouldBe 42_000L
+            }
+        }
+
+        context("seekTargetToBookPosition") {
+            test("in-window seek maps directly to a book position") {
+                val window = currentChapterWindow(threeChapters, bookPositionMs = 150_000L, totalDurationMs)
+                window.seekTargetToBookPosition(30_000L) shouldBe 130_000L
+            }
+
+            test("out-of-range seek clamps to the window bounds") {
+                val window = currentChapterWindow(threeChapters, bookPositionMs = 150_000L, totalDurationMs)
+                window.seekTargetToBookPosition(-10_000L) shouldBe 100_000L
+                window.seekTargetToBookPosition(999_000L) shouldBe 250_000L
+            }
+
+            test("round-trips through a real PlaybackTimeline across a file boundary") {
+                val timeline =
+                    PlaybackTimeline.build(
+                        bookId = BookId("book-1"),
+                        files =
+                            listOf(
+                                TimelineFileInput(
+                                    audioFileId = "af-1",
+                                    filename = "part1.mp3",
+                                    format = "mp3",
+                                    durationMs = 180_000L,
+                                    size = 1_000L,
+                                    localPath = "/tmp/part1.mp3",
+                                    streamingUrl = "",
+                                ),
+                                TimelineFileInput(
+                                    audioFileId = "af-2",
+                                    filename = "part2.mp3",
+                                    format = "mp3",
+                                    durationMs = 180_000L,
+                                    size = 1_000L,
+                                    localPath = "/tmp/part2.mp3",
+                                    streamingUrl = "",
+                                ),
+                            ),
+                    )
+                // Chapter 2 spans the file boundary: file 0 ends at 180_000, chapter starts at 150_000.
+                val chapters =
+                    listOf(
+                        chapter("c1", "Chapter One", startTime = 0L, duration = 150_000L),
+                        chapter("c2", "Chapter Two", startTime = 150_000L, duration = 100_000L),
+                    )
+
+                // Currently 20s into chapter 2, which itself started 30s before the file boundary —
+                // so this is 50s into file 1 (index 1).
+                val bookPositionMs = timeline.toBookPosition(mediaItemIndex = 1, positionInFileMs = 50_000L)
+                bookPositionMs shouldBe 230_000L
+
+                val window = currentChapterWindow(chapters, bookPositionMs, timeline.totalDurationMs)
+                window.chapterIndex shouldBe 1
+                window.positionInWindowMs shouldBe 80_000L
+
+                // Seek to 10s into chapter 2 — should land 20s before the file boundary, still file 0.
+                val seekBookPositionMs = window.seekTargetToBookPosition(10_000L)
+                seekBookPositionMs shouldBe 160_000L
+                val resolved = timeline.resolve(seekBookPositionMs)
+                resolved.mediaItemIndex shouldBe 0
+                resolved.positionInFileMs shouldBe 160_000L
+
+                // Seek to 50s into chapter 2 — past the file boundary, into file 1.
+                val seekIntoFile2Ms = window.seekTargetToBookPosition(50_000L)
+                seekIntoFile2Ms shouldBe 200_000L
+                val resolvedFile2 = timeline.resolve(seekIntoFile2Ms)
+                resolvedFile2.mediaItemIndex shouldBe 1
+                resolvedFile2.positionInFileMs shouldBe 20_000L
+            }
+        }
+
+        context("previousChapterTarget") {
+            test("early in the current chapter, previous moves to the start of the prior chapter") {
+                val target = previousChapterTarget(threeChapters, bookPositionMs = 101_000L, totalDurationMs)
+                target shouldBe 0L
+            }
+
+            test("more than the restart threshold into the chapter, previous restarts the current chapter") {
+                val target = previousChapterTarget(threeChapters, bookPositionMs = 120_000L, totalDurationMs)
+                target shouldBe 100_000L
+            }
+
+            test("exactly at the restart threshold still moves to the prior chapter") {
+                val target =
+                    previousChapterTarget(
+                        threeChapters,
+                        bookPositionMs = 100_000L + 3_000L,
+                        totalDurationMs,
+                        restartThresholdMs = 3_000L,
+                    )
+                target shouldBe 0L
+            }
+
+            test("clamps at the first chapter — previous always restarts it, never goes negative") {
+                val target = previousChapterTarget(threeChapters, bookPositionMs = 500L, totalDurationMs)
+                target shouldBe 0L
+            }
+
+            test("chapterless book restarts the book") {
+                val target = previousChapterTarget(emptyList(), bookPositionMs = 50_000L, totalDurationMs)
+                target shouldBe 0L
+            }
+        }
+
+        context("nextChapterTarget") {
+            test("moves to the start of the next chapter") {
+                val target = nextChapterTarget(threeChapters, bookPositionMs = 50_000L, totalDurationMs)
+                target shouldBe 100_000L
+            }
+
+            test("clamps at the last chapter — stays at its own start") {
+                val target = nextChapterTarget(threeChapters, bookPositionMs = 260_000L, totalDurationMs)
+                target shouldBe 250_000L
+            }
+
+            test("chapterless book has no next target beyond the book start") {
+                val target = nextChapterTarget(emptyList(), bookPositionMs = 50_000L, totalDurationMs)
+                target shouldBe 0L
+            }
+        }
+
+        context("hasPreviousChapter / hasNextChapter") {
+            test("first chapter has no previous chapter") {
+                val window = currentChapterWindow(threeChapters, bookPositionMs = 0L, totalDurationMs)
+                hasPreviousChapter(threeChapters, window) shouldBe false
+                hasNextChapter(threeChapters, window) shouldBe true
+            }
+
+            test("middle chapter has both a previous and a next chapter") {
+                val window = currentChapterWindow(threeChapters, bookPositionMs = 150_000L, totalDurationMs)
+                hasPreviousChapter(threeChapters, window) shouldBe true
+                hasNextChapter(threeChapters, window) shouldBe true
+            }
+
+            test("last chapter has no next chapter") {
+                val window = currentChapterWindow(threeChapters, bookPositionMs = 260_000L, totalDurationMs)
+                hasPreviousChapter(threeChapters, window) shouldBe true
+                hasNextChapter(threeChapters, window) shouldBe false
+            }
+
+            test("chapterless book has neither") {
+                val window = currentChapterWindow(emptyList(), bookPositionMs = 50_000L, totalDurationMs)
+                hasPreviousChapter(emptyList(), window) shouldBe false
+                hasNextChapter(emptyList(), window) shouldBe false
+            }
+        }
+    })

--- a/app/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/ChapterWindowTest.kt
+++ b/app/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/ChapterWindowTest.kt
@@ -209,27 +209,29 @@ class ChapterWindowTest :
         }
 
         context("hasPreviousChapter / hasNextChapter") {
-            test("first chapter still reports a previous chapter — restart-current is always available") {
+            test("previous is always available — restart-current, even at chapter 0 or a chapterless book") {
+                // Not scenario-dependent: hasPreviousChapter() takes no window/chapters input by
+                // design (see its KDoc) — this is the one assertion of that invariant.
+                hasPreviousChapter() shouldBe true
+            }
+
+            test("first chapter has a next chapter") {
                 val window = currentChapterWindow(threeChapters, bookPositionMs = 0L, totalDurationMs)
-                hasPreviousChapter() shouldBe true
                 hasNextChapter(threeChapters, window) shouldBe true
             }
 
-            test("middle chapter has both a previous and a next chapter") {
+            test("middle chapter has a next chapter") {
                 val window = currentChapterWindow(threeChapters, bookPositionMs = 150_000L, totalDurationMs)
-                hasPreviousChapter() shouldBe true
                 hasNextChapter(threeChapters, window) shouldBe true
             }
 
-            test("last chapter still reports a previous chapter; has no next chapter") {
+            test("last chapter has no next chapter") {
                 val window = currentChapterWindow(threeChapters, bookPositionMs = 260_000L, totalDurationMs)
-                hasPreviousChapter() shouldBe true
                 hasNextChapter(threeChapters, window) shouldBe false
             }
 
-            test("chapterless book still reports a previous window (restart-the-book) but no next") {
+            test("chapterless book has no next chapter") {
                 val window = currentChapterWindow(emptyList(), bookPositionMs = 50_000L, totalDurationMs)
-                hasPreviousChapter() shouldBe true
                 hasNextChapter(emptyList(), window) shouldBe false
             }
         }

--- a/app/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/MediaControllerHolderTest.kt
+++ b/app/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/MediaControllerHolderTest.kt
@@ -27,7 +27,6 @@ class MediaControllerHolderTest :
                     MediaControllerHolder(
                         context = stubContext,
                         playbackManager = writer,
-                        scope = this.backgroundScope,
                     )
 
                 holder.playerListener.onIsPlayingChanged(true)
@@ -44,7 +43,6 @@ class MediaControllerHolderTest :
                     MediaControllerHolder(
                         context = stubContext,
                         playbackManager = writer,
-                        scope = this.backgroundScope,
                     )
 
                 holder.playerListener.onPlaybackStateChanged(Player.STATE_BUFFERING)
@@ -61,7 +59,6 @@ class MediaControllerHolderTest :
                     MediaControllerHolder(
                         context = stubContext,
                         playbackManager = writer,
-                        scope = this.backgroundScope,
                     )
                 // _controller is null at this point — toCommonPlaybackState returns Paused
                 holder.playerListener.onPlaybackStateChanged(Player.STATE_READY)
@@ -83,7 +80,6 @@ class MediaControllerHolderTest :
                     MediaControllerHolder(
                         context = stubContext,
                         playbackManager = writer,
-                        scope = this.backgroundScope,
                     )
 
                 holder.playerListener.onPlaybackParametersChanged(PlaybackParameters(1.5f))

--- a/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
+++ b/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
@@ -230,7 +230,6 @@ val playbackModule =
             MediaControllerHolder(
                 context = get(),
                 playbackManager = get(),
-                scope = get(),
             )
         }
 

--- a/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/automotive/CustomActions.kt
+++ b/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/automotive/CustomActions.kt
@@ -20,6 +20,17 @@ object CustomActions {
     // Bundle keys for sleep timer
     const val EXTRA_TIMER_MINUTES = "timer_minutes"
 
+    // In-app book-relative seek. The session player is ChapterWindowPlayer, the chapter-scoped
+    // presentation wrapper (see its class KDoc), so a plain controller.seekTo(index, positionMs)
+    // is reinterpreted chapter-relatively and clamped to the current chapter window — it cannot
+    // express a book position. This custom command carries the book-relative target explicitly
+    // instead, and PlaybackService's onCustomCommand handler resolves it against the raw
+    // transport player, bypassing the wrapper's chapter-relative reinterpretation entirely.
+    const val SEEK_TO_BOOK_POSITION = "com.calypsan.listenup.SEEK_TO_BOOK_POSITION"
+
+    // Bundle key for the book-relative seek target, in milliseconds.
+    const val EXTRA_BOOK_POSITION_MS = "book_position_ms"
+
     /**
      * Speed options for cycling (in order).
      */
@@ -80,4 +91,22 @@ object CustomActions {
      * Create SessionCommand for canceling sleep timer.
      */
     fun cancelSleepTimerCommand(): SessionCommand = SessionCommand(CANCEL_SLEEP_TIMER, Bundle.EMPTY)
+
+    /**
+     * Create SessionCommand for the in-app book-relative seek transport.
+     *
+     * Advertised with [Bundle.EMPTY] extras — [SessionCommand] equality (used by Media3 to match
+     * an advertised command against an incoming one) ignores extras, so this matches sends built
+     * with [seekToBookPositionArgs] carrying the actual target.
+     */
+    fun seekToBookPositionCommand(): SessionCommand = SessionCommand(SEEK_TO_BOOK_POSITION, Bundle.EMPTY)
+
+    /**
+     * Build the args [Bundle] for a [seekToBookPositionCommand] send: the book-relative seek
+     * target, in milliseconds.
+     */
+    fun seekToBookPositionArgs(positionMs: Long): Bundle =
+        Bundle().apply {
+            putLong(EXTRA_BOOK_POSITION_MS, positionMs)
+        }
 }

--- a/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/AndroidPlaybackController.kt
+++ b/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/AndroidPlaybackController.kt
@@ -5,6 +5,7 @@ import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import androidx.media3.common.PlaybackParameters
 import androidx.media3.session.MediaController
+import com.calypsan.listenup.client.automotive.CustomActions
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.flow.StateFlow
 
@@ -57,27 +58,35 @@ class AndroidPlaybackController(
             ?: logger.warn { "AndroidPlaybackController.pause: controller not ready" }
     }
 
+    /**
+     * Seeks to a book-relative position by round-tripping it through the session as a custom
+     * command, rather than resolving it to a `(index, offset)` pair and calling
+     * `controller.seekTo(index, offset)` directly.
+     *
+     * The session player is [ChapterWindowPlayer], the chapter-scoped presentation wrapper (see
+     * its class KDoc) — a plain controller-side seek is interpreted by the wrapper as
+     * chapter-relative and clamped to the current chapter window, so a cross-chapter book-relative
+     * seek would silently land in the wrong place. [CustomActions.SEEK_TO_BOOK_POSITION] carries
+     * the book-relative target as-is; [PlaybackService.onCustomCommand] resolves it against the
+     * raw transport player, bypassing the wrapper's chapter-relative reinterpretation entirely.
+     */
     override fun seekTo(positionMs: Long) {
         val controller = holder.controller
         if (controller == null) {
             logger.warn { "AndroidPlaybackController.seekTo($positionMs): controller not ready" }
             return
         }
-        if (cachedQueue.isEmpty()) {
-            logger.warn {
-                "AndroidPlaybackController.seekTo($positionMs): no cached queue, falling back to single-arg seek"
-            }
-            controller.seekTo(positionMs)
-            return
-        }
-        val (index, offset) = resolveQueuePosition(cachedQueue, positionMs)
-        logger.debug { "AndroidPlaybackController.seekTo: bookPos=$positionMs → idx=$index, offset=$offset" }
-        controller.seekTo(index, offset)
+        logger.debug { "AndroidPlaybackController.seekTo: bookPos=$positionMs via SEEK_TO_BOOK_POSITION" }
+        controller.sendCustomCommand(
+            CustomActions.seekToBookPositionCommand(),
+            CustomActions.seekToBookPositionArgs(positionMs),
+        )
     }
 
     /**
-     * Resolves a book-relative position (ms) to a `(itemIndex, offsetWithinItem)` pair
-     * suitable for Media3 `seekTo(windowIndex, positionMs)` and `setMediaItems(..., startIndex, positionMs)`.
+     * Resolves a book-relative position (ms) to a `(itemIndex, offsetWithinItem)` pair suitable
+     * for Media3 `setMediaItems(..., startIndex, positionMs)`. (Book-relative seeks no longer use
+     * this — see [seekTo]'s KDoc — this is now [setMediaQueue]'s sole caller.)
      *
      * - Empty list → `(0, 0)`
      * - Position within an item → `(itemIndex, bookPositionMs - item.offsetMs)`

--- a/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/ChapterWindow.kt
+++ b/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/ChapterWindow.kt
@@ -17,7 +17,7 @@ import com.calypsan.listenup.client.domain.model.Chapter
  * @property windowDurationMs Length of this window, in milliseconds.
  * @property positionInWindowMs Position within the window, clamped to `[0, windowDurationMs]`.
  */
-data class ChapterWindow(
+internal data class ChapterWindow(
     val chapterIndex: Int,
     val windowStartMs: Long,
     val windowDurationMs: Long,
@@ -37,7 +37,7 @@ data class ChapterWindow(
  * When [chapters] is empty, the whole book is presented as a single window — the
  * chapterless-book fallback required by every caller of this function.
  */
-fun currentChapterWindow(
+internal fun currentChapterWindow(
     chapters: List<Chapter>,
     bookPositionMs: Long,
     totalBookDurationMs: Long,
@@ -68,8 +68,11 @@ fun currentChapterWindow(
  * Translates a chapter-relative seek target (as reported by a system surface's seek bar)
  * into a book-relative position, clamped to this window's bounds.
  */
-fun ChapterWindow.seekTargetToBookPosition(chapterRelativePositionMs: Long): Long =
+internal fun ChapterWindow.seekTargetToBookPosition(chapterRelativePositionMs: Long): Long =
     windowStartMs + chapterRelativePositionMs.coerceIn(0L, windowDurationMs)
+
+/** Default "previous" restart-vs-jump threshold — see [previousChapterTarget]. */
+internal const val PREVIOUS_RESTART_THRESHOLD_MS = 3_000L
 
 /**
  * Book-relative target for a "previous" (skip-to-previous-chapter) command.
@@ -77,16 +80,18 @@ fun ChapterWindow.seekTargetToBookPosition(chapterRelativePositionMs: Long): Lon
  * Standard media-player "restart" behavior: more than [restartThresholdMs] into the
  * current chapter restarts it (returns its start); otherwise the target is the previous
  * chapter's start. Clamped at the first chapter — there is never a previous chapter to
- * move into, but restarting the current (first) chapter is always the fallback.
+ * move into, but restarting the current (first) chapter is always the fallback. A
+ * chapterless book resolves to [ChapterWindow.chapterIndex] `-1`, which is already `<= 0`,
+ * so it naturally falls into that same restart-the-window clamp without a separate check.
  */
-fun previousChapterTarget(
+internal fun previousChapterTarget(
     chapters: List<Chapter>,
     bookPositionMs: Long,
     totalBookDurationMs: Long,
-    restartThresholdMs: Long = 3_000L,
+    restartThresholdMs: Long = PREVIOUS_RESTART_THRESHOLD_MS,
 ): Long {
     val window = currentChapterWindow(chapters, bookPositionMs, totalBookDurationMs)
-    if (chapters.isEmpty() || window.chapterIndex <= 0 || window.positionInWindowMs > restartThresholdMs) {
+    if (window.chapterIndex <= 0 || window.positionInWindowMs > restartThresholdMs) {
         return window.windowStartMs
     }
     return chapters[window.chapterIndex - 1].startTime
@@ -96,17 +101,15 @@ fun previousChapterTarget(
  * Book-relative target for a "next" (skip-to-next-chapter) command.
  *
  * Clamped at the last chapter — there is no next chapter to move into, so the target
- * stays at the current chapter's own start.
+ * stays at the current chapter's own start. A chapterless book has no chapter at
+ * `chapterIndex + 1` to find, so it naturally falls into that same clamp.
  */
-fun nextChapterTarget(
+internal fun nextChapterTarget(
     chapters: List<Chapter>,
     bookPositionMs: Long,
     totalBookDurationMs: Long,
 ): Long {
     val window = currentChapterWindow(chapters, bookPositionMs, totalBookDurationMs)
-    if (chapters.isEmpty()) {
-        return window.windowStartMs
-    }
     return chapters.getOrNull(window.chapterIndex + 1)?.startTime ?: window.windowStartMs
 }
 
@@ -122,10 +125,15 @@ fun nextChapterTarget(
  * [ChapterWindowPlayer] reads the same way for both commands, and so a future change to this
  * rule has one place to land.
  */
-fun hasPreviousChapter(): Boolean = true
+internal fun hasPreviousChapter(): Boolean = true
 
-/** True when a chapter follows [window]'s chapter — gates COMMAND_SEEK_TO_NEXT availability. */
-fun hasNextChapter(
+/**
+ * True when a chapter follows [window]'s chapter — gates COMMAND_SEEK_TO_NEXT availability.
+ *
+ * A chapterless book resolves to `chapterIndex` `-1` against `chapters.lastIndex` `-1`,
+ * which is already false, so an empty [chapters] list needs no separate check.
+ */
+internal fun hasNextChapter(
     chapters: List<Chapter>,
     window: ChapterWindow,
-): Boolean = chapters.isNotEmpty() && window.chapterIndex < chapters.lastIndex
+): Boolean = window.chapterIndex < chapters.lastIndex

--- a/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/ChapterWindow.kt
+++ b/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/ChapterWindow.kt
@@ -110,11 +110,19 @@ fun nextChapterTarget(
     return chapters.getOrNull(window.chapterIndex + 1)?.startTime ?: window.windowStartMs
 }
 
-/** True when a chapter precedes [window]'s chapter — gates COMMAND_SEEK_TO_PREVIOUS availability. */
-fun hasPreviousChapter(
-    chapters: List<Chapter>,
-    window: ChapterWindow,
-): Boolean = chapters.isNotEmpty() && window.chapterIndex > 0
+/**
+ * Always true — `COMMAND_SEEK_TO_PREVIOUS` is never gated on a prior chapter existing.
+ *
+ * Standard Media3/media-player UX keeps "previous" available as a restart-the-current-window
+ * affordance even at the first chapter (or in a chapterless book): [previousChapterTarget]
+ * already resolves that case to a harmless clamp at the window's own start. Greying the button
+ * out here — the failure mode the design explicitly calls out to avoid — would only be correct
+ * if restart were unavailable too, which it never is. Kept as a named predicate (matching
+ * [hasNextChapter]'s shape, even though it needs no inputs) so the call site in
+ * [ChapterWindowPlayer] reads the same way for both commands, and so a future change to this
+ * rule has one place to land.
+ */
+fun hasPreviousChapter(): Boolean = true
 
 /** True when a chapter follows [window]'s chapter — gates COMMAND_SEEK_TO_NEXT availability. */
 fun hasNextChapter(

--- a/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/ChapterWindow.kt
+++ b/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/ChapterWindow.kt
@@ -1,0 +1,123 @@
+package com.calypsan.listenup.client.playback
+
+import com.calypsan.listenup.client.domain.model.Chapter
+
+/**
+ * A single-chapter view of book-relative playback position.
+ *
+ * System playback surfaces (Android Auto now-playing, the notification, the lock screen,
+ * Bluetooth/AVRCP, Wear) present elapsed/remaining time and the seek bar for the *current
+ * chapter*, not the whole book — the same way a music player shows the current track, not
+ * the whole album. [ChapterWindow] is that re-presentation: a chapter-relative window over
+ * the book's absolute timeline.
+ *
+ * @property chapterIndex Index into the chapters list, or `-1` when the book has no chapters
+ *   (the whole book is presented as one window in that case).
+ * @property windowStartMs Book-relative start of this window, in milliseconds.
+ * @property windowDurationMs Length of this window, in milliseconds.
+ * @property positionInWindowMs Position within the window, clamped to `[0, windowDurationMs]`.
+ */
+data class ChapterWindow(
+    val chapterIndex: Int,
+    val windowStartMs: Long,
+    val windowDurationMs: Long,
+    val positionInWindowMs: Long,
+)
+
+/**
+ * Computes the [ChapterWindow] containing [bookPositionMs].
+ *
+ * Chapter resolution (last chapter whose start is at-or-before the position) mirrors
+ * `PlaybackManagerImpl.updateCurrentChapter` so the in-app chapter indicator and the
+ * system-surface window never disagree about which chapter is "current". A chapter's
+ * window end is the next chapter's start, or the book's total duration for the last
+ * chapter — chapters have no stored end, and this keeps windows contiguous even if a
+ * chapter's own `duration` field doesn't exactly match the gap to the next chapter.
+ *
+ * When [chapters] is empty, the whole book is presented as a single window — the
+ * chapterless-book fallback required by every caller of this function.
+ */
+fun currentChapterWindow(
+    chapters: List<Chapter>,
+    bookPositionMs: Long,
+    totalBookDurationMs: Long,
+): ChapterWindow {
+    if (chapters.isEmpty()) {
+        return ChapterWindow(
+            chapterIndex = -1,
+            windowStartMs = 0L,
+            windowDurationMs = totalBookDurationMs,
+            positionInWindowMs = bookPositionMs.coerceIn(0L, totalBookDurationMs),
+        )
+    }
+
+    val index = chapters.indexOfLast { it.startTime <= bookPositionMs }.coerceAtLeast(0)
+    val chapter = chapters[index]
+    val windowEndMs = chapters.getOrNull(index + 1)?.startTime ?: totalBookDurationMs
+    val windowDurationMs = (windowEndMs - chapter.startTime).coerceAtLeast(0L)
+
+    return ChapterWindow(
+        chapterIndex = index,
+        windowStartMs = chapter.startTime,
+        windowDurationMs = windowDurationMs,
+        positionInWindowMs = (bookPositionMs - chapter.startTime).coerceIn(0L, windowDurationMs),
+    )
+}
+
+/**
+ * Translates a chapter-relative seek target (as reported by a system surface's seek bar)
+ * into a book-relative position, clamped to this window's bounds.
+ */
+fun ChapterWindow.seekTargetToBookPosition(chapterRelativePositionMs: Long): Long =
+    windowStartMs + chapterRelativePositionMs.coerceIn(0L, windowDurationMs)
+
+/**
+ * Book-relative target for a "previous" (skip-to-previous-chapter) command.
+ *
+ * Standard media-player "restart" behavior: more than [restartThresholdMs] into the
+ * current chapter restarts it (returns its start); otherwise the target is the previous
+ * chapter's start. Clamped at the first chapter — there is never a previous chapter to
+ * move into, but restarting the current (first) chapter is always the fallback.
+ */
+fun previousChapterTarget(
+    chapters: List<Chapter>,
+    bookPositionMs: Long,
+    totalBookDurationMs: Long,
+    restartThresholdMs: Long = 3_000L,
+): Long {
+    val window = currentChapterWindow(chapters, bookPositionMs, totalBookDurationMs)
+    if (chapters.isEmpty() || window.chapterIndex <= 0 || window.positionInWindowMs > restartThresholdMs) {
+        return window.windowStartMs
+    }
+    return chapters[window.chapterIndex - 1].startTime
+}
+
+/**
+ * Book-relative target for a "next" (skip-to-next-chapter) command.
+ *
+ * Clamped at the last chapter — there is no next chapter to move into, so the target
+ * stays at the current chapter's own start.
+ */
+fun nextChapterTarget(
+    chapters: List<Chapter>,
+    bookPositionMs: Long,
+    totalBookDurationMs: Long,
+): Long {
+    val window = currentChapterWindow(chapters, bookPositionMs, totalBookDurationMs)
+    if (chapters.isEmpty()) {
+        return window.windowStartMs
+    }
+    return chapters.getOrNull(window.chapterIndex + 1)?.startTime ?: window.windowStartMs
+}
+
+/** True when a chapter precedes [window]'s chapter — gates COMMAND_SEEK_TO_PREVIOUS availability. */
+fun hasPreviousChapter(
+    chapters: List<Chapter>,
+    window: ChapterWindow,
+): Boolean = chapters.isNotEmpty() && window.chapterIndex > 0
+
+/** True when a chapter follows [window]'s chapter — gates COMMAND_SEEK_TO_NEXT availability. */
+fun hasNextChapter(
+    chapters: List<Chapter>,
+    window: ChapterWindow,
+): Boolean = chapters.isNotEmpty() && window.chapterIndex < chapters.lastIndex

--- a/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/ChapterWindowPlayer.kt
+++ b/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/ChapterWindowPlayer.kt
@@ -115,10 +115,36 @@ class ChapterWindowPlayer(
             .buildUpon()
             .setPlaylist(listOf(chapterMediaItemData(baseState, context.window, context.chapters, player)))
             .setCurrentMediaItemIndex(0)
-            .setContentPositionMs(context.window.positionInWindowMs)
+            .setContentPositionMs(windowPositionSupplier(context.window))
             .setAvailableCommands(baseState.availableCommands.withChapterSeekCommands(context.chapters, context.window))
             .build()
     }
+
+    /**
+     * Live [SimpleBasePlayer.PositionSupplier] for [window]'s position, re-derived from the
+     * underlying player on every call rather than stamped once at [getState]-build time.
+     *
+     * `setContentPositionMs(Long)` freezes the position at the moment [getState] runs. That's
+     * fine for a Media3 controller, which re-polls [getState] on its own cadence and gets a fresh
+     * stamp each time — but an in-process reader holding onto a [State] between
+     * [ForwardingSimpleBasePlayer]'s automatic invalidations (see the class KDoc's "Invalidation"
+     * section) would see the position frozen at whatever it was when that [State] was built. A
+     * supplier fixes that the same way [SimpleBasePlayer.PositionSupplier.getExtrapolating] does
+     * for a raw player position, and matches [SimpleBasePlayer]'s own idiom for live-advancing
+     * positions (`setContentPositionMs(PositionSupplier)`).
+     */
+    private fun windowPositionSupplier(window: ChapterWindow): SimpleBasePlayer.PositionSupplier =
+        SimpleBasePlayer.PositionSupplier {
+            val timeline = timelineProvider()
+            if (timeline == null) {
+                // Timeline gone (playback torn down) — fall back to the position captured when
+                // this window was computed rather than crashing or returning a stale zero.
+                window.positionInWindowMs
+            } else {
+                val liveBookPositionMs = timeline.toBookPosition(player.currentMediaItemIndex, player.currentPosition)
+                (liveBookPositionMs - window.windowStartMs).coerceIn(0L, window.windowDurationMs)
+            }
+        }
 
     override fun handleSeek(
         mediaItemIndex: Int,

--- a/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/ChapterWindowPlayer.kt
+++ b/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/ChapterWindowPlayer.kt
@@ -14,8 +14,19 @@ import com.google.common.util.concurrent.ListenableFuture
 /** Stable UID for the single [SimpleBasePlayer.MediaItemData] every reported [SimpleBasePlayer.State] carries. */
 private const val CHAPTER_WINDOW_MEDIA_ITEM_UID = "chapter-window"
 
-/** Restart-current-chapter threshold for the "previous" command — see [ChapterWindowPlayer] KDoc. */
-private const val PREVIOUS_RESTART_THRESHOLD_MS = 3_000L
+/**
+ * Snapshot of everything [ChapterWindowPlayer.getState] and [ChapterWindowPlayer.handleSeek]
+ * both need: the chapters, the underlying player's book-relative position, the [ChapterWindow]
+ * derived from it, and the [PlaybackTimeline] used to resolve book positions back to
+ * player coordinates. Computed once per call by `currentChapterContext()` so the two
+ * override points never drift on how they read the underlying player.
+ */
+private data class ChapterSeekContext(
+    val chapters: List<Chapter>,
+    val bookPositionMs: Long,
+    val window: ChapterWindow,
+    val timeline: PlaybackTimeline,
+)
 
 /**
  * Re-presents the wrapped local ExoPlayer as a single-window timeline scoped to the current
@@ -37,9 +48,10 @@ private const val PREVIOUS_RESTART_THRESHOLD_MS = 3_000L
  * `BasePlayer.seekToPrevious()`/`seekToNext()` always route through [handleSeek] with
  * `COMMAND_SEEK_TO_PREVIOUS`/`COMMAND_SEEK_TO_NEXT` (there is never a previous/next *media item*
  * to hop to), which is exactly what car head-unit prev/next buttons invoke. "Previous" restarts
- * the current chapter when more than [PREVIOUS_RESTART_THRESHOLD_MS] into it — standard
- * media-player behavior — otherwise it moves to the previous chapter's start (or, at the first
- * chapter / in a chapterless book, clamps to the window's own start — a harmless restart).
+ * the current chapter when more than [PREVIOUS_RESTART_THRESHOLD_MS] into it (the default
+ * [previousChapterTarget] applies) — standard media-player behavior — otherwise it moves to the
+ * previous chapter's start (or, at the first chapter / in a chapterless book, clamps to the
+ * window's own start — a harmless restart).
  * `COMMAND_SEEK_TO_PREVIOUS` (and its `_MEDIA_ITEM` variant) is therefore *always* advertised via
  * [getState] — [hasPreviousChapter] — matching standard Media3/media-player UX where "previous"
  * is never greyed out; it's always at least a restart affordance. `COMMAND_SEEK_TO_NEXT` (and its
@@ -92,23 +104,14 @@ class ChapterWindowPlayer(
 
     override fun getState(): State {
         val baseState = super.getState()
-        val timeline = timelineProvider() ?: return baseState
-        val chapters = chaptersProvider()
-        val underlyingPlayer = player
-
-        val bookPositionMs =
-            timeline.toBookPosition(
-                underlyingPlayer.currentMediaItemIndex,
-                underlyingPlayer.currentPosition,
-            )
-        val window = currentChapterWindow(chapters, bookPositionMs, timeline.totalDurationMs)
+        val context = currentChapterContext() ?: return baseState
 
         return baseState
             .buildUpon()
-            .setPlaylist(listOf(chapterMediaItemData(baseState, window, chapters, underlyingPlayer)))
+            .setPlaylist(listOf(chapterMediaItemData(baseState, context.window, context.chapters, player)))
             .setCurrentMediaItemIndex(0)
-            .setContentPositionMs(window.positionInWindowMs)
-            .setAvailableCommands(baseState.availableCommands.withChapterSeekCommands(chapters, window))
+            .setContentPositionMs(context.window.positionInWindowMs)
+            .setAvailableCommands(baseState.availableCommands.withChapterSeekCommands(context.chapters, context.window))
             .build()
     }
 
@@ -117,38 +120,29 @@ class ChapterWindowPlayer(
         positionMs: Long,
         seekCommand: Int,
     ): ListenableFuture<*> {
-        val timeline = timelineProvider() ?: return super.handleSeek(mediaItemIndex, positionMs, seekCommand)
         if (seekCommand == Player.COMMAND_SEEK_BACK || seekCommand == Player.COMMAND_SEEK_FORWARD) {
             // Skip-back/forward increments operate on the real player position directly —
             // they aren't chapter-relative, so the default handling is already correct.
             return super.handleSeek(mediaItemIndex, positionMs, seekCommand)
         }
-
-        val chapters = chaptersProvider()
-        val currentBookPositionMs = timeline.toBookPosition(player.currentMediaItemIndex, player.currentPosition)
-        val window = currentChapterWindow(chapters, currentBookPositionMs, timeline.totalDurationMs)
+        val context = currentChapterContext() ?: return super.handleSeek(mediaItemIndex, positionMs, seekCommand)
 
         val targetBookPositionMs =
             when (seekCommand) {
                 Player.COMMAND_SEEK_TO_PREVIOUS, Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM -> {
-                    previousChapterTarget(
-                        chapters,
-                        currentBookPositionMs,
-                        timeline.totalDurationMs,
-                        PREVIOUS_RESTART_THRESHOLD_MS,
-                    )
+                    previousChapterTarget(context.chapters, context.bookPositionMs, context.timeline.totalDurationMs)
                 }
 
                 Player.COMMAND_SEEK_TO_NEXT, Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM -> {
-                    nextChapterTarget(chapters, currentBookPositionMs, timeline.totalDurationMs)
+                    nextChapterTarget(context.chapters, context.bookPositionMs, context.timeline.totalDurationMs)
                 }
 
                 Player.COMMAND_SEEK_TO_DEFAULT_POSITION -> {
-                    window.windowStartMs
+                    context.window.windowStartMs
                 }
 
                 Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM, Player.COMMAND_SEEK_TO_MEDIA_ITEM -> {
-                    window.seekTargetToBookPosition(positionMs)
+                    context.window.seekTargetToBookPosition(positionMs)
                 }
 
                 else -> {
@@ -156,9 +150,23 @@ class ChapterWindowPlayer(
                 }
             }
 
-        val resolved = timeline.resolve(targetBookPositionMs)
+        val resolved = context.timeline.resolve(targetBookPositionMs)
         player.seekTo(resolved.mediaItemIndex, resolved.positionInFileMs)
         return Futures.immediateVoidFuture()
+    }
+
+    /**
+     * Reads the underlying player's current book position and derives the [ChapterWindow] it
+     * falls in — the single computation [getState] and [handleSeek] both build on. Returns null
+     * before playback has been prepared (no [PlaybackTimeline] yet), in which case callers fall
+     * back to default `ForwardingSimpleBasePlayer`/`SimpleBasePlayer` handling.
+     */
+    private fun currentChapterContext(): ChapterSeekContext? {
+        val timeline = timelineProvider() ?: return null
+        val chapters = chaptersProvider()
+        val bookPositionMs = timeline.toBookPosition(player.currentMediaItemIndex, player.currentPosition)
+        val window = currentChapterWindow(chapters, bookPositionMs, timeline.totalDurationMs)
+        return ChapterSeekContext(chapters, bookPositionMs, window, timeline)
     }
 
     /** Builds the single [SimpleBasePlayer.MediaItemData] representing [window]. */

--- a/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/ChapterWindowPlayer.kt
+++ b/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/ChapterWindowPlayer.kt
@@ -42,7 +42,7 @@ private data class ChapterSeekContext(
  * and pass through this wrapper unmodified.
  *
  * This is handed to `MediaLibrarySession.Builder` in place of the raw local player
- * (`PlaybackService`, in a follow-up change). All chapter-window math is pure and lives in
+ * (see `PlaybackService.initializeMediaSession`). All chapter-window math is pure and lives in
  * [ChapterWindow.kt][ChapterWindow] — this class is a thin [ForwardingSimpleBasePlayer] adapter
  * over it, following the same split as [ControllerTrust]/[controllerTrustOf] in
  * `ControllerGating.kt`.

--- a/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/ChapterWindowPlayer.kt
+++ b/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/ChapterWindowPlayer.kt
@@ -1,0 +1,206 @@
+package com.calypsan.listenup.client.playback
+
+import androidx.annotation.OptIn
+import androidx.media3.common.ForwardingSimpleBasePlayer
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
+import androidx.media3.common.SimpleBasePlayer
+import androidx.media3.common.util.UnstableApi
+import com.calypsan.listenup.client.domain.model.Chapter
+import com.calypsan.listenup.client.domain.playback.PlaybackTimeline
+import com.google.common.util.concurrent.Futures
+import com.google.common.util.concurrent.ListenableFuture
+
+/** Stable UID for the single [SimpleBasePlayer.MediaItemData] every reported [SimpleBasePlayer.State] carries. */
+private const val CHAPTER_WINDOW_MEDIA_ITEM_UID = "chapter-window"
+
+/** Restart-current-chapter threshold for the "previous" command — see [ChapterWindowPlayer] KDoc. */
+private const val PREVIOUS_RESTART_THRESHOLD_MS = 3_000L
+
+/**
+ * Re-presents the wrapped local ExoPlayer as a single-window timeline scoped to the current
+ * chapter, so every system playback surface (Android Auto now-playing, the phone notification,
+ * the lock screen, Bluetooth/AVRCP, Wear) shows elapsed/remaining time and a seek bar for the
+ * *chapter*, not the whole book or the underlying audio file — the same way a music player
+ * shows the current track, not the whole album. In-app UI is unaffected; it reads
+ * `PlaybackManager` directly and never touches this wrapper.
+ *
+ * This is handed to `MediaLibrarySession.Builder` in place of the raw local player
+ * (`PlaybackService`, in a follow-up change). All chapter-window math is pure and lives in
+ * [ChapterWindow.kt][ChapterWindow] — this class is a thin [ForwardingSimpleBasePlayer] adapter
+ * over it, following the same split as [ControllerTrust]/[controllerTrustOf] in
+ * `ControllerGating.kt`.
+ *
+ * **Previous/next chapter mapping.** `Player.seekToPrevious()`/`seekToNext()` normally bypass
+ * chapter logic entirely — chapter skip today only exists as custom session commands. Because
+ * this wrapper always reports a single-item playlist (the current chapter's window), Media3's
+ * `BasePlayer.seekToPrevious()`/`seekToNext()` always route through [handleSeek] with
+ * `COMMAND_SEEK_TO_PREVIOUS`/`COMMAND_SEEK_TO_NEXT` (there is never a previous/next *media item*
+ * to hop to), which is exactly what car head-unit prev/next buttons invoke. "Previous" restarts
+ * the current chapter when more than [PREVIOUS_RESTART_THRESHOLD_MS] into it — standard
+ * media-player behavior — otherwise it moves to the previous chapter's start. Both commands
+ * (and their `_MEDIA_ITEM` variants, in case a controller prefers those) are only advertised via
+ * [getState] when a previous/next chapter actually exists — [hasPreviousChapter]/
+ * [hasNextChapter] — so a controller greys out the button at the first/last chapter rather than
+ * firing a seek that silently restarts it.
+ *
+ * **Invalidation.** [ForwardingSimpleBasePlayer] already invalidates state automatically on
+ * every underlying-player event (play/pause, buffering, ExoPlayer-driven position
+ * discontinuities). The one case that doesn't cover is a chapter boundary crossed purely by
+ * elapsed playback time — no underlying-player event fires for that. [invalidate] is the public
+ * hook for it: the service collects `PlaybackManager.currentChapter` and calls [invalidate] on
+ * chapter rollover so connected controllers pick up the new chapter title/duration together with
+ * a position discontinuity.
+ *
+ * **Chapterless / single-chapter books.** When [chaptersProvider] returns an empty list,
+ * [currentChapterWindow] presents the whole book as one window — no special-casing is visible to
+ * controllers; they simply see a single "chapter" spanning the whole book.
+ *
+ * **No androidHostTest for this class.** Unlike `SpeedAwareCastPlayer`
+ * (`playback/cast/SpeedAwareCastPlayer.kt`), which can be constructed with a bare
+ * `mock<Player>()`, this class can't be instantiated at all in this Robolectric-free lane:
+ * `SimpleBasePlayer`'s constructor calls `player.getApplicationLooper()` and builds a real
+ * `Handler` from it immediately, and even stubbing that call with Mokkery to return
+ * `Looper.getMainLooper()` throws `RuntimeException: Method getMainLooper in android.os.Looper
+ * not mocked` (verified empirically) — there is no way to hand it a working `Looper` without
+ * Robolectric. Every chapter-window calculation this class depends on lives in
+ * [ChapterWindow.kt][ChapterWindow] and is fully covered by `ChapterWindowTest`; this adapter
+ * layer (state/metadata assembly, command gating, seek dispatch) is exercised on a real device
+ * instead.
+ *
+ * @param player The local ExoPlayer instance to wrap.
+ * @param chaptersProvider Synchronous snapshot of the current book's chapters (empty when the
+ *   book has none). The service passes `playbackManager.chapters.value`.
+ * @param timelineProvider Synchronous snapshot of the file/offset timeline for the currently
+ *   playing book, or null before playback has been prepared. The service passes
+ *   `playbackManager.currentTimeline.value`.
+ */
+@OptIn(UnstableApi::class)
+class ChapterWindowPlayer(
+    player: Player,
+    private val chaptersProvider: () -> List<Chapter>,
+    private val timelineProvider: () -> PlaybackTimeline?,
+) : ForwardingSimpleBasePlayer(player) {
+    /**
+     * Forces every connected controller to re-read [getState] and observe a position
+     * discontinuity. See the "Invalidation" section of the class KDoc for when this is needed
+     * beyond [ForwardingSimpleBasePlayer]'s automatic invalidation.
+     */
+    fun invalidate() = invalidateState()
+
+    override fun getState(): State {
+        val baseState = super.getState()
+        val timeline = timelineProvider() ?: return baseState
+        val chapters = chaptersProvider()
+        val underlyingPlayer = player
+
+        val bookPositionMs =
+            timeline.toBookPosition(
+                underlyingPlayer.currentMediaItemIndex,
+                underlyingPlayer.currentPosition,
+            )
+        val window = currentChapterWindow(chapters, bookPositionMs, timeline.totalDurationMs)
+
+        return baseState
+            .buildUpon()
+            .setPlaylist(listOf(chapterMediaItemData(baseState, window, chapters, underlyingPlayer)))
+            .setCurrentMediaItemIndex(0)
+            .setContentPositionMs(window.positionInWindowMs)
+            .setAvailableCommands(baseState.availableCommands.withChapterSeekCommands(chapters, window))
+            .build()
+    }
+
+    override fun handleSeek(
+        mediaItemIndex: Int,
+        positionMs: Long,
+        seekCommand: Int,
+    ): ListenableFuture<*> {
+        val timeline = timelineProvider() ?: return super.handleSeek(mediaItemIndex, positionMs, seekCommand)
+        if (seekCommand == Player.COMMAND_SEEK_BACK || seekCommand == Player.COMMAND_SEEK_FORWARD) {
+            // Skip-back/forward increments operate on the real player position directly —
+            // they aren't chapter-relative, so the default handling is already correct.
+            return super.handleSeek(mediaItemIndex, positionMs, seekCommand)
+        }
+
+        val chapters = chaptersProvider()
+        val currentBookPositionMs = timeline.toBookPosition(player.currentMediaItemIndex, player.currentPosition)
+        val window = currentChapterWindow(chapters, currentBookPositionMs, timeline.totalDurationMs)
+
+        val targetBookPositionMs =
+            when (seekCommand) {
+                Player.COMMAND_SEEK_TO_PREVIOUS, Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM -> {
+                    previousChapterTarget(
+                        chapters,
+                        currentBookPositionMs,
+                        timeline.totalDurationMs,
+                        PREVIOUS_RESTART_THRESHOLD_MS,
+                    )
+                }
+
+                Player.COMMAND_SEEK_TO_NEXT, Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM -> {
+                    nextChapterTarget(chapters, currentBookPositionMs, timeline.totalDurationMs)
+                }
+
+                Player.COMMAND_SEEK_TO_DEFAULT_POSITION -> {
+                    window.windowStartMs
+                }
+
+                Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM, Player.COMMAND_SEEK_TO_MEDIA_ITEM -> {
+                    window.seekTargetToBookPosition(positionMs)
+                }
+
+                else -> {
+                    return super.handleSeek(mediaItemIndex, positionMs, seekCommand)
+                }
+            }
+
+        val resolved = timeline.resolve(targetBookPositionMs)
+        player.seekTo(resolved.mediaItemIndex, resolved.positionInFileMs)
+        return Futures.immediateVoidFuture()
+    }
+
+    /** Builds the single [SimpleBasePlayer.MediaItemData] representing [window]. */
+    private fun chapterMediaItemData(
+        baseState: State,
+        window: ChapterWindow,
+        chapters: List<Chapter>,
+        underlyingPlayer: Player,
+    ): SimpleBasePlayer.MediaItemData {
+        val chapterTitle = chapters.getOrNull(window.chapterIndex)?.title
+        val metadataBuilder = baseState.currentMetadata.buildUpon()
+        if (chapterTitle != null) {
+            metadataBuilder.setTitle(chapterTitle)
+        }
+        if (window.chapterIndex >= 0) {
+            metadataBuilder.setTrackNumber(window.chapterIndex + 1)
+            metadataBuilder.setTotalTrackCount(chapters.size)
+        }
+
+        return SimpleBasePlayer.MediaItemData
+            .Builder(CHAPTER_WINDOW_MEDIA_ITEM_UID)
+            .setMediaItem(underlyingPlayer.currentMediaItem ?: MediaItem.EMPTY)
+            .setMediaMetadata(metadataBuilder.build())
+            .setDurationUs(window.windowDurationMs * 1_000L)
+            .setIsSeekable(true)
+            .build()
+    }
+
+    /** Adds/removes the chapter-aware seek commands so a controller reflects [window]'s edges. */
+    private fun Player.Commands.withChapterSeekCommands(
+        chapters: List<Chapter>,
+        window: ChapterWindow,
+    ): Player.Commands {
+        val hasPrevious = hasPreviousChapter(chapters, window)
+        val hasNext = hasNextChapter(chapters, window)
+        return buildUpon()
+            .addIf(Player.COMMAND_SEEK_TO_PREVIOUS, hasPrevious)
+            .removeIf(Player.COMMAND_SEEK_TO_PREVIOUS, !hasPrevious)
+            .addIf(Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM, hasPrevious)
+            .removeIf(Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM, !hasPrevious)
+            .addIf(Player.COMMAND_SEEK_TO_NEXT, hasNext)
+            .removeIf(Player.COMMAND_SEEK_TO_NEXT, !hasNext)
+            .addIf(Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM, hasNext)
+            .removeIf(Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM, !hasNext)
+            .build()
+    }
+}

--- a/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/ChapterWindowPlayer.kt
+++ b/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/ChapterWindowPlayer.kt
@@ -33,8 +33,13 @@ private data class ChapterSeekContext(
  * chapter, so every system playback surface (Android Auto now-playing, the phone notification,
  * the lock screen, Bluetooth/AVRCP, Wear) shows elapsed/remaining time and a seek bar for the
  * *chapter*, not the whole book or the underlying audio file — the same way a music player
- * shows the current track, not the whole album. In-app UI is unaffected; it reads
- * `PlaybackManager` directly and never touches this wrapper.
+ * shows the current track, not the whole album. In-app UI still reads `PlaybackManager`
+ * directly for its state (fed by `PlaybackService`'s own poll of the raw transport player, not
+ * a controller of this wrapper), and in-app seeks ride the `SEEK_TO_BOOK_POSITION` custom
+ * session command rather than a plain controller seek — a controller-side seek through this
+ * wrapper is reinterpreted chapter-relatively and clamped to the current chapter window, which
+ * cannot express a book position. Plain play/pause/speed controller calls are coordinate-agnostic
+ * and pass through this wrapper unmodified.
  *
  * This is handed to `MediaLibrarySession.Builder` in place of the raw local player
  * (`PlaybackService`, in a follow-up change). All chapter-window math is pure and lives in

--- a/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/ChapterWindowPlayer.kt
+++ b/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/ChapterWindowPlayer.kt
@@ -38,11 +38,13 @@ private const val PREVIOUS_RESTART_THRESHOLD_MS = 3_000L
  * `COMMAND_SEEK_TO_PREVIOUS`/`COMMAND_SEEK_TO_NEXT` (there is never a previous/next *media item*
  * to hop to), which is exactly what car head-unit prev/next buttons invoke. "Previous" restarts
  * the current chapter when more than [PREVIOUS_RESTART_THRESHOLD_MS] into it — standard
- * media-player behavior — otherwise it moves to the previous chapter's start. Both commands
- * (and their `_MEDIA_ITEM` variants, in case a controller prefers those) are only advertised via
- * [getState] when a previous/next chapter actually exists — [hasPreviousChapter]/
- * [hasNextChapter] — so a controller greys out the button at the first/last chapter rather than
- * firing a seek that silently restarts it.
+ * media-player behavior — otherwise it moves to the previous chapter's start (or, at the first
+ * chapter / in a chapterless book, clamps to the window's own start — a harmless restart).
+ * `COMMAND_SEEK_TO_PREVIOUS` (and its `_MEDIA_ITEM` variant) is therefore *always* advertised via
+ * [getState] — [hasPreviousChapter] — matching standard Media3/media-player UX where "previous"
+ * is never greyed out; it's always at least a restart affordance. `COMMAND_SEEK_TO_NEXT` (and its
+ * `_MEDIA_ITEM` variant) stays gated on [hasNextChapter]: past the last chapter there is genuinely
+ * nothing to skip to, so the button greys out there.
  *
  * **Invalidation.** [ForwardingSimpleBasePlayer] already invalidates state automatically on
  * every underlying-player event (play/pause, buffering, ExoPlayer-driven position
@@ -190,7 +192,7 @@ class ChapterWindowPlayer(
         chapters: List<Chapter>,
         window: ChapterWindow,
     ): Player.Commands {
-        val hasPrevious = hasPreviousChapter(chapters, window)
+        val hasPrevious = hasPreviousChapter()
         val hasNext = hasNextChapter(chapters, window)
         return buildUpon()
             .addIf(Player.COMMAND_SEEK_TO_PREVIOUS, hasPrevious)

--- a/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/MediaControllerHolder.kt
+++ b/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/MediaControllerHolder.kt
@@ -10,14 +10,8 @@ import androidx.media3.session.SessionToken
 import com.google.common.util.concurrent.ListenableFuture
 import com.google.common.util.concurrent.MoreExecutors
 import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.isActive
-import kotlinx.coroutines.launch
 import kotlin.concurrent.atomics.AtomicInt
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 
@@ -27,8 +21,16 @@ private val logger = KotlinLogging.logger {}
  * Singleton holder for the MediaController connection.
  *
  * NowPlayingViewModel consumes this controller via the PlaybackController seam
- * (there is no longer a separate PlayerViewModel). The holder also owns the
- * Player.Listener and position polling that drive PlaybackStateWriter on Android.
+ * (there is no longer a separate PlayerViewModel). The holder owns the
+ * Player.Listener that drives PlaybackStateWriter's state/speed/error updates on
+ * Android — those are coordinate-agnostic and forwarded faithfully by
+ * `ChapterWindowPlayer`, the chapter-scoped presentation wrapper the session now
+ * hands out to controllers. Position polling used to live here too, but once the
+ * session player became that wrapper, the controller's `currentMediaItemIndex`/
+ * `currentPosition` turned chapter-relative — polling them here would corrupt
+ * book-position tracking for any book past its first chapter. The poll now lives
+ * in `PlaybackService` instead, which reads the raw transport player directly and
+ * pushes book-relative coordinates through the same `PlaybackStateWriter` seam.
  *
  * The holder manages the lifecycle through reference counting:
  * - Each consumer calls acquire() on init
@@ -40,7 +42,6 @@ private val logger = KotlinLogging.logger {}
 class MediaControllerHolder(
     private val context: Context,
     private val playbackManager: PlaybackStateWriter,
-    private val scope: CoroutineScope,
 ) {
     private var controllerFuture: ListenableFuture<MediaController>? = null
     private var _controller: MediaController? = null
@@ -101,37 +102,6 @@ class MediaControllerHolder(
             Player.STATE_ENDED -> PlaybackState.Ended
             else -> PlaybackState.Idle
         }
-
-    private var positionPollJob: Job? = null
-
-    private companion object {
-        const val POSITION_POLL_INTERVAL_MS = 250L
-    }
-
-    internal fun startPositionPolling(controller: MediaController) {
-        positionPollJob?.cancel()
-        // Media3's MediaController is single-threaded — isPlaying/currentPosition must
-        // be read on its application thread (the main thread). The injected scope runs
-        // on Dispatchers.IO, so the loop body is pinned to Main.immediate; without this
-        // the poll throws "MediaController method is called from a wrong thread".
-        positionPollJob =
-            scope.launch(Dispatchers.Main.immediate) {
-                while (isActive) {
-                    if (controller.isPlaying) {
-                        // controller.currentPosition is FILE-relative (position within the
-                        // current media item). For a multi-file book this is NOT the book
-                        // position — push through the media-item seam so PlaybackManager
-                        // converts to book-relative via the active timeline. Passing the raw
-                        // offset would corrupt currentPositionMs (regressed saves, wrong skips).
-                        playbackManager.updatePositionFromMediaItem(
-                            mediaItemIndex = controller.currentMediaItemIndex,
-                            positionInItemMs = controller.currentPosition,
-                        )
-                    }
-                    delay(POSITION_POLL_INTERVAL_MS)
-                }
-            }
-    }
 
     /**
      * Acquire a reference to the controller.
@@ -200,10 +170,7 @@ class MediaControllerHolder(
             try {
                 _controller = controllerFuture?.get()
                 isConnected.value = true
-                _controller?.let { newController ->
-                    newController.addListener(playerListener)
-                    startPositionPolling(newController)
-                }
+                _controller?.addListener(playerListener)
                 logger.info { "MediaControllerHolder: connected" }
             } catch (e: Exception) {
                 logger.error(e) { "MediaControllerHolder: connection failed" }
@@ -215,8 +182,6 @@ class MediaControllerHolder(
     private fun disconnect() {
         logger.info { "MediaControllerHolder: disconnecting" }
 
-        positionPollJob?.cancel()
-        positionPollJob = null
         _controller?.removeListener(playerListener)
 
         _controller?.release()

--- a/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
+++ b/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
@@ -171,6 +171,11 @@ class PlaybackService : MediaLibraryService() {
 
         // Search cache configuration
         private const val MAX_SEARCH_CACHE_SIZE = 5
+
+        // ExoPlayer's COMMAND_SEEK_BACK/SEEK_FORWARD increments — matches the in-app
+        // 10s-back/30s-forward skip amounts (see initializePlayer's comment for why).
+        private const val SEEK_BACK_INCREMENT_MS = 10_000L
+        private const val SEEK_FORWARD_INCREMENT_MS = 30_000L
     }
 
     override fun onCreate() {
@@ -236,6 +241,12 @@ class PlaybackService : MediaLibraryService() {
                     true,
                 ).setHandleAudioBecomingNoisy(true) // Pause when headphones unplugged
                 .setWakeMode(C.WAKE_MODE_LOCAL) // Keep CPU awake during playback
+                // Match the in-app 10s-back/30s-forward skip amounts (NowPlayingViewModel's
+                // defaults) rather than Media3's 5s/15s defaults, so head units/watches that
+                // render COMMAND_SEEK_BACK/SEEK_FORWARD (car steering-wheel buttons, Wear tiles)
+                // skip by the same amount the in-app buttons do.
+                .setSeekBackIncrementMs(SEEK_BACK_INCREMENT_MS)
+                .setSeekForwardIncrementMs(SEEK_FORWARD_INCREMENT_MS)
                 .build()
                 .apply {
                     addListener(PlayerListener())
@@ -1352,19 +1363,24 @@ class PlaybackService : MediaLibraryService() {
         /**
          * Handle playback resumption from system UI.
          *
-         * Called when user taps "Resume ListenUp" from Android Auto, Wear OS,
-         * or system notifications after device reboot.
+         * Called when user taps "Resume ListenUp" from Android Auto, Wear OS, or system
+         * notifications after device reboot.
          *
-         * Note: This callback is deprecated in Media3 1.4+ in favor of browse-based
-         * resumption via MediaLibraryService. We keep it for backward compatibility
-         * with older system UI integrations and as a fallback when browse isn't used.
+         * This is the 3-arg overload — the 2-arg `onPlaybackResumption(mediaSession, controller)`
+         * is the one that's deprecated (in favor of this one), not the reverse. [isForPlayback]
+         * distinguishes why the system is asking: `false` means it only wants the item/metadata to
+         * populate a resumption notification (e.g. right after a reboot), with no immediate
+         * intention to start audio; `true` means the user actually pressed play and playback should
+         * start once resolved. Our preparation work — reading the last-played book and resolving
+         * its start position — is needed to answer either request, so this implementation is
+         * identical for both flag values.
          */
-        @Deprecated("Kept for backward compatibility with older system UI integrations")
         override fun onPlaybackResumption(
             mediaSession: MediaSession,
             controller: MediaSession.ControllerInfo,
+            isForPlayback: Boolean,
         ): ListenableFuture<MediaSession.MediaItemsWithStartPosition> {
-            logger.info { "Playback resumption requested" }
+            logger.info { "Playback resumption requested (isForPlayback=$isForPlayback)" }
 
             return CallbackToFutureAdapter.getFuture { completer ->
                 serviceScope.launch {

--- a/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
+++ b/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
@@ -102,9 +102,11 @@ class PlaybackService : MediaLibraryService() {
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
     private var idleJob: Job? = null
     private var positionUpdateJob: Job? = null
+    private var uiPositionJob: Job? = null
 
     // Inject dependencies
     private val playbackManager: PlaybackManager by inject()
+    private val playbackStateWriter: PlaybackStateWriter by inject()
     private val progressTracker: ProgressTracker by inject()
     private val listeningEventRecorder: com.calypsan.listenup.client.playback.ListeningEventRecorder by inject()
     private val positionRepository: PlaybackPositionRepository by inject()
@@ -162,6 +164,10 @@ class PlaybackService : MediaLibraryService() {
 
         // Position update interval
         private const val POSITION_UPDATE_INTERVAL = 30_000L // 30 seconds
+
+        // UI-rate position poll interval — matches MediaControllerHolder's former poll cadence
+        // (see startPositionUpdates' KDoc for why this now lives here instead).
+        private const val POSITION_UI_UPDATE_INTERVAL = 250L
 
         // Search cache configuration
         private const val MAX_SEARCH_CACHE_SIZE = 5
@@ -273,7 +279,12 @@ class PlaybackService : MediaLibraryService() {
 
         // System surfaces (Auto, notification, lock screen, Bluetooth) get the chapter-scoped
         // presentation wrapper, never the raw local player — see ChapterWindowPlayer's class KDoc.
-        // In-app UI is unaffected: it reads PlaybackManager directly and never touches the session.
+        // In-app UI still reads PlaybackManager directly for its state (now fed by this service's
+        // raw-player poll — see startPositionUpdates), and in-app seeks ride the
+        // SEEK_TO_BOOK_POSITION custom command (see onCustomCommand) rather than a plain
+        // controller seek, which the wrapper would reinterpret chapter-relatively. Plain
+        // play/pause/speed controller calls are coordinate-agnostic and still go through the
+        // session unmodified.
         val wrapper =
             ChapterWindowPlayer(
                 player = activePlayer,
@@ -482,6 +493,7 @@ class PlaybackService : MediaLibraryService() {
 
         idleJob?.cancel()
         positionUpdateJob?.cancel()
+        uiPositionJob?.cancel()
 
         // Clear chapter change callback to avoid memory leaks
         playbackManager.onChapterChanged = null
@@ -591,11 +603,34 @@ class PlaybackService : MediaLibraryService() {
                     }
                 }
             }
+
+        // Second, faster poll driving in-app UI position display. This used to be
+        // MediaControllerHolder's job — it polled the MediaController it held on a 250ms loop —
+        // but the session player is now ChapterWindowPlayer, the chapter-scoped presentation
+        // wrapper (see activeTransportPlayer's KDoc), so a MediaController's coordinates are
+        // chapter-relative and can no longer feed PlaybackStateWriter.updatePositionFromMediaItem
+        // (it interprets its arguments as file coordinates). The service reads the raw transport
+        // player instead, which was never re-presented. Running it here rather than in-app also
+        // means the notification's chapter rollover (driven by playbackManager.onChapterChanged)
+        // now advances even when no UI client is bound, since the service itself keeps polling.
+        uiPositionJob?.cancel()
+        uiPositionJob =
+            serviceScope.launch {
+                while (isActive) {
+                    delay(POSITION_UI_UPDATE_INTERVAL)
+                    val p = activeTransportPlayer() ?: break
+                    if (p.isPlaying) {
+                        playbackStateWriter.updatePositionFromMediaItem(p.currentMediaItemIndex, p.currentPosition)
+                    }
+                }
+            }
     }
 
     private fun stopPositionUpdates() {
         positionUpdateJob?.cancel()
         positionUpdateJob = null
+        uiPositionJob?.cancel()
+        uiPositionJob = null
     }
 
     /**
@@ -794,7 +829,7 @@ class PlaybackService : MediaLibraryService() {
         ): MediaSession.ConnectionResult {
             val customCommands =
                 AudiobookNotificationProvider.getCustomCommands() +
-                    listOf(CustomActions.cycleSpeedCommand())
+                    listOf(CustomActions.cycleSpeedCommand(), CustomActions.seekToBookPositionCommand())
 
             // Limited to 3 custom actions by Android Auto guidelines.
             val customLayout =
@@ -1396,6 +1431,24 @@ class PlaybackService : MediaLibraryService() {
                             currentSpeed,
                         )} -> ${CustomActions.formatSpeed(newSpeed)}"
                     }
+                }
+
+                CustomActions.SEEK_TO_BOOK_POSITION -> {
+                    // The in-app seek transport (see AndroidPlaybackController.seekTo's KDoc):
+                    // book-relative because the session player is ChapterWindowPlayer, and a
+                    // controller-side seek would be reinterpreted chapter-relatively and clamped
+                    // to the current chapter window.
+                    val target = args.getLong(CustomActions.EXTRA_BOOK_POSITION_MS, -1L)
+                    if (target < 0) {
+                        return Futures.immediateFuture(SessionResult(SessionResult.RESULT_ERROR_BAD_VALUE))
+                    }
+                    if (timeline != null) {
+                        val resolved = timeline.resolve(target.coerceIn(0L, timeline.totalDurationMs))
+                        p.seekTo(resolved.mediaItemIndex, resolved.positionInFileMs)
+                    } else {
+                        p.seekTo(target)
+                    }
+                    logger.debug { "Seek to book position: ${target}ms" }
                 }
             }
 

--- a/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
+++ b/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
@@ -635,7 +635,7 @@ class PlaybackService : MediaLibraryService() {
 
     /**
      * Apply restored playback speed to ExoPlayer.
-     * Extracted to keep onAddMediaItems and onPlaybackResumption within complexity limits.
+     * Extracted to keep resolveMediaItems and onPlaybackResumption within complexity limits.
      */
     private fun applyResumeSpeed(speed: Float) {
         player?.setPlaybackSpeed(speed)
@@ -1088,10 +1088,78 @@ class PlaybackService : MediaLibraryService() {
         // ========== Playback Preparation ==========
 
         /**
-         * Called when Android Auto requests to play media items.
+         * Resolves controller-requested [MediaItem]s (voice-search queries and/or book mediaIds)
+         * to the actual playable [MediaItem]s Media3 needs, applying the restored playback speed
+         * as each book resolves. Shared by [onAddMediaItems] (the Auto "add to queue" callback)
+         * and [onSetMediaItems] (the Auto tap-to-play / voice-search callback, which additionally
+         * needs the resolved book's [PlaybackManager.PrepareResult] to compute a resume start
+         * position — see [onSetMediaItems]'s KDoc) so the two callbacks never drift on how a
+         * mediaId or voice query becomes a playable item.
          *
-         * Resolves book IDs from media items and prepares full playback timeline.
-         * Also handles voice search via requestMetadata.searchQuery (Media3 pattern).
+         * @return the resolved items, plus the last [PlaybackManager.PrepareResult] produced
+         *   while resolving [mediaItems] (null if none of them resolved to a book). "Last" rather
+         *   than "the" result because [onSetMediaItems] only relies on it when [mediaItems]
+         *   contained exactly one entry — the tap-to-play/voice-search shape.
+         */
+        private suspend fun resolveMediaItems(
+            mediaItems: List<MediaItem>,
+        ): Pair<List<MediaItem>, PlaybackManager.PrepareResult?> {
+            val resolvedItems = mutableListOf<MediaItem>()
+            var lastPrepareResult: PlaybackManager.PrepareResult? = null
+
+            for (item in mediaItems) {
+                // Check for voice search query (Media3 pattern)
+                val searchQuery = item.requestMetadata.searchQuery
+                if (searchQuery != null) {
+                    logger.info { "Voice search detected: query='$searchQuery'" }
+                    val (voiceItems, voicePrepareResult) = handleVoiceSearch(item)
+                    resolvedItems.addAll(voiceItems)
+                    if (voicePrepareResult != null) lastPrepareResult = voicePrepareResult
+                    continue
+                }
+
+                val bookId = BrowseTree.extractBookId(item.mediaId)
+                if (bookId != null) {
+                    // Prepare playback for this book
+                    val prepareResult = playbackManager.prepareForPlayback(BookId(bookId))
+                    if (prepareResult != null) {
+                        // Build MediaItems from timeline
+                        val bookItems =
+                            prepareResult.timeline.files.map { file ->
+                                MediaItem
+                                    .Builder()
+                                    .setMediaId(file.audioFileId)
+                                    .setUri(file.playbackUri)
+                                    .setMediaMetadata(
+                                        MediaMetadata
+                                            .Builder()
+                                            .setTitle(prepareResult.bookTitle)
+                                            .setArtist(prepareResult.bookAuthor)
+                                            .setAlbumTitle(prepareResult.seriesName)
+                                            .setMediaType(MediaMetadata.MEDIA_TYPE_AUDIO_BOOK)
+                                            .build(),
+                                    ).build()
+                            }
+                        // Apply the restored playback speed to ExoPlayer
+                        applyResumeSpeed(prepareResult.resumeSpeed)
+                        resolvedItems.addAll(bookItems)
+                        lastPrepareResult = prepareResult
+                    }
+                } else {
+                    // Not a book ID, pass through as-is
+                    resolvedItems.add(item)
+                }
+            }
+
+            return resolvedItems to lastPrepareResult
+        }
+
+        /**
+         * Called when Android Auto adds media items to the queue.
+         *
+         * Resolves book IDs from media items and prepares full playback timeline via
+         * [resolveMediaItems]. Also handles voice search via requestMetadata.searchQuery (Media3
+         * pattern).
          *
          * Voice search flow:
          * 1. User says "Hey Google, play [book name] on ListenUp"
@@ -1109,50 +1177,7 @@ class PlaybackService : MediaLibraryService() {
             return CallbackToFutureAdapter.getFuture { completer ->
                 serviceScope.launch {
                     try {
-                        val resolvedItems = mutableListOf<MediaItem>()
-
-                        for (item in mediaItems) {
-                            // Check for voice search query (Media3 pattern)
-                            val searchQuery = item.requestMetadata.searchQuery
-                            if (searchQuery != null) {
-                                logger.info { "Voice search detected: query='$searchQuery'" }
-                                val voiceItems = handleVoiceSearch(item)
-                                resolvedItems.addAll(voiceItems)
-                                continue
-                            }
-
-                            val bookId = BrowseTree.extractBookId(item.mediaId)
-                            if (bookId != null) {
-                                // Prepare playback for this book
-                                val prepareResult = playbackManager.prepareForPlayback(BookId(bookId))
-                                if (prepareResult != null) {
-                                    // Build MediaItems from timeline
-                                    val bookItems =
-                                        prepareResult.timeline.files.map { file ->
-                                            MediaItem
-                                                .Builder()
-                                                .setMediaId(file.audioFileId)
-                                                .setUri(file.playbackUri)
-                                                .setMediaMetadata(
-                                                    MediaMetadata
-                                                        .Builder()
-                                                        .setTitle(prepareResult.bookTitle)
-                                                        .setArtist(prepareResult.bookAuthor)
-                                                        .setAlbumTitle(prepareResult.seriesName)
-                                                        .setMediaType(MediaMetadata.MEDIA_TYPE_AUDIO_BOOK)
-                                                        .build(),
-                                                ).build()
-                                        }
-                                    // Apply the restored playback speed to ExoPlayer
-                                    applyResumeSpeed(prepareResult.resumeSpeed)
-                                    resolvedItems.addAll(bookItems)
-                                }
-                            } else {
-                                // Not a book ID, pass through as-is
-                                resolvedItems.add(item)
-                            }
-                        }
-
+                        val (resolvedItems, _) = resolveMediaItems(mediaItems)
                         completer.set(resolvedItems)
                     } catch (e: CancellationException) {
                         throw e
@@ -1166,13 +1191,84 @@ class PlaybackService : MediaLibraryService() {
         }
 
         /**
+         * Called when a controller sets (rather than adds to) the media items — the path Auto's
+         * tap-to-play and voice search actually take. Media3's default implementation delegates
+         * to [onAddMediaItems] and echoes back the controller-provided [startIndex]/[startPositionMs]
+         * verbatim; Auto never supplies either (`startIndex == C.INDEX_UNSET`), so without an
+         * override here every book tapped in Auto's browse list started from position zero.
+         *
+         * [startIndex] `!= C.INDEX_UNSET` means the controller expressed explicit start intent —
+         * that's the in-app [AndroidPlaybackController.setMediaQueue] path, which always supplies
+         * one — so this branch preserves [startIndex]/[startPositionMs] verbatim, keeping that path
+         * byte-identical to before this override existed.
+         *
+         * Otherwise (Auto tap-to-play / voice search): when [mediaItems] resolved to exactly one
+         * book — the shape both of those callers always send — resume it at its saved position via
+         * [PlaybackManager.PrepareResult.timeline]`.resolve(resumePositionMs)`, rather than the
+         * default index/position-zero. When more than one book resolved (or none), fall back to
+         * `C.INDEX_UNSET`/`C.TIME_UNSET`, which per [MediaSession.MediaItemsWithStartPosition]'s
+         * contract tells Media3 to apply its own default index/position.
+         */
+        override fun onSetMediaItems(
+            mediaSession: MediaSession,
+            controller: MediaSession.ControllerInfo,
+            mediaItems: List<MediaItem>,
+            startIndex: Int,
+            startPositionMs: Long,
+        ): ListenableFuture<MediaSession.MediaItemsWithStartPosition> {
+            logger.info { "onSetMediaItems: ${mediaItems.size} items, startIndex=$startIndex" }
+
+            return CallbackToFutureAdapter.getFuture { completer ->
+                serviceScope.launch {
+                    try {
+                        val (resolvedItems, prepareResult) = resolveMediaItems(mediaItems)
+
+                        if (startIndex != C.INDEX_UNSET) {
+                            completer.set(
+                                MediaSession.MediaItemsWithStartPosition(resolvedItems, startIndex, startPositionMs),
+                            )
+                            return@launch
+                        }
+
+                        val resumeStart =
+                            if (mediaItems.size == 1 && prepareResult != null) {
+                                prepareResult.timeline.resolve(prepareResult.resumePositionMs)
+                            } else {
+                                null
+                            }
+
+                        completer.set(
+                            if (resumeStart != null) {
+                                MediaSession.MediaItemsWithStartPosition(
+                                    resolvedItems,
+                                    resumeStart.mediaItemIndex,
+                                    resumeStart.positionInFileMs,
+                                )
+                            } else {
+                                MediaSession.MediaItemsWithStartPosition(resolvedItems, C.INDEX_UNSET, C.TIME_UNSET)
+                            },
+                        )
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        logger.error(e) { "Failed to resolve media items for onSetMediaItems" }
+                        completer.setException(e)
+                    }
+                }
+                "SetMediaItems"
+            }
+        }
+
+        /**
          * Handle voice search from Android Auto / Google Assistant.
          *
          * Extracts search query and extras from MediaItem's requestMetadata,
-         * resolves through VoiceIntentResolver, and returns playable media items.
+         * resolves through VoiceIntentResolver, and returns playable media items alongside the
+         * resolved book's [PlaybackManager.PrepareResult] (null when nothing resolved) — see
+         * [resolveMediaItems]'s KDoc for why the caller needs it too.
          */
-        private suspend fun handleVoiceSearch(item: MediaItem): List<MediaItem> {
-            val searchQuery = item.requestMetadata.searchQuery ?: return emptyList()
+        private suspend fun handleVoiceSearch(item: MediaItem): Pair<List<MediaItem>, PlaybackManager.PrepareResult?> {
+            val searchQuery = item.requestMetadata.searchQuery ?: return emptyList<MediaItem>() to null
             val extras = item.requestMetadata.extras
 
             // Extract structured hints from extras (if available)
@@ -1221,7 +1317,7 @@ class PlaybackService : MediaLibraryService() {
 
             if (bookId == null) {
                 logger.warn { "Could not resolve book ID from voice intent: $intent" }
-                return emptyList()
+                return emptyList<MediaItem>() to null
             }
 
             logger.info { "Playing book from voice search: $bookId" }
@@ -1230,25 +1326,27 @@ class PlaybackService : MediaLibraryService() {
             val prepareResult = playbackManager.prepareForPlayback(BookId(bookId))
             if (prepareResult == null) {
                 logger.error { "Failed to prepare book for voice playback: $bookId" }
-                return emptyList()
+                return emptyList<MediaItem>() to null
             }
 
             // Build MediaItems from timeline
-            return prepareResult.timeline.files.map { file ->
-                MediaItem
-                    .Builder()
-                    .setMediaId(file.audioFileId)
-                    .setUri(file.playbackUri)
-                    .setMediaMetadata(
-                        MediaMetadata
-                            .Builder()
-                            .setTitle(prepareResult.bookTitle)
-                            .setArtist(prepareResult.bookAuthor)
-                            .setAlbumTitle(prepareResult.seriesName)
-                            .setMediaType(MediaMetadata.MEDIA_TYPE_AUDIO_BOOK)
-                            .build(),
-                    ).build()
-            }
+            val items =
+                prepareResult.timeline.files.map { file ->
+                    MediaItem
+                        .Builder()
+                        .setMediaId(file.audioFileId)
+                        .setUri(file.playbackUri)
+                        .setMediaMetadata(
+                            MediaMetadata
+                                .Builder()
+                                .setTitle(prepareResult.bookTitle)
+                                .setArtist(prepareResult.bookAuthor)
+                                .setAlbumTitle(prepareResult.seriesName)
+                                .setMediaType(MediaMetadata.MEDIA_TYPE_AUDIO_BOOK)
+                                .build(),
+                        ).build()
+                }
+            return items to prepareResult
         }
 
         /**

--- a/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
+++ b/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
@@ -89,6 +89,7 @@ private val logger = KotlinLogging.logger {}
 class PlaybackService : MediaLibraryService() {
     private var mediaLibrarySession: MediaLibraryService.MediaLibrarySession? = null
     private var player: ExoPlayer? = null
+    private var chapterWindowPlayer: ChapterWindowPlayer? = null
     private var notificationProvider: AudiobookNotificationProvider? = null
     private var castSessionController: CastSessionController? = null
 
@@ -127,16 +128,31 @@ class PlaybackService : MediaLibraryService() {
      * relative to the entire book for progress tracking. The PlaybackTimeline
      * handles this translation.
      *
-     * Reads the active session player — the local ExoPlayer normally, the cast
+     * Reads the active transport player — the local ExoPlayer normally, the cast
      * player while casting — so position recording follows wherever audio is playing.
      *
      * @return Book-relative position in milliseconds, or 0 if unavailable
      */
     private fun getBookRelativePosition(): Long {
-        val player = mediaLibrarySession?.player ?: player ?: return 0L
+        val player = activeTransportPlayer() ?: return 0L
         val timeline = playbackManager.currentTimeline.value ?: return player.currentPosition
         return timeline.toBookPosition(player.currentMediaItemIndex, player.currentPosition)
     }
+
+    /**
+     * The player actually producing audio right now — the cast player while [casting],
+     * otherwise the raw local ExoPlayer.
+     *
+     * The session player (`mediaLibrarySession?.player`) is a presentation wrapper once local
+     * playback is active: [ChapterWindowPlayer] re-presents the book's timeline as a single
+     * chapter-scoped window for system surfaces (Auto, notification, lock screen, Bluetooth), so
+     * its media-item index and positions are chapter-relative, not book-relative. Every internal
+     * consumer of transport state — progress sync, listening-event recording, the sleep timer,
+     * custom-command seek math — must read this instead of the session player, or it will
+     * silently compute against the wrong coordinate space. Cast surfaces stay file-scoped
+     * (pre-existing, tracked separately), so the cast player never needs this distinction.
+     */
+    private fun activeTransportPlayer(): Player? = if (casting) castSessionController?.castPlayer else player
 
     companion object {
         // Idle timeout tiers
@@ -163,6 +179,10 @@ class PlaybackService : MediaLibraryService() {
         // Register callback for chapter changes to update notification
         playbackManager.onChapterChanged = { chapterInfo ->
             logger.debug { "Chapter changed: ${chapterInfo.title}" }
+            // No underlying-player event fires for a chapter boundary crossed purely by elapsed
+            // playback time — invalidate() is the explicit hook so connected controllers pick up
+            // the new chapter window (see ChapterWindowPlayer's "Invalidation" KDoc).
+            chapterWindowPlayer?.invalidate()
             updateNotificationForChapter(chapterInfo)
         }
     }
@@ -250,7 +270,19 @@ class PlaybackService : MediaLibraryService() {
                 logger.error { "initializeMediaSession called before player init" }
                 return
             }
-        val builder = MediaLibrarySession.Builder(this, activePlayer, LibrarySessionCallback())
+
+        // System surfaces (Auto, notification, lock screen, Bluetooth) get the chapter-scoped
+        // presentation wrapper, never the raw local player — see ChapterWindowPlayer's class KDoc.
+        // In-app UI is unaffected: it reads PlaybackManager directly and never touches the session.
+        val wrapper =
+            ChapterWindowPlayer(
+                player = activePlayer,
+                chaptersProvider = { playbackManager.chapters.value },
+                timelineProvider = { playbackManager.currentTimeline.value },
+            )
+        chapterWindowPlayer = wrapper
+
+        val builder = MediaLibrarySession.Builder(this, wrapper, LibrarySessionCallback())
         if (sessionIntent != null) {
             builder.setSessionActivity(sessionIntent)
         }
@@ -357,8 +389,11 @@ class PlaybackService : MediaLibraryService() {
         val controller = castSessionController ?: return
         val session = mediaLibrarySession ?: return
         val local = player ?: return
+        val wrapper = chapterWindowPlayer ?: return
         // If the session isn't currently on the cast player, nothing to do (we never swapped).
-        if (session.player === local) return
+        // (Was an identity check against `local` before ChapterWindowPlayer existed — the session
+        // player is never `local` anymore even when not casting, since it's now the wrapper.)
+        if (!casting) return
         val cast = controller.castPlayer
         val index = cast.currentMediaItemIndex
         val positionInItem = cast.currentPosition
@@ -373,25 +408,27 @@ class PlaybackService : MediaLibraryService() {
         local.seekTo(index, positionInItem)
         local.playWhenReady = wasPlaying
         local.setPlaybackSpeed(speed)
-        session.player = local
+        session.player = wrapper
         casting = false // normal idle logic resumes now that the local player drives the session
         logger.info { "Swapped back to local at index=$index pos=$positionInItem" }
         saveCurrentPosition() // existing method — persists through the normal recorder
     }
 
     /**
-     * Update metadata when chapter changes.
+     * Push the chapter subtitle to session extras when the chapter changes.
      *
-     * Updates MediaMetadata on the player to show chapter info in:
-     * - Android notification
-     * - Android Auto display
-     * - Bluetooth metadata (car displays, headphones)
+     * Chapter title/track number/total count for system surfaces (Android Auto display,
+     * Bluetooth metadata, the lock screen) now come from [ChapterWindowPlayer]'s window
+     * `MediaItemData` — the single metadata source for the session player, kept in sync via
+     * [ChapterWindowPlayer.invalidate] (called alongside this function in `onCreate`'s
+     * `onChapterChanged` hook). This function's remaining job is the session-extras push:
+     * `AudiobookNotificationProvider` builds the phone notification's subtitle straight from
+     * `playbackManager.currentChapter` rather than session extras, but the extra is kept for any
+     * other consumer relying on it.
      */
     private fun updateNotificationForChapter(chapterInfo: PlaybackManager.ChapterInfo) {
         val session = mediaLibrarySession ?: return
-        val p = player ?: return
 
-        // Build chapter subtitle for display
         val chapterText =
             if (chapterInfo.isGenericTitle) {
                 "Chapter ${chapterInfo.index + 1} of ${chapterInfo.totalChapters}"
@@ -402,54 +439,20 @@ class PlaybackService : MediaLibraryService() {
         val timeRemaining = DurationFormatter.hoursMinutesOrUnderMinute(chapterInfo.remainingMs.milliseconds)
         val displaySubtitle = "$chapterText • $timeRemaining left"
 
-        // Get current book info from the existing metadata
-        val currentMetadata = p.mediaMetadata
-        val bookTitle = currentMetadata.title ?: "Unknown Book"
-        val author = currentMetadata.artist
-        val seriesName = currentMetadata.albumTitle
-        val artworkUri = currentMetadata.artworkUri
-
-        // Build updated metadata with chapter info
-        // MEDIA_TYPE_AUDIO_BOOK_CHAPTER tells Android Auto this is a chapter
-        val updatedMetadata =
-            MediaMetadata
-                .Builder()
-                .setTitle(bookTitle)
-                .setDisplayTitle(bookTitle)
-                .setSubtitle(chapterText)
-                .setDescription(displaySubtitle)
-                .setArtist(author)
-                .setAlbumTitle(seriesName)
-                .setArtworkUri(artworkUri)
-                .setMediaType(MediaMetadata.MEDIA_TYPE_AUDIO_BOOK_CHAPTER)
-                .setTrackNumber(chapterInfo.index + 1)
-                .setTotalTrackCount(chapterInfo.totalChapters)
-                .build()
-
-        // Update the current MediaItem's metadata
-        // This propagates to Android Auto, notifications, and Bluetooth
-        val currentIndex = p.currentMediaItemIndex
-        val currentItem = p.currentMediaItem
-        if (currentItem != null && currentIndex >= 0) {
-            val updatedItem =
-                currentItem
-                    .buildUpon()
-                    .setMediaMetadata(updatedMetadata)
-                    .build()
-            p.replaceMediaItem(currentIndex, updatedItem)
-        }
-
-        // Also update session extras for backward compatibility
         session.setSessionExtras(Bundle().apply { putString("chapter_subtitle", displaySubtitle) })
 
         logger.debug {
-            "Updated chapter metadata: $chapterText (${chapterInfo.index + 1}/${chapterInfo.totalChapters})"
+            "Updated chapter subtitle: $chapterText (${chapterInfo.index + 1}/${chapterInfo.totalChapters})"
         }
     }
 
     override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaLibrarySession? = mediaLibrarySession
 
     override fun onTaskRemoved(rootIntent: Intent?) {
+        // Legitimately the session player, not activeTransportPlayer(): this only issues a
+        // pause command (ForwardingSimpleBasePlayer forwards setPlayWhenReady verbatim to the
+        // wrapped local player) and checks session liveness — it never reads a chapter-relative
+        // position or index, so there's nothing here for the presentation wrapper to corrupt.
         val player = mediaLibrarySession?.player
 
         // Pause playback when user swipes app away — notification remains for resume
@@ -488,6 +491,7 @@ class PlaybackService : MediaLibraryService() {
         // when mediaLibrarySession was never built or was already null.
         mediaLibrarySession?.release()
         mediaLibrarySession = null
+        chapterWindowPlayer = null
         castSessionController?.release()
         castSessionController = null
         player?.release()
@@ -564,21 +568,24 @@ class PlaybackService : MediaLibraryService() {
             serviceScope.launch {
                 while (isActive) {
                     delay(POSITION_UPDATE_INTERVAL)
-                    // Gate + read off the ACTIVE session player — the cast player while casting, the
-                    // local ExoPlayer otherwise. The local player is paused during a cast (its audio
-                    // focus is released), so gating on player.isPlaying froze all periodic persistence
-                    // for the whole cast session: position stopped propagating to other devices and a
-                    // battery-death mid-cast lost the session + dropped the span. getBookRelativePosition()
-                    // already reads the session player, so only the gate had to follow it here.
-                    val sessionPlayer = mediaLibrarySession?.player ?: player ?: break
+                    // Gate + read off the TRANSPORT player — the cast player while casting, the
+                    // local ExoPlayer otherwise. Never the session player: once ChapterWindowPlayer
+                    // presents the session, its positions are chapter-relative and would corrupt
+                    // this data. The local player is paused during a cast (its audio focus is
+                    // released), so gating on player.isPlaying froze all periodic persistence for
+                    // the whole cast session: position stopped propagating to other devices and a
+                    // battery-death mid-cast lost the session + dropped the span.
+                    // getBookRelativePosition() already reads the transport player, so only the
+                    // gate had to follow it here.
+                    val transportPlayer = activeTransportPlayer() ?: break
                     val bookId = currentBookId ?: break
 
-                    if (sessionPlayer.isPlaying) {
+                    if (transportPlayer.isPlaying) {
                         val positionMs = getBookRelativePosition()
                         progressTracker.onPositionUpdate(
                             bookId = bookId,
                             positionMs = positionMs,
-                            speed = sessionPlayer.playbackParameters.speed,
+                            speed = transportPlayer.playbackParameters.speed,
                         )
                         listeningEventRecorder.onPeriodicTick(positionMs = positionMs)
                     }
@@ -1308,16 +1315,18 @@ class PlaybackService : MediaLibraryService() {
             customCommand: SessionCommand,
             args: Bundle,
         ): ListenableFuture<SessionResult> {
-            // Route transport controls to the ACTIVE session player — the cast player while
-            // casting — so skip/chapter/speed reach the receiver, not the paused local player.
-            // Queue order is identical on both (the index-shift guard in handoffToCast ensures
-            // a 1:1 map), so the timeline's book-relative → index/offset math holds unchanged.
+            // Route transport controls to the TRANSPORT player — the cast player while casting,
+            // the raw local ExoPlayer otherwise — so skip/chapter/speed reach the receiver, not
+            // the paused local player, and so the seek math below (which resolves book-relative
+            // positions via `timeline`) never runs against ChapterWindowPlayer's chapter-relative
+            // coordinates. Queue order is identical on both (the index-shift guard in
+            // handoffToCast ensures a 1:1 map), so the timeline's book-relative → index/offset
+            // math holds unchanged.
             val p =
-                mediaLibrarySession?.player ?: player ?: return Futures.immediateFuture(
+                activeTransportPlayer() ?: return Futures.immediateFuture(
                     SessionResult(SessionResult.RESULT_ERROR_UNKNOWN),
                 )
             val chapters = playbackManager.chapters.value
-            val currentChapter = playbackManager.currentChapter.value
             val timeline = playbackManager.currentTimeline.value
 
             when (customCommand.customAction) {
@@ -1354,22 +1363,26 @@ class PlaybackService : MediaLibraryService() {
                 }
 
                 AudiobookNotificationProvider.COMMAND_PREV_CHAPTER -> {
-                    if (currentChapter != null && chapters.isNotEmpty() && timeline != null) {
-                        val prevIndex = (currentChapter.index - 1).coerceAtLeast(0)
-                        val prevChapter = chapters[prevIndex]
-                        val resolved = timeline.resolve(prevChapter.startTime)
+                    // Shares its mapping with ChapterWindowPlayer.handleSeek's
+                    // COMMAND_SEEK_TO_PREVIOUS branch — one implementation, same
+                    // restart-vs-jump threshold everywhere (see previousChapterTarget's KDoc).
+                    if (chapters.isNotEmpty() && timeline != null) {
+                        val target =
+                            previousChapterTarget(chapters, getBookRelativePosition(), timeline.totalDurationMs)
+                        val resolved = timeline.resolve(target)
                         p.seekTo(resolved.mediaItemIndex, resolved.positionInFileMs)
-                        logger.debug { "Previous chapter: ${prevIndex + 1} of ${chapters.size}" }
+                        logger.debug { "Previous chapter target: ${target}ms" }
                     }
                 }
 
                 AudiobookNotificationProvider.COMMAND_NEXT_CHAPTER -> {
-                    if (currentChapter != null && chapters.isNotEmpty() && timeline != null) {
-                        val nextIndex = (currentChapter.index + 1).coerceAtMost(chapters.size - 1)
-                        val nextChapter = chapters[nextIndex]
-                        val resolved = timeline.resolve(nextChapter.startTime)
+                    // Shares its mapping with ChapterWindowPlayer.handleSeek's
+                    // COMMAND_SEEK_TO_NEXT branch — one implementation everywhere.
+                    if (chapters.isNotEmpty() && timeline != null) {
+                        val target = nextChapterTarget(chapters, getBookRelativePosition(), timeline.totalDurationMs)
+                        val resolved = timeline.resolve(target)
                         p.seekTo(resolved.mediaItemIndex, resolved.positionInFileMs)
-                        logger.debug { "Next chapter: ${nextIndex + 1} of ${chapters.size}" }
+                        logger.debug { "Next chapter target: ${target}ms" }
                     }
                 }
 


### PR DESCRIPTION
Implements the Android leg of \`docs/2026-08-01-chapter-scoped-car-surfaces-design.md\` (approved): every system playback surface (Android Auto now-playing, phone notification, lock screen, Bluetooth/AVRCP, Wear) now shows a **chapter-scoped** seek bar and elapsed/remaining time — like a music player shows the current track, not the album.

## How

- **\`ChapterWindowPlayer\`** — a \`ForwardingSimpleBasePlayer\` handed to the \`MediaLibrarySession\` in place of the raw ExoPlayer. Presents a single-window timeline for the current chapter (duration = chapter length, position = live via \`PositionSupplier\`); prev/next map to chapter boundaries; chapterless books present as one whole-book window. All window math is pure (\`ChapterWindow.kt\`, 23 Kotest tests).
- **Audit-driven blocker fixes** — the in-app client rides \`MediaController\` → session → wrapper, so two paths had to move off the wrapper's chapter-relative coordinates: the 250 ms position poll moved from \`MediaControllerHolder\` into \`PlaybackService\` (reads the raw transport player; notification chapter rollover now advances with no UI bound), and in-app seeks ride a new \`SEEK_TO_BOOK_POSITION\` custom session command resolved against the transport player.
- **Pre-existing Auto bugs fixed** (from the design's audit, findings recorded in the design doc): books tapped in Auto's browse list now resume at the saved position (\`onSetMediaItems\` override); \`onPlaybackResumption\` migrated to the non-deprecated \`isForPlayback\` overload; seek increments aligned to the in-app 10 s back / 30 s forward.
- Audit findings not fixed inline → #1238, #1239, #1240.

## Testing

- \`verifyLocal\` green (full Linux Lint + JVM test lanes), \`:app:androidApp:assembleDebug\` green.
- New/updated Kotest suites: \`ChapterWindowTest\` (23), \`AndroidPlaybackControllerTest\`, \`MediaControllerHolderTest\`.
- The wrapper/session glue is not unit-testable in the Robolectric-free lane (documented in-code); needs the planned car smoke test: seek bar spans the chapter, scrub-within-chapter, rollover at the boundary, prev/next chapter, in-app scrubber + chapter jumps unaffected.

iOS leg (chapter-relative \`MPNowPlayingInfoCenter\`) follows on this branch via the Kit handoff brief (\`docs/2026-08-01-chapter-scoped-ios-handoff.md\`).