### PR TITLE
✨ feat(sharedUI): Android Auto browse polish — pagination, typed sign-in error, grid hints

### DIFF
--- a/app/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/automotive/AutoBrowseErrorsTest.kt
+++ b/app/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/automotive/AutoBrowseErrorsTest.kt
@@ -1,0 +1,52 @@
+package com.calypsan.listenup.client.automotive
+
+import androidx.media3.session.MediaConstants
+import androidx.media3.session.SessionError
+import androidx.test.core.app.ApplicationProvider
+import com.calypsan.listenup.api.dto.auth.SessionId
+import com.calypsan.listenup.api.dto.auth.UserId
+import com.calypsan.listenup.client.domain.model.AuthState
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Pins the typed signed-out browse error (#1239): authentication-expired code plus the
+ * error-resolution PendingIntent extras that let the head unit deep-link into sign-in,
+ * and the auth-state gate deciding when browse returns it.
+ */
+@RunWith(RobolectricTestRunner::class)
+class AutoBrowseErrorsTest {
+    @Test
+    fun `signedOutError carries auth code and resolution intent extras`() {
+        val error = AutoBrowseErrors.signedOutError(ApplicationProvider.getApplicationContext())
+
+        assertEquals(SessionError.ERROR_SESSION_AUTHENTICATION_EXPIRED, error.code)
+        assertNotNull(error.extras.getString(MediaConstants.EXTRAS_KEY_ERROR_RESOLUTION_ACTION_LABEL_COMPAT))
+        assertNotNull(
+            error.extras.getParcelable(
+                MediaConstants.EXTRAS_KEY_ERROR_RESOLUTION_ACTION_INTENT_COMPAT,
+                android.app.PendingIntent::class.java,
+            ),
+        )
+    }
+
+    @Test
+    fun `gate fires for genuinely signed-out states only`() {
+        assertTrue(browseNeedsSignIn(AuthState.NeedsServerUrl))
+        assertTrue(browseNeedsSignIn(AuthState.NeedsSetup))
+        assertTrue(browseNeedsSignIn(AuthState.NeedsLogin(openRegistration = false)))
+        assertTrue(browseNeedsSignIn(AuthState.PendingApproval(UserId("u1"), "u@example.com")))
+
+        assertFalse(browseNeedsSignIn(AuthState.Initializing))
+        assertFalse(browseNeedsSignIn(AuthState.CheckingServer))
+        assertFalse(browseNeedsSignIn(AuthState.Authenticated(UserId("u1"), SessionId("s1"))))
+        // Never-stranded: a lapsed session leaves local data intact — browse keeps working
+        // offline from Room; the car must NOT throw up a sign-in wall.
+        assertFalse(browseNeedsSignIn(AuthState.SessionLapsed(UserId("u1"))))
+    }
+}

--- a/app/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/automotive/BrowsePaginationTest.kt
+++ b/app/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/automotive/BrowsePaginationTest.kt
@@ -27,4 +27,20 @@ class BrowsePaginationTest :
         test("negative page is treated as first page") {
             paginate(items, page = -1, pageSize = 10) shouldBe (1..10).toList()
         }
+
+        test("isLastPage: mid-sequence page is not last") {
+            isLastPage(items, page = 1, pageSize = 10) shouldBe false
+        }
+
+        test("isLastPage: final partial page is last") {
+            isLastPage(items, page = 2, pageSize = 10) shouldBe true
+        }
+
+        test("isLastPage: non-positive pageSize means the whole list was returned") {
+            isLastPage(items, page = 0, pageSize = 0) shouldBe true
+        }
+
+        test("isLastPage: exact boundary (items.size == (page+1)*pageSize) is last") {
+            isLastPage((1..20).toList(), page = 1, pageSize = 10) shouldBe true
+        }
     })

--- a/app/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/automotive/BrowsePaginationTest.kt
+++ b/app/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/automotive/BrowsePaginationTest.kt
@@ -1,0 +1,30 @@
+package com.calypsan.listenup.client.automotive
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/** Pins the browse pagination slice shared by onGetChildren and onGetSearchResult (#1238). */
+class BrowsePaginationTest :
+    FunSpec({
+        val items = (1..25).toList()
+
+        test("first page") { paginate(items, page = 0, pageSize = 10) shouldBe (1..10).toList() }
+
+        test("middle page") { paginate(items, page = 1, pageSize = 10) shouldBe (11..20).toList() }
+
+        test("last partial page") { paginate(items, page = 2, pageSize = 10) shouldBe (21..25).toList() }
+
+        test("page past the end is empty") { paginate(items, page = 3, pageSize = 10) shouldBe emptyList() }
+
+        test("non-positive pageSize returns everything (head unit did not paginate)") {
+            paginate(items, page = 0, pageSize = 0) shouldBe items
+        }
+
+        test("Int.MAX_VALUE pageSize does not overflow") {
+            paginate(items, page = 0, pageSize = Int.MAX_VALUE) shouldBe items
+        }
+
+        test("negative page is treated as first page") {
+            paginate(items, page = -1, pageSize = 10) shouldBe (1..10).toList()
+        }
+    })

