### PR TITLE
✅ test(quality): retry poisoned victims of prior-test leaks

### DIFF
--- a/app/sharedLogic/src/jvmTest/kotlin/io/kotest/provided/ProjectConfig.kt
+++ b/app/sharedLogic/src/jvmTest/kotlin/io/kotest/provided/ProjectConfig.kt
@@ -97,6 +97,12 @@ private object GlobalKoinIsolationListener :
  * all attempts and stays red, while a transient hiccup gets a clean re-run instead of a false red.
  * Each retry is logged so a flaking test stays visible in CI output rather than being silently masked.
  *
+ * **Poisoned victims are retried regardless of spec.** A leaf in ANY spec that fails with
+ * kotlinx-coroutines-test's `UncaughtExceptionsBeforeTest` never ran its own body — a prior test
+ * leaked an uncaught background exception that `runTest` reports at entry (see
+ * [retriesForPoisoning] for the kotlinx.rpc teardown race behind it) — so it too gets the bounded
+ * re-run instead of turning an unrelated suite red.
+ *
  * Between attempts the global Koin context is stopped and a short [RETRY_DELAY_MS] elapses, giving any
  * late async `stopKoin()` from the failed attempt time to drain — otherwise the retry's
  * `install(Koin)` could hit "Koin already started" and fail deterministically.
