### PR TITLE
🐛 fix(sharedUI): activate the book when playback starts outside the app

### DIFF
--- a/app/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/automotive/BrowseTreeMediaIdTest.kt
+++ b/app/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/automotive/BrowseTreeMediaIdTest.kt
@@ -1,0 +1,30 @@
+package com.calypsan.listenup.client.automotive
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Media-id round-tripping for the browse tree.
+ *
+ * `PlaybackService.onSetMediaItems` runs [BrowseTree.extractBookId] over every media id a
+ * controller sets, including the queue the app's own player builds — where ids are audio
+ * file ids, not browse ids. A false match there would rebuild the queue and override the
+ * position the app just resolved, so "what is *not* a book id" is the load-bearing half.
+ */
+class BrowseTreeMediaIdTest :
+    FunSpec({
+
+        test("a browse book id round-trips") {
+            BrowseTree.extractBookId(BrowseTree.bookId("book-1")) shouldBe "book-1"
+        }
+
+        test("an audio file id is not a book id") {
+            BrowseTree.extractBookId("af-3f2a9c1e") shouldBe null
+        }
+
+        test("the other browse prefixes are not book ids") {
+            BrowseTree.extractBookId("${BrowseTree.PREFIX_SERIES}series-1") shouldBe null
+            BrowseTree.extractBookId("${BrowseTree.PREFIX_AUTHOR}author-1") shouldBe null
+            BrowseTree.extractBookId("${BrowseTree.PREFIX_COLLECTION}collection-1") shouldBe null
+        }
+    })

--- a/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
+++ b/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
@@ -1257,6 +1257,12 @@ class PlaybackService : MediaLibraryService() {
                     try {
                         val (resolvedItems, prepareResult) = resolveMediaItems(mediaItems)
 
+                        // The queue is this book's now. currentBookId is what every progress
+                        // write is keyed on, and only the VM used to set it — so a book started
+                        // from Auto, the Assistant or a media button saved its position onto
+                        // whatever the app happened to activate last.
+                        prepareResult?.let { playbackManager.activateBook(it.timeline.bookId) }
+
                         if (startIndex != C.INDEX_UNSET) {
                             completer.set(
                                 MediaSession.MediaItemsWithStartPosition(resolvedItems, startIndex, startPositionMs),
@@ -1437,6 +1443,10 @@ class PlaybackService : MediaLibraryService() {
                             completer.setException(IllegalStateException("Failed to prepare book"))
                             return@launch
                         }
+
+                        // Same reason as onSetMediaItems: resumption is a play path the VM
+                        // never sees, so nothing else sets the book progress is keyed on.
+                        playbackManager.activateBook(lastPlayed.bookId)
 
                         // Build MediaItems from timeline
                         val resolvedMediaItems =


### PR DESCRIPTION
Rescoped after #1241 landed. That PR fixed the reported half of #1236 (the missing `onSetMediaItems` override, so Auto/Assistant playback now resumes at the saved position) — this one fixes the sibling bug found while tracing it, which #1241 did not cover.

## The bug

`playbackManager.activateBook()` had exactly one call site in the codebase: `NowPlayingViewModel`. Every progress write in `PlaybackService` is keyed on `playbackManager.currentBookId.value` — `saveCurrentPosition`, `saveCurrentPositionBlocking`, the 30s position loop, the listener callbacks. So a book started by a path the VM never sees — a voice search, an Auto browse tap, a media-button resumption — left `currentBookId` at whatever the app happened to activate last, and wrote that book's position onto the wrong row. Or dropped it entirely, when nothing had been activated yet.

`onSetMediaItems` resolving a book and `onPlaybackResumption` preparing the last-played book are exactly the two moments where the queue becomes that book's, so that's where activation belongs.

The in-app path is unaffected: its items are already playable, so `resolveMediaItems` returns a null `prepareResult` and no activation fires — the VM has already done it.

## Test

`BrowseTreeMediaIdTest` (3) — `onSetMediaItems` runs `BrowseTree.extractBookId` over every media id a controller sets, including the audio-file ids in the queue the app's own player builds. A false match there would rebuild the queue and override the position the app just resolved. `extractBookId` had no test anywhere; this pins the negative cases.

The activation itself is not covered: instantiating `PlaybackService` needs ExoPlayer plus the full Koin graph behind its `by inject()` delegates, the gap `PlaybackServiceTest`'s KDoc documents. `PlaybackTimeline.resolve` — the resume arithmetic both callbacks depend on — is already covered by `PlaybackTimelineTest`.

## Gates

`spotlessCheck`, `detekt`, `:app:sharedUI:testAndroidHostTest` (280 tests, 0 failures), `:app:androidApp:assembleDebug`. An earlier revision of this branch also passed the full `verifyLocal` and the macOS lanes on the Mac mini (swiftlint, 533 iOS tests, Release build); nothing here touches iOS, `contract/` or `server/`.