--- a/app/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/automotive/BrowseTreeProviderTest.kt
+++ b/app/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/automotive/BrowseTreeProviderTest.kt
@@ -292,19 +292,19 @@ class BrowseTreeProviderTest {
     // ──────────────────────────────────────────────────────────────────────────────
 
     @Test
-    fun `getChildren LIBRARY_SERIES caps result at 8 items even with more series`(): Unit =
+    fun `getChildren LIBRARY_SERIES caps result at 100 items even with more series`(): Unit =
         runBlocking {
-            val manySeries = (1..12).map { makeSeries("s-$it", "Series $it") }
+            val manySeries = (1..105).map { makeSeries("s-$it", "Series $it") }
             val provider = makeProvider(allSeries = manySeries)
-            provider.getChildren(BrowseTree.LIBRARY_SERIES) shouldHaveSize 8
+            provider.getChildren(BrowseTree.LIBRARY_SERIES) shouldHaveSize 100
         }
 
     @Test
-    fun `getChildren LIBRARY_AUTHORS caps result at 8 items`(): Unit =
+    fun `getChildren LIBRARY_AUTHORS caps result at 100 items`(): Unit =
         runBlocking {
-            val manyAuthors = (1..15).map { makeContributor("a-$it", "Author $it") }
+            val manyAuthors = (1..105).map { makeContributor("a-$it", "Author $it") }
             val provider = makeProvider(allContributors = manyAuthors)
-            provider.getChildren(BrowseTree.LIBRARY_AUTHORS) shouldHaveSize 8
+            provider.getChildren(BrowseTree.LIBRARY_AUTHORS) shouldHaveSize 100
         }
 
     // ──────────────────────────────────────────────────────────────────────────────

--- a/app/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/automotive/BrowseTreeProviderTest.kt
+++ b/app/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/automotive/BrowseTreeProviderTest.kt
@@ -2,6 +2,7 @@ package com.calypsan.listenup.client.automotive
 
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
+import com.calypsan.listenup.api.error.InternalError
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.core.ContributorId
@@ -33,6 +34,7 @@ import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertThrows
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -135,6 +137,16 @@ class BrowseTreeProviderTest {
             children[0].mediaMetadata.isPlayable shouldBe true
             children[1].mediaId shouldBe BrowseTree.bookId("book-2")
         }
+
+    @Test
+    fun `getChildren LIBRARY_RECENT throws when the continue-listening read fails`() {
+        // A repository failure must surface, not silently render as an empty shelf (#1239) —
+        // onGetChildren maps the thrown exception to RESULT_ERROR_UNKNOWN.
+        val provider = makeProvider(continueListeningFails = true)
+        assertThrows(IllegalStateException::class.java) {
+            runBlocking { provider.getChildren(BrowseTree.LIBRARY_RECENT) }
+        }
+    }
 
     // ──────────────────────────────────────────────────────────────────────────────
     // LIBRARY_DOWNLOADED branch
@@ -337,6 +349,7 @@ class BrowseTreeProviderTest {
 
     private fun makeProvider(
         continueListeningBooks: List<ContinueListeningBook> = emptyList(),
+        continueListeningFails: Boolean = false,
         downloadedBooks: List<DownloadedBookSummary> = emptyList(),
         allSeries: List<Series> = emptyList(),
         seriesWithBooksById: Map<String, SeriesWithBooks> = emptyMap(),
@@ -373,7 +386,7 @@ class BrowseTreeProviderTest {
         every { downloadRepository.observeDownloadedBooks() } returns flowOf(downloadedBooks)
 
         return BrowseTreeProvider(
-            homeRepository = FakeHomeRepository(continueListeningBooks),
+            homeRepository = FakeHomeRepository(continueListeningBooks, continueListeningFails),
             bookRepository = bookRepository,
             seriesRepository = seriesRepository,
             contributorRepository = contributorRepository,
@@ -453,8 +466,14 @@ class BrowseTreeProviderTest {
 
 private class FakeHomeRepository(
     private val books: List<ContinueListeningBook>,
+    private val fails: Boolean = false,
 ) : HomeRepository {
-    override suspend fun getContinueListening(limit: Int): AppResult<List<ContinueListeningBook>> = AppResult.Success(books.take(limit))
+    override suspend fun getContinueListening(limit: Int): AppResult<List<ContinueListeningBook>> =
+        if (fails) {
+            AppResult.Failure(InternalError())
+        } else {
+            AppResult.Success(books.take(limit))
+        }
 
     override fun observeContinueListening(limit: Int): Flow<List<ContinueListeningItem>> = flowOf(books.take(limit).map { book -> ContinueListeningItem.Ready(bookId = book.bookId, book = book) })
 }

--- a/app/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/automotive/BrowseTreeProviderTest.kt
+++ b/app/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/automotive/BrowseTreeProviderTest.kt
@@ -2,6 +2,7 @@ package com.calypsan.listenup.client.automotive
 
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
+import androidx.media3.session.MediaConstants
 import com.calypsan.listenup.api.error.InternalError
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.core.BookId
@@ -34,6 +35,7 @@ import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThrows
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -108,6 +110,27 @@ class BrowseTreeProviderTest {
                 item.mediaMetadata.isBrowsable shouldBe true
                 item.mediaMetadata.isPlayable shouldBe false
             }
+        }
+
+    @Test
+    fun `book-level folders declare grid playable children`(): Unit =
+        runBlocking {
+            val provider = makeProvider()
+            val children = provider.getChildren(BrowseTree.LIBRARY)
+
+            val recent = children.first { it.mediaId == BrowseTree.LIBRARY_RECENT }
+            val styles = requireNotNull(recent.mediaMetadata.extras)
+            assertEquals(
+                MediaConstants.EXTRAS_VALUE_CONTENT_STYLE_GRID_ITEM,
+                styles.getInt(MediaConstants.EXTRAS_KEY_CONTENT_STYLE_PLAYABLE),
+            )
+
+            val downloaded = children.first { it.mediaId == BrowseTree.LIBRARY_DOWNLOADED }
+            assertEquals(
+                MediaConstants.EXTRAS_VALUE_CONTENT_STYLE_GRID_ITEM,
+                requireNotNull(downloaded.mediaMetadata.extras)
+                    .getInt(MediaConstants.EXTRAS_KEY_CONTENT_STYLE_PLAYABLE),
+            )
         }
 
     // ──────────────────────────────────────────────────────────────────────────────
@@ -226,6 +249,14 @@ class BrowseTreeProviderTest {
             children[0].mediaMetadata.title.toString() shouldBe "Brandon Sanderson"
             children[0].mediaMetadata.isBrowsable shouldBe true
             children[1].mediaId shouldBe BrowseTree.authorId("author-2")
+        }
+
+    @Test
+    fun `author entries are typed as artists`(): Unit =
+        runBlocking {
+            val provider = makeProvider(allContributors = listOf(makeContributor("author-1", "Brandon Sanderson")))
+            val authors = provider.getChildren(BrowseTree.LIBRARY_AUTHORS)
+            assertEquals(MediaMetadata.MEDIA_TYPE_ARTIST, authors.first().mediaMetadata.mediaType)
         }
 
     // ──────────────────────────────────────────────────────────────────────────────

--- a/app/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/AutoStartPositionTest.kt
+++ b/app/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/AutoStartPositionTest.kt
@@ -1,0 +1,80 @@
+package com.calypsan.listenup.client.playback
+
+import androidx.media3.common.C
+import com.calypsan.listenup.client.domain.playback.PlaybackTimeline
+import com.calypsan.listenup.client.domain.playback.TimelineFileInput
+import com.calypsan.listenup.core.BookId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Pins the start-position decision used by PlaybackService.onSetMediaItems — the #1236
+ * regression pin. Voice search and Auto tap-to-play send one request item with no explicit
+ * start (startIndex == C.INDEX_UNSET); the decision must resolve the book's saved resume
+ * position (auto-rewind already folded in by PlaybackPreparer), never index/position zero.
+ */
+class AutoStartPositionTest :
+    FunSpec({
+        // Two files of 10 min each; book position 900_000 resolves to file 1 @ 300_000.
+        val timeline =
+            PlaybackTimeline.build(
+                bookId = BookId("book1"),
+                files =
+                    listOf(
+                        TimelineFileInput("af-1", "part1.mp3", "mp3", 600_000L, 1L, null, "https://s/1"),
+                        TimelineFileInput("af-2", "part2.mp3", "mp3", 600_000L, 1L, null, "https://s/2"),
+                    ),
+            )
+
+        test("voice-search shape (one item, no explicit start) resumes at the saved position") {
+            val (index, positionMs) =
+                autoStartPosition(
+                    requestedStartIndex = C.INDEX_UNSET,
+                    requestedStartPositionMs = C.TIME_UNSET,
+                    requestItemCount = 1,
+                    resumeTimeline = timeline,
+                    resumePositionMs = 900_000L,
+                )
+            index shouldBe 1
+            positionMs shouldBe 300_000L
+        }
+
+        test("explicit controller start index passes through verbatim (in-app setMediaQueue path)") {
+            val (index, positionMs) =
+                autoStartPosition(
+                    requestedStartIndex = 3,
+                    requestedStartPositionMs = 12_345L,
+                    requestItemCount = 1,
+                    resumeTimeline = timeline,
+                    resumePositionMs = 900_000L,
+                )
+            index shouldBe 3
+            positionMs shouldBe 12_345L
+        }
+
+        test("multi-item request falls back to Media3 defaults") {
+            val (index, positionMs) =
+                autoStartPosition(
+                    requestedStartIndex = C.INDEX_UNSET,
+                    requestedStartPositionMs = C.TIME_UNSET,
+                    requestItemCount = 2,
+                    resumeTimeline = timeline,
+                    resumePositionMs = 900_000L,
+                )
+            index shouldBe C.INDEX_UNSET
+            positionMs shouldBe C.TIME_UNSET
+        }
+
+        test("no resolved book falls back to Media3 defaults") {
+            val (index, positionMs) =
+                autoStartPosition(
+                    requestedStartIndex = C.INDEX_UNSET,
+                    requestedStartPositionMs = C.TIME_UNSET,
+                    requestItemCount = 1,
+                    resumeTimeline = null,
+                    resumePositionMs = 0L,
+                )
+            index shouldBe C.INDEX_UNSET
+            positionMs shouldBe C.TIME_UNSET
+        }
+    })

--- a/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/automotive/AutoBrowseErrors.kt
+++ b/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/automotive/AutoBrowseErrors.kt
@@ -1,0 +1,64 @@
+package com.calypsan.listenup.client.automotive
+
+import android.app.PendingIntent
+import android.content.Context
+import android.os.Bundle
+import androidx.media3.session.MediaConstants
+import androidx.media3.session.SessionError
+import com.calypsan.listenup.client.domain.model.AuthState
+
+/**
+ * Whether the Auto browse surface should answer with the typed signed-out error instead of
+ * content (#1239). Only genuinely signed-out states gate: transient startup states
+ * ([AuthState.Initializing], [AuthState.CheckingServer]) must NOT flash a sign-in prompt —
+ * browse reads Room and works offline while a stored session is being restored.
+ */
+internal fun browseNeedsSignIn(state: AuthState): Boolean =
+    when (state) {
+        is AuthState.NeedsServerUrl,
+        is AuthState.NeedsSetup,
+        is AuthState.NeedsLogin,
+        is AuthState.PendingApproval,
+        -> true
+
+        // SessionLapsed deliberately does NOT gate: credentials are dead but local data is
+        // intact (never stranded) — browse serves the Room mirror offline, exactly like the
+        // in-app shell, which shows a non-blocking "sign in to sync" affordance instead of a wall.
+        is AuthState.Initializing,
+        is AuthState.CheckingServer,
+        is AuthState.Authenticated,
+        is AuthState.SessionLapsed,
+        -> false
+    }
+
+/**
+ * Typed browse errors for Android Auto — honest-over-silent in the car (#1239).
+ */
+internal object AutoBrowseErrors {
+    /**
+     * Authentication-expired [SessionError] with the error-resolution extras: the head unit
+     * shows the label and deep-links into the app (launch intent; the signed-out app lands on
+     * sign-in) when the user taps it on the phone.
+     */
+    fun signedOutError(context: Context): SessionError {
+        val launch =
+            requireNotNull(context.packageManager.getLaunchIntentForPackage(context.packageName)) {
+                "own package has no launch intent"
+            }
+        val pending =
+            PendingIntent.getActivity(context, 0, launch, PendingIntent.FLAG_IMMUTABLE)
+        val extras =
+            Bundle().apply {
+                putString(
+                    MediaConstants.EXTRAS_KEY_ERROR_RESOLUTION_ACTION_LABEL_COMPAT,
+                    "Sign in to ListenUp",
+                )
+                putParcelable(MediaConstants.EXTRAS_KEY_ERROR_RESOLUTION_ACTION_INTENT_COMPAT, pending)
+            }
+        return SessionError(
+            SessionError.ERROR_SESSION_AUTHENTICATION_EXPIRED,
+            "Sign in to ListenUp on your phone.",
+            extras,
+        )
+    }
+}

--- a/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/automotive/BrowsePagination.kt
+++ b/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/automotive/BrowsePagination.kt
@@ -19,3 +19,14 @@ internal fun <T> paginate(
     val end = minOf(start + pageSize, items.size.toLong())
     return items.subList(start.toInt(), end.toInt())
 }
+
+/**
+ * Whether [page] is the final page of [items] under [paginate]'s clamping rules — kept beside
+ * it so the boundary math has exactly one home. A non-positive [pageSize] means the head unit
+ * didn't paginate: the whole list was returned, so it is by definition the last page.
+ */
+internal fun isLastPage(
+    items: List<*>,
+    page: Int,
+    pageSize: Int,
+): Boolean = pageSize <= 0 || (page.coerceAtLeast(0).toLong() + 1) * pageSize >= items.size

--- a/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/automotive/BrowsePagination.kt
+++ b/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/automotive/BrowsePagination.kt
@@ -1,0 +1,21 @@
+package com.calypsan.listenup.client.automotive
+
+/**
+ * Slices a full browse/search result list to the head unit's requested page — the one
+ * pagination shape shared by `onGetChildren` and `onGetSearchResult` (#1238).
+ *
+ * Legacy browsers that don't paginate send `pageSize = Int.MAX_VALUE` (or the callback's
+ * documented "no paging" values) — long arithmetic keeps the end index from overflowing,
+ * and a non-positive [pageSize] returns the whole list.
+ */
+internal fun <T> paginate(
+    items: List<T>,
+    page: Int,
+    pageSize: Int,
+): List<T> {
+    if (pageSize <= 0) return items
+    val start = page.coerceAtLeast(0).toLong() * pageSize
+    if (start >= items.size) return emptyList()
+    val end = minOf(start + pageSize, items.size.toLong())
+    return items.subList(start.toInt(), end.toInt())
+}

--- a/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/automotive/BrowseTreeProvider.kt
+++ b/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/automotive/BrowseTreeProvider.kt
@@ -1,8 +1,10 @@
 package com.calypsan.listenup.client.automotive
 
 import android.net.Uri
+import android.os.Bundle
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
+import androidx.media3.session.MediaConstants
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.client.domain.model.ContinueListeningBook
@@ -106,6 +108,7 @@ class BrowseTreeProvider(
                     BrowseTree.LIBRARY,
                     "Library",
                     MediaMetadata.MEDIA_TYPE_FOLDER_AUDIO_BOOKS,
+                    childStyleExtras(playableAsGrid = true),
                 )
             }
 
@@ -129,6 +132,7 @@ class BrowseTreeProvider(
                 mediaId = BrowseTree.LIBRARY,
                 title = "Library",
                 mediaType = MediaMetadata.MEDIA_TYPE_FOLDER_AUDIO_BOOKS,
+                childStyle = childStyleExtras(playableAsGrid = true),
             ),
         )
 
@@ -155,11 +159,13 @@ class BrowseTreeProvider(
                 mediaId = BrowseTree.LIBRARY_RECENT,
                 title = "Recently Played",
                 mediaType = MediaMetadata.MEDIA_TYPE_FOLDER_AUDIO_BOOKS,
+                childStyle = childStyleExtras(playableAsGrid = true),
             ),
             createBrowsableItem(
                 mediaId = BrowseTree.LIBRARY_DOWNLOADED,
                 title = "Downloaded",
                 mediaType = MediaMetadata.MEDIA_TYPE_FOLDER_AUDIO_BOOKS,
+                childStyle = childStyleExtras(playableAsGrid = true),
             ),
             createBrowsableItem(
                 mediaId = BrowseTree.LIBRARY_SERIES,
@@ -200,6 +206,7 @@ class BrowseTreeProvider(
                     mediaId = BrowseTree.seriesId(series.id.value),
                     title = series.name,
                     mediaType = MediaMetadata.MEDIA_TYPE_FOLDER_AUDIO_BOOKS,
+                    childStyle = childStyleExtras(playableAsGrid = true),
                 )
             }
 
@@ -212,7 +219,8 @@ class BrowseTreeProvider(
                 createBrowsableItem(
                     mediaId = BrowseTree.authorId(author.id.value),
                     title = author.name,
-                    mediaType = MediaMetadata.MEDIA_TYPE_FOLDER_AUDIO_BOOKS,
+                    mediaType = MediaMetadata.MEDIA_TYPE_ARTIST,
+                    childStyle = childStyleExtras(playableAsGrid = true),
                 )
             }
 
@@ -265,10 +273,16 @@ class BrowseTreeProvider(
 
     // ========== Item Builders ==========
 
+    /**
+     * @param childStyle Content-style extras (#1240) declaring how THIS item's children
+     *   render on the head unit — grid for book-level folders (covers available), list
+     *   for category folders. Null leaves Auto's own default (list).
+     */
     private fun createBrowsableItem(
         mediaId: String,
         title: String,
         mediaType: Int,
+        childStyle: Bundle? = null,
     ): MediaItem =
         MediaItem
             .Builder()
@@ -280,8 +294,26 @@ class BrowseTreeProvider(
                     .setIsPlayable(false)
                     .setIsBrowsable(true)
                     .setMediaType(mediaType)
+                    .setExtras(childStyle)
                     .build(),
             ).build()
+
+    /** Extras declaring how this browsable's CHILDREN render on the head unit (#1240). */
+    private fun childStyleExtras(playableAsGrid: Boolean): Bundle =
+        Bundle().apply {
+            putInt(
+                MediaConstants.EXTRAS_KEY_CONTENT_STYLE_BROWSABLE,
+                MediaConstants.EXTRAS_VALUE_CONTENT_STYLE_LIST_ITEM,
+            )
+            putInt(
+                MediaConstants.EXTRAS_KEY_CONTENT_STYLE_PLAYABLE,
+                if (playableAsGrid) {
+                    MediaConstants.EXTRAS_VALUE_CONTENT_STYLE_GRID_ITEM
+                } else {
+                    MediaConstants.EXTRAS_VALUE_CONTENT_STYLE_LIST_ITEM
+                },
+            )
+        }
 
     private fun createPlayableBookItem(book: ContinueListeningBook): MediaItem {
         val artworkUri = book.coverPath?.let { Uri.parse("file://$it") }

--- a/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/automotive/BrowseTreeProvider.kt
+++ b/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/automotive/BrowseTreeProvider.kt
@@ -176,9 +176,10 @@ class BrowseTreeProvider(
     private suspend fun getRecentBooks(): List<MediaItem> {
         val result = homeRepository.getContinueListening(CONTINUE_LISTENING_LIMIT)
         if (result !is AppResult.Success) {
-            return emptyList()
+            // Surface as a typed browse error (onGetChildren maps this to RESULT_ERROR_UNKNOWN)
+            // rather than an empty library the head unit renders as "no content" (#1239).
+            error("continue-listening read failed: ${(result as AppResult.Failure).error.code}")
         }
-
         return result.data.map { book -> createPlayableBookItem(book) }
     }
 

--- a/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/automotive/BrowseTreeProvider.kt
+++ b/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/automotive/BrowseTreeProvider.kt
@@ -17,7 +17,11 @@ import kotlinx.coroutines.flow.first
 
 private val logger = KotlinLogging.logger {}
 
-private const val MAX_ITEMS_PER_LEVEL = 8
+/** Safety bound per catalog browse level; the head unit pages within it (#1238). */
+private const val MAX_ITEMS_PER_LEVEL = 100
+
+/** The continue-listening shelf stays a small curated row — a deliberate product choice. */
+private const val CONTINUE_LISTENING_LIMIT = 8
 
 /**
  * Provides browse tree data for Android Auto.
@@ -170,7 +174,7 @@ class BrowseTreeProvider(
         )
 
     private suspend fun getRecentBooks(): List<MediaItem> {
-        val result = homeRepository.getContinueListening(MAX_ITEMS_PER_LEVEL)
+        val result = homeRepository.getContinueListening(CONTINUE_LISTENING_LIMIT)
         if (result !is AppResult.Success) {
             return emptyList()
         }

--- a/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/automotive/CustomActions.kt
+++ b/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/automotive/CustomActions.kt
@@ -7,18 +7,11 @@ import androidx.media3.session.SessionCommand
  * Custom session commands for Android Auto and external controllers.
  *
  * These commands extend the standard media controls with audiobook-specific
- * functionality like speed cycling, chapter navigation, and sleep timer.
+ * functionality like speed cycling and chapter navigation.
  */
 object CustomActions {
     // Speed control
     const val CYCLE_SPEED = "com.calypsan.listenup.CYCLE_SPEED"
-
-    // Sleep timer
-    const val SET_SLEEP_TIMER = "com.calypsan.listenup.SET_SLEEP_TIMER"
-    const val CANCEL_SLEEP_TIMER = "com.calypsan.listenup.CANCEL_SLEEP_TIMER"
-
-    // Bundle keys for sleep timer
-    const val EXTRA_TIMER_MINUTES = "timer_minutes"
 
     // In-app book-relative seek. The session player is ChapterWindowPlayer, the chapter-scoped
     // presentation wrapper (see its class KDoc), so a plain controller.seekTo(index, positionMs)
@@ -73,24 +66,6 @@ object CustomActions {
      * Create SessionCommand for speed cycling.
      */
     fun cycleSpeedCommand(): SessionCommand = SessionCommand(CYCLE_SPEED, Bundle.EMPTY)
-
-    /**
-     * Create SessionCommand for setting sleep timer.
-     *
-     * @param minutes Timer duration in minutes
-     */
-    fun setSleepTimerCommand(minutes: Int): SessionCommand {
-        val args =
-            Bundle().apply {
-                putInt(EXTRA_TIMER_MINUTES, minutes)
-            }
-        return SessionCommand(SET_SLEEP_TIMER, args)
-    }
-
-    /**
-     * Create SessionCommand for canceling sleep timer.
-     */
-    fun cancelSleepTimerCommand(): SessionCommand = SessionCommand(CANCEL_SLEEP_TIMER, Bundle.EMPTY)
 
     /**
      * Create SessionCommand for the in-app book-relative seek transport.

--- a/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/AutoStartPosition.kt
+++ b/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/AutoStartPosition.kt
@@ -1,0 +1,37 @@
+package com.calypsan.listenup.client.playback
+
+import androidx.media3.common.C
+import com.calypsan.listenup.client.domain.playback.PlaybackTimeline
+
+/**
+ * Decides the start index/position for a controller `setMediaItems` request — the seam behind
+ * [PlaybackService]'s `onSetMediaItems` override (see its KDoc for the full contract).
+ *
+ * - An explicit [requestedStartIndex] (`!= C.INDEX_UNSET`) is the in-app
+ *   `AndroidPlaybackController.setMediaQueue` path: pass both values through verbatim.
+ * - Otherwise, when the request contained exactly one item and it resolved to a book —
+ *   the Auto tap-to-play / voice-search shape — resume at the book's saved position via
+ *   [PlaybackTimeline.resolve]. `resumePositionMs` already includes the auto-rewind offset
+ *   (folded in by `PlaybackPreparer.resumeStartPositionMs`). This is the #1236 pin.
+ * - Otherwise `C.INDEX_UNSET`/`C.TIME_UNSET`, which tells Media3 to apply its own defaults.
+ */
+internal fun autoStartPosition(
+    requestedStartIndex: Int,
+    requestedStartPositionMs: Long,
+    requestItemCount: Int,
+    resumeTimeline: PlaybackTimeline?,
+    resumePositionMs: Long,
+): Pair<Int, Long> =
+    when {
+        requestedStartIndex != C.INDEX_UNSET -> {
+            requestedStartIndex to requestedStartPositionMs
+        }
+
+        requestItemCount == 1 && resumeTimeline != null -> {
+            resumeTimeline.resolve(resumePositionMs).let { it.mediaItemIndex to it.positionInFileMs }
+        }
+
+        else -> {
+            C.INDEX_UNSET to C.TIME_UNSET
+        }
+    }

--- a/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
+++ b/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
@@ -28,9 +28,11 @@ import androidx.media3.session.SessionCommand
 import androidx.media3.session.SessionResult
 import com.calypsan.listenup.api.error.PlaybackError
 import com.calypsan.listenup.client.composeapp.R
+import com.calypsan.listenup.client.automotive.AutoBrowseErrors
 import com.calypsan.listenup.client.automotive.BrowseTree
 import com.calypsan.listenup.client.automotive.BrowseTreeProvider
 import com.calypsan.listenup.client.automotive.CustomActions
+import com.calypsan.listenup.client.automotive.browseNeedsSignIn
 import com.calypsan.listenup.client.automotive.isLastPage
 import com.calypsan.listenup.client.automotive.paginate
 import com.calypsan.listenup.client.playback.cast.CastMediaItemFactory
@@ -41,6 +43,7 @@ import com.calypsan.listenup.api.result.AppResult
 import com.calypsan.listenup.core.BookId
 import com.calypsan.listenup.core.error.ErrorBus
 import com.calypsan.listenup.api.result.getOrNull
+import com.calypsan.listenup.client.domain.repository.AuthSession
 import com.calypsan.listenup.client.domain.repository.HomeRepository
 import com.calypsan.listenup.client.domain.repository.PlaybackPositionRepository
 import com.calypsan.listenup.client.voice.MediaFocus
@@ -118,6 +121,7 @@ class PlaybackService : MediaLibraryService() {
     private val tokenProvider: AndroidAudioTokenProvider by inject()
     private val sleepTimerManager: SleepTimerManager by inject()
     private val browseTreeProvider: BrowseTreeProvider by inject()
+    private val authSession: AuthSession by inject()
     private val voiceIntentResolver: VoiceIntentResolver by inject()
     private val homeRepository: HomeRepository by inject()
     private val castPreparer: CastPreparer by inject()
@@ -906,6 +910,12 @@ class PlaybackService : MediaLibraryService() {
                 logger.debug { "onGetLibraryRoot rejected for untrusted controller: ${browser.packageName}" }
                 return Futures.immediateFuture(LibraryResult.ofError(LibraryResult.RESULT_ERROR_PERMISSION_DENIED))
             }
+            if (browseNeedsSignIn(authSession.authState.value)) {
+                logger.debug { "onGetLibraryRoot: signed out — returning auth error" }
+                return Futures.immediateFuture(
+                    LibraryResult.ofError(AutoBrowseErrors.signedOutError(applicationContext)),
+                )
+            }
             logger.debug { "onGetLibraryRoot" }
             val root = browseTreeProvider.getRoot()
             return Futures.immediateFuture(LibraryResult.ofItem(root, params))
@@ -920,6 +930,12 @@ class PlaybackService : MediaLibraryService() {
             params: MediaLibraryService.LibraryParams?,
         ): ListenableFuture<LibraryResult<ImmutableList<MediaItem>>> {
             logger.debug { "onGetChildren: parentId=$parentId, page=$page, pageSize=$pageSize" }
+
+            if (browseNeedsSignIn(authSession.authState.value)) {
+                return Futures.immediateFuture(
+                    LibraryResult.ofError(AutoBrowseErrors.signedOutError(applicationContext)),
+                )
+            }
 
             return CallbackToFutureAdapter.getFuture { completer ->
                 serviceScope.launch {

--- a/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
+++ b/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
@@ -1236,12 +1236,8 @@ class PlaybackService : MediaLibraryService() {
          * one — so this branch preserves [startIndex]/[startPositionMs] verbatim, keeping that path
          * byte-identical to before this override existed.
          *
-         * Otherwise (Auto tap-to-play / voice search): when [mediaItems] resolved to exactly one
-         * book — the shape both of those callers always send — resume it at its saved position via
-         * [PlaybackManager.PrepareResult.timeline]`.resolve(resumePositionMs)`, rather than the
-         * default index/position-zero. When more than one book resolved (or none), fall back to
-         * `C.INDEX_UNSET`/`C.TIME_UNSET`, which per [MediaSession.MediaItemsWithStartPosition]'s
-         * contract tells Media3 to apply its own default index/position.
+         * Otherwise (Auto tap-to-play / voice search), the start index/position is decided by
+         * [autoStartPosition] — see its KDoc for the full contract.
          */
         override fun onSetMediaItems(
             mediaSession: MediaSession,
@@ -1263,30 +1259,20 @@ class PlaybackService : MediaLibraryService() {
                         // whatever the app happened to activate last.
                         prepareResult?.let { playbackManager.activateBook(it.timeline.bookId) }
 
-                        if (startIndex != C.INDEX_UNSET) {
-                            completer.set(
-                                MediaSession.MediaItemsWithStartPosition(resolvedItems, startIndex, startPositionMs),
+                        val (resolvedStartIndex, resolvedStartPositionMs) =
+                            autoStartPosition(
+                                requestedStartIndex = startIndex,
+                                requestedStartPositionMs = startPositionMs,
+                                requestItemCount = mediaItems.size,
+                                resumeTimeline = prepareResult?.timeline,
+                                resumePositionMs = prepareResult?.resumePositionMs ?: 0L,
                             )
-                            return@launch
-                        }
-
-                        val resumeStart =
-                            if (mediaItems.size == 1 && prepareResult != null) {
-                                prepareResult.timeline.resolve(prepareResult.resumePositionMs)
-                            } else {
-                                null
-                            }
-
                         completer.set(
-                            if (resumeStart != null) {
-                                MediaSession.MediaItemsWithStartPosition(
-                                    resolvedItems,
-                                    resumeStart.mediaItemIndex,
-                                    resumeStart.positionInFileMs,
-                                )
-                            } else {
-                                MediaSession.MediaItemsWithStartPosition(resolvedItems, C.INDEX_UNSET, C.TIME_UNSET)
-                            },
+                            MediaSession.MediaItemsWithStartPosition(
+                                resolvedItems,
+                                resolvedStartIndex,
+                                resolvedStartPositionMs,
+                            ),
                         )
                     } catch (e: CancellationException) {
                         throw e

--- a/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
+++ b/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
@@ -31,6 +31,7 @@ import com.calypsan.listenup.client.composeapp.R
 import com.calypsan.listenup.client.automotive.BrowseTree
 import com.calypsan.listenup.client.automotive.BrowseTreeProvider
 import com.calypsan.listenup.client.automotive.CustomActions
+import com.calypsan.listenup.client.automotive.isLastPage
 import com.calypsan.listenup.client.automotive.paginate
 import com.calypsan.listenup.client.playback.cast.CastMediaItemFactory
 import com.calypsan.listenup.client.playback.cast.CastPreparer
@@ -1101,8 +1102,8 @@ class PlaybackService : MediaLibraryService() {
             val pageItems = paginate(items, page, pageSize)
 
             // Clean up cache after the last page is retrieved
-            val isLastPage = pageSize <= 0 || (page.coerceAtLeast(0).toLong() + 1) * pageSize >= items.size
-            if (isLastPage) {
+            val lastPage = isLastPage(items, page, pageSize)
+            if (lastPage) {
                 searchResultsCache.remove(query)
                 logger.debug { "Search cache cleared for query: $query" }
             }

--- a/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
+++ b/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
@@ -31,6 +31,7 @@ import com.calypsan.listenup.client.composeapp.R
 import com.calypsan.listenup.client.automotive.BrowseTree
 import com.calypsan.listenup.client.automotive.BrowseTreeProvider
 import com.calypsan.listenup.client.automotive.CustomActions
+import com.calypsan.listenup.client.automotive.paginate
 import com.calypsan.listenup.client.playback.cast.CastMediaItemFactory
 import com.calypsan.listenup.client.playback.cast.CastPreparer
 import com.calypsan.listenup.client.playback.cast.CastSessionController
@@ -923,7 +924,8 @@ class PlaybackService : MediaLibraryService() {
                 serviceScope.launch {
                     try {
                         val children = browseTreeProvider.getChildren(parentId)
-                        completer.set(LibraryResult.ofItemList(ImmutableList.copyOf(children), params))
+                        val pageItems = paginate(children, page, pageSize)
+                        completer.set(LibraryResult.ofItemList(ImmutableList.copyOf(pageItems), params))
                     } catch (e: CancellationException) {
                         throw e
                     } catch (e: Exception) {
@@ -1096,19 +1098,10 @@ class PlaybackService : MediaLibraryService() {
             logger.debug { "onGetSearchResult: query='$query', page=$page, pageSize=$pageSize" }
 
             val items = searchResultsCache[query] ?: emptyList()
+            val pageItems = paginate(items, page, pageSize)
 
-            // Apply pagination
-            val startIndex = page * pageSize
-            val endIndex = minOf(startIndex + pageSize, items.size)
-            val pageItems =
-                if (startIndex < items.size) {
-                    items.subList(startIndex, endIndex)
-                } else {
-                    emptyList()
-                }
-
-            // Clean up cache after last page is retrieved
-            val isLastPage = endIndex >= items.size
+            // Clean up cache after the last page is retrieved
+            val isLastPage = pageSize <= 0 || (page.coerceAtLeast(0).toLong() + 1) * pageSize >= items.size
             if (isLastPage) {
                 searchResultsCache.remove(query)
                 logger.debug { "Search cache cleared for query: $query" }


### PR DESCRIPTION
Closes #1238, closes #1239, closes #1240, closes #1236.

- **#1236** — confirmed fixed by #1241's `onSetMediaItems` override, now empirically pinned: the decision is extracted into a pure `autoStartPosition` seam with a 4-case Kotest test proving the voice-search shape resumes at the saved position (auto-rewind already folded in by `PlaybackPreparer`). In-car voice check remains on the pre-merge list.
- **#1238** — `onGetChildren` honors `page`/`pageSize` via the same `paginate`/`isLastPage` helpers `onGetSearchResult` now shares (boundary math has exactly one home); catalog levels bounded at 100; the continue-listening shelf stays a curated 8 (deliberate product choice).
- **#1239** — genuinely signed-out browse returns `SessionError.ERROR_SESSION_AUTHENTICATION_EXPIRED` with the error-resolution PendingIntent ("Sign in to ListenUp" → launch intent). Transient startup states and `SessionLapsed` deliberately do NOT gate — browse serves the Room mirror offline (never stranded). Repo read failures now surface as typed errors instead of a silent empty library.
- **#1240** — never-advertised `SET_SLEEP_TIMER`/`CANCEL_SLEEP_TIMER` surface deleted; grid content-style hints on book-level folders (Recently Played, Downloaded, series, authors); author entries typed `MEDIA_TYPE_ARTIST`.

Tests: +9 new cases across four suites (`AutoStartPositionTest`, `BrowsePaginationTest` 11, `AutoBrowseErrorsTest`, `BrowseTreeProviderTest` 24). Full `:app:sharedUI:testAndroidHostTest` green; `verifyLocal` green except the known local-only `SidecarParsersAreReadOnly` Konsist timeout (passes alone; never seen on CI).

**Pre-merge in-car checklist (Simon):** grid presentation looks right · >8-item level pages fully · signed-out shows the sign-in error with working resolution tap · "Hey Google, play <book>" resumes mid-book · chapter seek bar / boundary rollover regression check from #1241.