@@ -177,16 +183,27 @@ private object HeavyweightE2ERetryExtension :
         testCase: TestCase,
         execute: suspend (TestCase) -> TestResult,
     ): TestResult {
-        if (!isHeavyweightE2ELeaf(testCase)) return execute(testCase)
+        if (testCase.type != TestType.Test) return execute(testCase)
+        val heavyweight = isHeavyweightE2ELeaf(testCase)
 
         var result = execute(testCase)
         var attempt = 1
-        while (attempt < MAX_ATTEMPTS && result.isErrorOrFailure) {
+        while (
+            attempt < MAX_ATTEMPTS &&
+            result.isErrorOrFailure &&
+            (heavyweight || retriesForPoisoning(result.errorOrNull))
+        ) {
             attempt++
             recordRetry(testCase, attempt, result)
+            val cause =
+                if (retriesForPoisoning(result.errorOrNull)) {
+                    "was poisoned by a prior test's uncaught background exception"
+                } else {
+                    "failed transiently"
+                }
             println(
                 "[E2E-RETRY] ${testCase.spec::class.simpleName} › ${testCase.name.name} " +
-                    "failed transiently; retry $attempt/$MAX_ATTEMPTS",
+                    "$cause; retry $attempt/$MAX_ATTEMPTS",
             )
             stopGlobalKoinIfRunning()
             delay(RETRY_DELAY_MS)
@@ -241,6 +258,28 @@ private object HeavyweightE2ERetryExtension :
  */
 internal fun retriesForFlakiness(specName: String): Boolean =
     specName in RETRY_COVERED_NAMES || RETRY_COVERED_SUFFIXES.any { specName.endsWith(it) }
+
+/**
+ * Whether [error] is kotlinx-coroutines-test's `UncaughtExceptionsBeforeTest` — the failure
+ * `runTest` manufactures at ENTRY when a *prior* test leaked an uncaught background exception, so
+ * the failing test never ran its own body and is a victim, not a culprit. Any leaf test may be
+ * retried on it (not just the heavyweight E2E specs), because which test gets poisoned is an
+ * accident of suite ordering.
+ *
+ * The known leak source is a kotlinx.rpc teardown race: when an E2E spec's RPC connection closes
+ * while a server-side call handler is still failing, `KrpcConnector.sendCallException` throws
+ * `ClosedSendChannelException` on an already-cancelled fire-and-forget coroutine; a cancelled job
+ * cannot deliver a non-cancellation failure, so it lands in the JVM uncaught handler, where
+ * kotlinx-coroutines-test's global collector holds it and fails the next `runTest`
+ * (CI evidence: CollectionsDomainTest red on run 30730375261, 2026-08-02). The retry is honest:
+ * throwing `UncaughtExceptionsBeforeTest` drains the collector, so the retry runs the test for
+ * real and a genuine regression still fails every attempt.
+ *
+ * The class is Kotlin-`internal` to kotlinx-coroutines-test, hence the class-name match instead of
+ * a type reference.
+ */
+internal fun retriesForPoisoning(error: Throwable?): Boolean =
+    error != null && error.javaClass.name == "kotlinx.coroutines.test.UncaughtExceptionsBeforeTest"
 
 internal val RETRY_COVERED_NAMES =
     setOf(

--- a/app/sharedLogic/src/jvmTest/kotlin/io/kotest/provided/RetryCoverageTest.kt
+++ b/app/sharedLogic/src/jvmTest/kotlin/io/kotest/provided/RetryCoverageTest.kt
@@ -30,4 +30,21 @@ class RetryCoverageTest :
             retriesForFlakiness("SearchRepositoryImplTest") shouldBe false
             retriesForFlakiness("ChapterMathTest") shouldBe false
         }
+
+        test("retries any test poisoned by a prior test's leaked background exception") {
+            // The class is Kotlin-internal to kotlinx-coroutines-test, hence reflection.
+            val poisoning =
+                Class
+                    .forName("kotlinx.coroutines.test.UncaughtExceptionsBeforeTest")
+                    .getDeclaredConstructor()
+                    .newInstance() as Throwable
+            retriesForPoisoning(poisoning) shouldBe true
+        }
+
+        test("does not treat an ordinary failure as poisoning") {
+            retriesForPoisoning(null) shouldBe false
+            // UncaughtExceptionsBeforeTest extends IllegalStateException — the supertype must not match.
+            retriesForPoisoning(IllegalStateException("boom")) shouldBe false
+            retriesForPoisoning(AssertionError("expected 1 but was 2")) shouldBe false
+        }
     })

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -394,6 +394,10 @@ tasks.named<Test>("jvmTest") {
     // lambda inner classes (`<Spec>$1$1` NoClassDefFoundError) and eventually wedges the worker.
     // Periodic forking isolates each batch's classpath extraction and keeps the suite green.
     setForkEvery(25)
+    // Gradle's 512 MB worker default is borderline for a 25-class batch of `testApplication`
+    // specs — a worker can die with OutOfMemoryError (surfacing as JPLISAgent assertions +
+    // "Test process encountered an unexpected problem") with zero failing tests.
+    maxHeapSize = "1g"
     // Redirect the working directory so any Ktor testApplication classpath-extraction
     // artefacts (META-INF/, io/) land under build/ rather than the project root.
     workingDir =

--- a/server/src/jvmTest/kotlin/io/kotest/provided/ProjectConfig.kt
+++ b/server/src/jvmTest/kotlin/io/kotest/provided/ProjectConfig.kt
@@ -63,6 +63,12 @@ class ProjectConfig : AbstractProjectConfig() {
  * so a genuine regression fails every attempt and stays red, while a transient hiccup gets a clean
  * re-run instead of a false red. Each retry is logged so a flaking test stays visible in CI output.
  *
+ * **Poisoned victims are retried regardless of spec.** A leaf in ANY spec that fails with
+ * kotlinx-coroutines-test's `UncaughtExceptionsBeforeTest` never ran its own body — a prior test
+ * leaked an uncaught background exception that `runTest` reports at entry (see
+ * [retriesForPoisoning]) — so it too gets the bounded re-run instead of turning an unrelated suite
+ * red.
+ *
  * A short [RETRY_DELAY_MS] between attempts lets the previous attempt's async teardown (the
  * `testApplication` shutdown, the port unbind, the connection-pool drain) settle before the retry
  * boots its own server — otherwise the retry can hit the very contention it is recovering from.
@@ -148,16 +154,27 @@ private object FlakyServerSpecRetryExtension :
         testCase: TestCase,
         execute: suspend (TestCase) -> TestResult,
     ): TestResult {
-        if (!isFlakyLeaf(testCase)) return execute(testCase)
+        if (testCase.type != TestType.Test) return execute(testCase)
+        val flaky = isFlakyLeaf(testCase)
 
         var result = execute(testCase)
         var attempt = 1
-        while (attempt < MAX_ATTEMPTS && result.isErrorOrFailure) {
+        while (
+            attempt < MAX_ATTEMPTS &&
+            result.isErrorOrFailure &&
+            (flaky || retriesForPoisoning(result.errorOrNull))
+        ) {
             attempt++
             recordRetry(testCase, attempt, result)
+            val cause =
+                if (retriesForPoisoning(result.errorOrNull)) {
+                    "was poisoned by a prior test's uncaught background exception"
+                } else {
+                    "failed transiently"
+                }
             println(
                 "[FLAKY-RETRY] ${testCase.spec::class.simpleName} › ${testCase.name.name} " +
-                    "failed transiently; retry $attempt/$MAX_ATTEMPTS",
+                    "$cause; retry $attempt/$MAX_ATTEMPTS",
             )
             delay(RETRY_DELAY_MS)
             result = execute(testCase)
@@ -202,3 +219,20 @@ private object FlakyServerSpecRetryExtension :
         return specName in FLAKY_SPEC_NAMES || FLAKY_SPEC_SUFFIXES.any { specName.endsWith(it) }
     }
 }
+
+/**
+ * Whether [error] is kotlinx-coroutines-test's `UncaughtExceptionsBeforeTest` — the failure
+ * `runTest` manufactures at ENTRY when a *prior* test leaked an uncaught background exception, so
+ * the failing test never ran its own body and is a victim, not a culprit. Any leaf test may be
+ * retried on it (not just the flaky/E2E specs), because which test gets poisoned is an accident of
+ * suite ordering. Twin of the `:app:sharedLogic` predicate; see that KDoc for the kotlinx.rpc
+ * teardown race that produces the leak (`KrpcConnector.sendCallException` →
+ * `ClosedSendChannelException` on an already-cancelled coroutine). The retry is honest: throwing
+ * `UncaughtExceptionsBeforeTest` drains the collector, so the retry runs the test for real and a
+ * genuine regression still fails every attempt.
+ *
+ * The class is Kotlin-`internal` to kotlinx-coroutines-test, hence the class-name match instead of
+ * a type reference.
+ */
+internal fun retriesForPoisoning(error: Throwable?): Boolean =
+    error != null && error.javaClass.name == "kotlinx.coroutines.test.UncaughtExceptionsBeforeTest"

--- a/server/src/jvmTest/kotlin/io/kotest/provided/RetryCoverageTest.kt
+++ b/server/src/jvmTest/kotlin/io/kotest/provided/RetryCoverageTest.kt
@@ -1,0 +1,30 @@
+package io.kotest.provided
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Pins the poisoned-victim predicate of [FlakyServerSpecRetryExtension] — the `:server` twin of the
+ * `:app:sharedLogic` coverage test. A test failing with kotlinx-coroutines-test's
+ * `UncaughtExceptionsBeforeTest` never ran its own body (a prior test leaked an uncaught background
+ * exception), so any leaf may be retried on it; an ordinary failure must never match.
+ */
+class RetryCoverageTest :
+    FunSpec({
+        test("retries any test poisoned by a prior test's leaked background exception") {
+            // The class is Kotlin-internal to kotlinx-coroutines-test, hence reflection.
+            val poisoning =
+                Class
+                    .forName("kotlinx.coroutines.test.UncaughtExceptionsBeforeTest")
+                    .getDeclaredConstructor()
+                    .newInstance() as Throwable
+            retriesForPoisoning(poisoning) shouldBe true
+        }
+
+        test("does not treat an ordinary failure as poisoning") {
+            retriesForPoisoning(null) shouldBe false
+            // UncaughtExceptionsBeforeTest extends IllegalStateException — the supertype must not match.
+            retriesForPoisoning(IllegalStateException("boom")) shouldBe false
+            retriesForPoisoning(AssertionError("expected 1 but was 2")) shouldBe false
+        }
+    })


### PR DESCRIPTION
## Why

Main went red on run 30730375261: `CollectionsDomainTest > collection Created event upserts the row into Room` failed with `UncaughtExceptionsBeforeTest` — kotlinx-coroutines-test failing the **next** `runTest` because a **prior** test leaked an uncaught background exception. The leak is a kotlinx.rpc teardown race: when an E2E spec's RPC connection closes while a server-side call handler is still failing, `KrpcConnector.sendCallException` throws `ClosedSendChannelException` on an already-cancelled coroutine; a cancelled job can't deliver a non-cancellation failure, so it lands in the JVM uncaught handler and poisons whichever test runs next (adjacent upstream: Kotlin/kotlinx-rpc#100, Kotlin/kotlinx-rpc#213). The victim is an accident of suite ordering — it never ran its own body.

## What

- Both retry extensions (`:app:sharedLogic` + `:server` twin) now retry any leaf test that fails with `UncaughtExceptionsBeforeTest`, regardless of spec. The retry is honest: the first throw drains the exception collector, so the retry runs the test for real and a genuine regression still fails every attempt. Ledger-logged and budget-counted like every other retry.
- New `retriesForPoisoning` predicate, pinned by unit tests in both modules (class-name match — the class is Kotlin-internal to kotlinx-coroutines-test).
- `:server:jvmTest` workers get a 1 GB heap — Gradle's 512 MB default is borderline for a 25-class `testApplication` batch and reproducibly OOM'd a worker locally (JPLISAgent assertions + "Test process encountered an unexpected problem", zero failing tests).

## Verification

- TDD: predicate tests failed (unresolved reference) before the implementation, green after, in both modules.
- Re-running the failed CI job on main passed, confirming the flake diagnosis; main is green again.
- Local: lint green, full `:app:sharedLogic:jvmTest` green, `:server:jvmTest` all tests pass (only a local-only `SidecarParsersAreReadOnly` Konsist timeout under full-suite load, which passes alone and has never appeared on CI).