### PR TITLE
🐛 fix(sharedUI): stop playback failures from stranding the listener

### DIFF
--- a/app/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/PlaybackErrorHandlerTest.kt
+++ b/app/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/PlaybackErrorHandlerTest.kt
@@ -58,6 +58,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -208,7 +209,7 @@ class PlaybackErrorHandlerTest {
 
     @Test
     fun `handle Network returns true and does not pause player`() {
-        runBlocking {
+        runTest {
             val tracker = FakeProgressTracker()
             val player = FakeExoPlayer(stubbedPosition = 8_000L)
             val errors = mutableListOf<String>()
@@ -225,7 +226,7 @@ class PlaybackErrorHandlerTest {
                     onShowError = { errors += it },
                 )
 
-            withClue("Network error should return true (ExoPlayer handles retry)") { result shouldBe true }
+            withClue("Network error should return true (recovery attempted)") { result shouldBe true }
             withClue("Player should NOT be paused for network errors") { player.pauseCount shouldBe 0 }
             withClue("No user-visible error for transient network issues") { errors.isEmpty() shouldBe true }
             withClue("Position saved once before handling") { tracker.savePlaybackStateCalls.size shouldBe 1 }
@@ -239,7 +240,7 @@ class PlaybackErrorHandlerTest {
 
     @Test
     fun `handle Network skips position save when currentBookId is null`() {
-        runBlocking {
+        runTest {
             val tracker = FakeProgressTracker()
 
             makeHandler(tracker = tracker).handle(
@@ -253,6 +254,145 @@ class PlaybackErrorHandlerTest {
             withClue("No save when bookId is null") { tracker.savePlaybackStateCalls.size shouldBe 0 }
         }
     }
+
+    // ── handle — recovery budget ──────────────────────────────────────────────
+    //
+    // These cover the fix for a stall that stranded a listener mid-book. The Network branch used
+    // to log "ExoPlayer handles retry internally" and return true without touching the player —
+    // but ExoPlayer's own retries are already spent by the time onPlayerError fires, so the
+    // player sat IDLE forever while the handler reported success.
+    //
+    // runTest (not runBlocking) so the recovery backoff runs on virtual time.
+
+    @Test
+    fun `handle Network re-prepares and resumes the player`() =
+        runTest {
+            val player = FakeExoPlayer()
+
+            val result =
+                makeHandler().handle(
+                    error = PlaybackErrorHandler.ClassifiedError.Network("net"),
+                    player = player,
+                    currentBookId = BookId("book1"),
+                    bookPositionMs = 1_000L,
+                    onShowError = {},
+                )
+
+            withClue("Recovery attempted, so playback continues") { result shouldBe true }
+            withClue("prepare() is what actually lifts the player out of IDLE") {
+                player.prepareCount shouldBe 1
+            }
+            withClue("play() resumes once prepared") { player.playCount shouldBe 1 }
+        }
+
+    @Test
+    fun `handle Network gives up once the retry budget is spent and tells the listener`() =
+        runTest {
+            val handler = makeHandler()
+            val player = FakeExoPlayer()
+            val errors = mutableListOf<String>()
+
+            repeat(RECOVERY_ATTEMPT_BUDGET) {
+                handler.handle(
+                    error = PlaybackErrorHandler.ClassifiedError.Network("net"),
+                    player = player,
+                    currentBookId = BookId("book1"),
+                    bookPositionMs = 1_000L,
+                    onShowError = { errors += it },
+                )
+            }
+
+            withClue("Budget spent on recovery, nothing surfaced yet") { errors.isEmpty() shouldBe true }
+
+            val exhausted =
+                handler.handle(
+                    error = PlaybackErrorHandler.ClassifiedError.Network("net"),
+                    player = player,
+                    currentBookId = BookId("book1"),
+                    bookPositionMs = 1_000L,
+                    onShowError = { errors += it },
+                )
+
+            withClue("Returning false lets the caller start the idle timer") { exhausted shouldBe false }
+            withClue("Listener is told once, not on every failed attempt") { errors.size shouldBe 1 }
+            withClue("The message points at the manual fallback") {
+                errors.single().contains("Tap play") shouldBe true
+            }
+            withClue("No further prepare() once the budget is spent") {
+                player.prepareCount shouldBe RECOVERY_ATTEMPT_BUDGET
+            }
+        }
+
+    @Test
+    fun `onPlaybackHealthy refills the budget so it is per-incident, not per-session`() =
+        runTest {
+            val handler = makeHandler()
+            val player = FakeExoPlayer()
+            val errors = mutableListOf<String>()
+
+            repeat(RECOVERY_ATTEMPT_BUDGET + 1) {
+                handler.handle(
+                    error = PlaybackErrorHandler.ClassifiedError.Network("net"),
+                    player = player,
+                    currentBookId = BookId("book1"),
+                    bookPositionMs = 1_000L,
+                    onShowError = { errors += it },
+                )
+            }
+            withClue("Precondition: budget is spent") { errors.size shouldBe 1 }
+
+            handler.onPlaybackHealthy()
+
+            val afterRecovery =
+                handler.handle(
+                    error = PlaybackErrorHandler.ClassifiedError.Network("net"),
+                    player = player,
+                    currentBookId = BookId("book1"),
+                    bookPositionMs = 1_000L,
+                    onShowError = { errors += it },
+                )
+
+            withClue("A later, unrelated stall gets a full budget of its own") {
+                afterRecovery shouldBe true
+            }
+            withClue("prepare() runs again after the refill") {
+                player.prepareCount shouldBe RECOVERY_ATTEMPT_BUDGET + 1
+            }
+        }
+
+    @Test
+    fun `handle Stuck draws on the same budget as Network`() =
+        runTest {
+            val handler = makeHandler()
+            val player = FakeExoPlayer()
+            val errors = mutableListOf<String>()
+
+            // A book that stalls, recovers, and stalls again is failing repeatedly whatever the
+            // reported cause — so a mix of the two must not double the effective budget.
+            repeat(RECOVERY_ATTEMPT_BUDGET) {
+                handler.handle(
+                    error = PlaybackErrorHandler.ClassifiedError.Network("net"),
+                    player = player,
+                    currentBookId = BookId("book1"),
+                    bookPositionMs = 1_000L,
+                    onShowError = { errors += it },
+                )
+            }
+
+            val stuckAfterNetworkBudget =
+                handler.handle(
+                    error = PlaybackErrorHandler.ClassifiedError.Stuck("stuck"),
+                    player = player,
+                    currentBookId = BookId("book1"),
+                    bookPositionMs = 1_000L,
+                    onShowError = { errors += it },
+                )
+
+            withClue("Stuck shares the budget rather than getting a fresh one") {
+                stuckAfterNetworkBudget shouldBe false
+            }
+            withClue("No stop/prepare cycle once the budget is spent") { player.stopCount shouldBe 0 }
+        }
 
     // ── handle — NotFound ─────────────────────────────────────────────────────
 
@@ -313,7 +453,7 @@ class PlaybackErrorHandlerTest {
 
     @Test
     fun `handle Stuck returns true and performs stop-prepare-seekTo-play recovery`() {
-        runBlocking {
+        runTest {
             val tracker = FakeProgressTracker()
             val player = FakeExoPlayer(stubbedPosition = 12_000L, stubbedMediaItemIndex = 2)
             val errors = mutableListOf<String>()
@@ -350,7 +490,7 @@ class PlaybackErrorHandlerTest {
 
     @Test
     fun `handle Stuck at position 0 does not call seekTo`() {
-        runBlocking {
+        runTest {
             val player = FakeExoPlayer(stubbedPosition = 0L, stubbedMediaItemIndex = 0)
 
             makeHandler().handle(

--- a/app/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/PlaybackRefusalTest.kt
+++ b/app/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/PlaybackRefusalTest.kt
@@ -1,0 +1,79 @@
+package com.calypsan.listenup.client.playback
+
+import androidx.media3.common.Player
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tells a refused start apart from an ordinary focus loss.
+ *
+ * Android 17's background audio hardening refuses `requestAudioFocus()` outright when the app has
+ * neither a visible activity nor a running foreground service — the framework logs
+ * `AudioHardening … level: partial … exemption: 0` and returns `AUDIOFOCUS_REQUEST_FAILED`.
+ * ExoPlayer honours that by putting `playWhenReady` straight back to false.
+ *
+ * The catch is that a phone call interrupting playback reports the *same* reason. One is a dead
+ * end the listener needs a way out of; the other is routine and self-healing. Getting this
+ * backwards means either silence when the listener is stuck, or a spurious notification every time
+ * someone rings them — so the distinction is drawn here, in one testable place.
+ */
+class PlaybackRefusalTest :
+    FunSpec({
+
+        test("a start refused before any audio played is a refusal") {
+            // The hardening case: play was requested, focus was denied, nothing ever sounded.
+            isPlaybackRefused(
+                playWhenReady = false,
+                reason = Player.PLAY_WHEN_READY_CHANGE_REASON_AUDIO_FOCUS_LOSS,
+                wasPlaying = false,
+            ) shouldBe true
+        }
+
+        test("losing focus mid-playback is not a refusal") {
+            // A phone call. Routine, and playback resumes on its own afterwards.
+            isPlaybackRefused(
+                playWhenReady = false,
+                reason = Player.PLAY_WHEN_READY_CHANGE_REASON_AUDIO_FOCUS_LOSS,
+                wasPlaying = true,
+            ) shouldBe false
+        }
+
+        test("the listener pausing is never a refusal") {
+            isPlaybackRefused(
+                playWhenReady = false,
+                reason = Player.PLAY_WHEN_READY_CHANGE_REASON_USER_REQUEST,
+                wasPlaying = true,
+            ) shouldBe false
+
+            isPlaybackRefused(
+                playWhenReady = false,
+                reason = Player.PLAY_WHEN_READY_CHANGE_REASON_USER_REQUEST,
+                wasPlaying = false,
+            ) shouldBe false
+        }
+
+        test("unplugging headphones is not a refusal") {
+            isPlaybackRefused(
+                playWhenReady = false,
+                reason = Player.PLAY_WHEN_READY_CHANGE_REASON_AUDIO_BECOMING_NOISY,
+                wasPlaying = true,
+            ) shouldBe false
+        }
+
+        test("reaching the end of the book is not a refusal") {
+            isPlaybackRefused(
+                playWhenReady = false,
+                reason = Player.PLAY_WHEN_READY_CHANGE_REASON_END_OF_MEDIA_ITEM,
+                wasPlaying = true,
+            ) shouldBe false
+        }
+
+        test("starting playback is never a refusal") {
+            // playWhenReady = true means the player is going; nothing was refused.
+            isPlaybackRefused(
+                playWhenReady = true,
+                reason = Player.PLAY_WHEN_READY_CHANGE_REASON_AUDIO_FOCUS_LOSS,
+                wasPlaying = false,
+            ) shouldBe false
+        }
+    })

--- a/app/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/StallRecoveryTest.kt
+++ b/app/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/StallRecoveryTest.kt
@@ -1,0 +1,78 @@
+package com.calypsan.listenup.client.playback
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.ints.shouldBeLessThan
+import io.kotest.matchers.shouldBe
+import androidx.media3.common.Player
+import okhttp3.Authenticator
+import okhttp3.Interceptor
+import okhttp3.Route
+
+private val passThroughInterceptor = Interceptor { chain -> chain.proceed(chain.request()) }
+
+private val giveUpAuthenticator = Authenticator { _: Route?, _ -> null }
+
+/**
+ * Guards the two bounds that stop a stalled stream from stranding a listener mid-book.
+ *
+ * Both exist because of a real incident: a stream stalled mid-walk and the player sat in
+ * `STATE_BUFFERING` indefinitely. The read timeout was infinite, so OkHttp never raised an
+ * `IOException`, so ExoPlayer never raised a `PlaybackException`, so [PlaybackErrorHandler]'s
+ * network-retry path — which was correct all along — was unreachable. Silence, not failure,
+ * was the bug.
+ */
+class StallRecoveryTest :
+    FunSpec({
+
+        test("every streaming socket timeout is finite so a half-open connection raises an error") {
+            val client = buildStreamingHttpClient(passThroughInterceptor, giveUpAuthenticator)
+
+            // The read timeout is the one that regressed: `readTimeout(0)` means "block forever",
+            // which converts a dead socket into an eternal spinner instead of a retryable failure.
+            client.readTimeoutMillis shouldBeGreaterThan 0
+            client.connectTimeoutMillis shouldBeGreaterThan 0
+            client.writeTimeoutMillis shouldBeGreaterThan 0
+        }
+
+        test("streaming timeouts match the declared budget") {
+            val client = buildStreamingHttpClient(passThroughInterceptor, giveUpAuthenticator)
+
+            client.readTimeoutMillis shouldBe STREAM_READ_TIMEOUT_MS
+            client.connectTimeoutMillis shouldBe STREAM_CONNECT_TIMEOUT_MS
+            client.writeTimeoutMillis shouldBe STREAM_WRITE_TIMEOUT_MS
+        }
+
+        test("the streaming client carries the auth interceptor and authenticator") {
+            val client = buildStreamingHttpClient(passThroughInterceptor, giveUpAuthenticator)
+
+            client.interceptors shouldBe listOf(passThroughInterceptor)
+            client.authenticator shouldBe giveUpAuthenticator
+        }
+
+        test("the stuck-buffering backstop fires well inside Media3's ten-minute default") {
+            // ExoPlayer.Builder.DEFAULT_STUCK_BUFFERING_DETECTION_TIMEOUT_MS is 600_000. Ten
+            // minutes of spinner is abandonment, not a backstop.
+            STUCK_BUFFERING_TIMEOUT_MS shouldBeLessThan 600_000
+        }
+
+        test("an idle player must be re-prepared before play, or the manual retry does nothing") {
+            // The state a terminal error — or the recovery stop/prepare cycle — leaves behind.
+            needsPrepareBeforePlay(Player.STATE_IDLE) shouldBe true
+        }
+
+        test("a player that is already going is not re-prepared") {
+            // Re-preparing a healthy player would restart the current item, so the check has to
+            // be exact rather than "anything that isn't READY".
+            needsPrepareBeforePlay(Player.STATE_READY) shouldBe false
+            needsPrepareBeforePlay(Player.STATE_BUFFERING) shouldBe false
+            needsPrepareBeforePlay(Player.STATE_ENDED) shouldBe false
+        }
+
+        test("the stuck-buffering backstop leaves room for a read timeout plus ExoPlayer retries") {
+            // Firing while a legitimate retry is still in flight would turn a recoverable blip
+            // into a user-visible error, so the backstop must clear one full read timeout and the
+            // retry/backoff window that follows it — not merely exceed the read timeout itself.
+            STUCK_BUFFERING_TIMEOUT_MS shouldBeGreaterThan (STREAM_READ_TIMEOUT_MS * 2)
+        }
+    })

--- a/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/AndroidPlaybackController.kt
+++ b/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/AndroidPlaybackController.kt
@@ -49,8 +49,17 @@ class AndroidPlaybackController(
     override val isReady: StateFlow<Boolean> = holder.isConnected
 
     override fun play() {
-        holder.controller?.play()
-            ?: logger.warn { "AndroidPlaybackController.play: controller not ready" }
+        val controller =
+            holder.controller
+                ?: return logger.warn { "AndroidPlaybackController.play: controller not ready" }
+
+        // An idle player — left that way by a terminal error, or by the recovery stop/prepare
+        // cycle — ignores play() entirely. See needsPrepareBeforePlay.
+        if (needsPrepareBeforePlay(controller.playbackState)) {
+            logger.info { "AndroidPlaybackController.play: player idle, re-preparing before play" }
+            controller.prepare()
+        }
+        controller.play()
     }
 
     override fun pause() {

--- a/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackErrorHandler.kt
+++ b/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackErrorHandler.kt
@@ -6,12 +6,26 @@ import androidx.media3.exoplayer.ExoPlayer
 import com.calypsan.listenup.core.BookId
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.delay
+import java.util.concurrent.atomic.AtomicInteger
 
 private val logger = KotlinLogging.logger {}
 
 private const val HTTP_UNAUTHORIZED = 401
 private const val HTTP_FORBIDDEN = 403
 private const val HTTP_NOT_FOUND = 404
+
+/**
+ * Backoff before each successive recovery attempt, and — by its length — the retry budget.
+ *
+ * Sized for the case that motivates it: walking through a dead spot. The five attempts span
+ * roughly half a minute of lost signal, which covers a tunnel or a lift without holding a wake
+ * lock open indefinitely against a network that is genuinely gone. When the budget is spent the
+ * listener is told, and the manual path in front of them works — see [needsPrepareBeforePlay].
+ */
+private val RECOVERY_BACKOFF_MS = listOf(1_000L, 2_000L, 4_000L, 8_000L, 16_000L)
+
+/** How many automatic recovery attempts a single stall gets before the listener is told. */
+internal val RECOVERY_ATTEMPT_BUDGET = RECOVERY_BACKOFF_MS.size
 
 /**
  * Handles playback errors with the principle: "Position is sacred."
@@ -27,6 +41,24 @@ class PlaybackErrorHandler(
     private val progressTracker: ProgressTracker,
     private val tokenProvider: AndroidAudioTokenProvider,
 ) {
+    /**
+     * Recovery attempts spent since playback was last healthy.
+     *
+     * Atomic because it is read from the service's coroutine scope and reset from Media3's
+     * player callbacks on the main looper.
+     */
+    private val recoveryAttempts = AtomicInteger(0)
+
+    /**
+     * Refills the recovery budget — call when playback is confirmed healthy again.
+     *
+     * Without this the budget is per-session rather than per-incident: a dead spot on the morning
+     * walk would silently consume the retries needed by an unrelated stall that evening.
+     */
+    fun onPlaybackHealthy() {
+        recoveryAttempts.set(0)
+    }
+
     /**
      * Classifies errors into actionable categories.
      */
@@ -130,10 +162,13 @@ class PlaybackErrorHandler(
 
         return when (error) {
             is ClassifiedError.Network -> {
-                // ExoPlayer handles retry internally
-                // Just log and let it buffer
-                logger.info { "Network error, ExoPlayer buffering: ${error.message}" }
-                true // Continue, ExoPlayer is handling it
+                // ExoPlayer's own load-error retries are already spent by the time onPlayerError
+                // fires — the player is IDLE and nothing is buffering. Re-preparing is the only
+                // thing that resumes playback; without it this branch is a silent no-op.
+                recoverOrGiveUp(player, onShowError, "network") { idle ->
+                    idle.prepare()
+                    idle.play()
+                }
             }
 
             is ClassifiedError.AuthExpired -> {
@@ -173,26 +208,27 @@ class PlaybackErrorHandler(
             }
 
             is ClassifiedError.Stuck -> {
-                // Media3 1.9.0 stuck player detection
-                // Player was buffering or ready but not making progress
+                // Media3's stuck-player detection (see StallRecovery.kt for the timeout we set).
+                // Shares the retry budget with the network path deliberately: a book that stalls,
+                // recovers, and stalls again is failing repeatedly whatever the reported cause,
+                // and each recovery here is a full stop/prepare/seek cycle.
                 logger.warn { "Stuck player detected: ${error.message}" }
 
-                // For HLS progressive transcoding, this might happen during long
-                // segment waits. Try to recover by re-preparing.
-                val currentPosition = player.currentPosition
-                val currentMediaItemIndex = player.currentMediaItemIndex
+                recoverOrGiveUp(player, onShowError, "stuck") { stuck ->
+                    // Re-preparing resets the position, so capture it first and restore it after.
+                    val currentPosition = stuck.currentPosition
+                    val currentMediaItemIndex = stuck.currentMediaItemIndex
 
-                player.stop()
-                player.prepare()
+                    stuck.stop()
+                    stuck.prepare()
 
-                // Restore position if we had one
-                if (currentPosition > 0) {
-                    player.seekTo(currentMediaItemIndex, currentPosition)
+                    if (currentPosition > 0) {
+                        stuck.seekTo(currentMediaItemIndex, currentPosition)
+                    }
+
+                    stuck.play()
+                    logger.info { "Attempting recovery from stuck state at position $currentPosition" }
                 }
-
-                player.play()
-                logger.info { "Attempting recovery from stuck state at position $currentPosition" }
-                true // Continue, we're attempting recovery
             }
 
             is ClassifiedError.Unknown -> {
@@ -202,6 +238,34 @@ class PlaybackErrorHandler(
                 false
             }
         }
+    }
+
+    /**
+     * Spends one unit of the recovery budget on [recover], or gives up and tells the listener.
+     *
+     * Backs off before acting: an immediate re-prepare against a network that has not returned
+     * just burns the budget in a few hundred milliseconds. Returns `true` while attempts remain
+     * (playback is being recovered), `false` once the budget is spent.
+     */
+    private suspend fun recoverOrGiveUp(
+        player: ExoPlayer,
+        onShowError: (String) -> Unit,
+        reason: String,
+        recover: (ExoPlayer) -> Unit,
+    ): Boolean {
+        val attempt = recoveryAttempts.getAndIncrement()
+
+        if (attempt >= RECOVERY_BACKOFF_MS.size) {
+            logger.warn { "Recovery budget spent after $attempt attempts ($reason); giving up" }
+            onShowError("Playback stopped and couldn't restart on its own. Tap play to try again.")
+            return false
+        }
+
+        val backoff = RECOVERY_BACKOFF_MS[attempt]
+        logger.info { "Recovering playback ($reason), attempt ${attempt + 1} in ${backoff}ms" }
+        delay(backoff)
+        recover(player)
+        return true
     }
 
     /**

--- a/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackRefusal.kt
+++ b/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackRefusal.kt
@@ -1,0 +1,29 @@
+package com.calypsan.listenup.client.playback
+
+import androidx.media3.common.Player
+
+/**
+ * Whether a play request was refused outright, as opposed to interrupted.
+ *
+ * Android 17's background audio hardening refuses `requestAudioFocus()` when the app has neither a
+ * visible activity nor a running foreground service — the framework logs
+ * `AudioHardening … level: partial … exemption: 0`, returns `AUDIOFOCUS_REQUEST_FAILED`, and
+ * ExoPlayer puts [Player.getPlayWhenReady] straight back to false. Nothing throws, so without this
+ * check the listener taps play and the app says nothing at all.
+ *
+ * We are the first app on a device to meet this: enforcement is gated on target SDK, so while we
+ * target 37 the rest of the phone is still in dry-run and logs "would be ignored".
+ *
+ * [wasPlaying] is what separates the two cases that share
+ * [Player.PLAY_WHEN_READY_CHANGE_REASON_AUDIO_FOCUS_LOSS]. Audio that was already sounding and then
+ * stopped is an interruption — a phone call — which resolves itself and must stay silent. Audio
+ * that never started is a refusal the listener is stuck behind, and needs a way out.
+ */
+internal fun isPlaybackRefused(
+    playWhenReady: Boolean,
+    reason: Int,
+    wasPlaying: Boolean,
+): Boolean =
+    !playWhenReady &&
+        reason == Player.PLAY_WHEN_READY_CHANGE_REASON_AUDIO_FOCUS_LOSS &&
+        !wasPlaying

--- a/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackRefusalNotifier.kt
+++ b/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackRefusalNotifier.kt
@@ -1,0 +1,90 @@
+package com.calypsan.listenup.client.playback
+
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import androidx.core.app.NotificationCompat
+import com.calypsan.listenup.api.error.PlaybackError
+import com.calypsan.listenup.client.notifications.NotificationChannels
+import io.github.oshai.kotlinlogging.KotlinLogging
+
+private val logger = KotlinLogging.logger {}
+
+private const val RES_TYPE_DRAWABLE = "drawable"
+
+/**
+ * Notification id for the refusal notice.
+ *
+ * Distinct from [AudiobookNotificationProvider.NOTIFICATION_ID] (1) so posting this can never
+ * replace or be replaced by the media notification — the two can legitimately coexist, and the
+ * media one is what the listener taps to try again.
+ */
+internal const val REFUSAL_NOTIFICATION_ID = 2
+
+/**
+ * Offers a way out when the platform refuses to start playback in the background.
+ *
+ * Android 17 refuses the audio-focus request outright when the app has no visible activity and no
+ * foreground service, and refuses the foreground-service start that would have made it eligible.
+ * Nothing throws, nothing sounds, and the lock-screen play button simply does nothing. We cannot
+ * force playback — but we can stop the dead end from being silent, and name the one action that
+ * does work: bring the app to the foreground, which makes the app eligible again.
+ *
+ * This is the Never Stranded principle applied to a refusal we don't control.
+ */
+internal class PlaybackRefusalNotifier(
+    private val context: Context,
+) {
+    private val notificationManager: NotificationManager?
+        get() = context.getSystemService(NotificationManager::class.java)
+
+    /**
+     * Posts the "open the app to resume" notice.
+     *
+     * Takes its copy from [error] so the wording lives with the typed error rather than being
+     * duplicated here. Silently does nothing when the listener has denied notifications — a
+     * degraded path, not a crash.
+     */
+    fun notifyRefused(error: PlaybackError) {
+        val manager = notificationManager ?: return
+        val launchIntent =
+            context.packageManager?.getLaunchIntentForPackage(context.packageName) ?: run {
+                logger.warn { "No launch intent; cannot offer a way back into the app" }
+                return
+            }
+
+        val contentIntent =
+            PendingIntent.getActivity(
+                context,
+                0,
+                launchIntent,
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+            )
+
+        val icon =
+            context.resources
+                .getIdentifier("ic_notification", RES_TYPE_DRAWABLE, context.packageName)
+                .takeIf { it != 0 }
+                ?: android.R.drawable.ic_media_play
+
+        val notification =
+            NotificationCompat
+                .Builder(context, NotificationChannels.PLAYBACK)
+                .setSmallIcon(icon)
+                .setContentTitle("Couldn't start playback")
+                .setContentText(error.message)
+                .setStyle(NotificationCompat.BigTextStyle().bigText(error.message))
+                .setContentIntent(contentIntent)
+                .setAutoCancel(true)
+                .setOnlyAlertOnce(true)
+                .build()
+
+        manager.notify(REFUSAL_NOTIFICATION_ID, notification)
+        logger.info { "Posted playback-refusal notice (${error.code})" }
+    }
+
+    /** Clears the notice — playback is going, so the dead end is behind us. */
+    fun clearRefusal() {
+        notificationManager?.cancel(REFUSAL_NOTIFICATION_ID)
+    }
+}

--- a/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
+++ b/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
@@ -109,6 +109,9 @@ class PlaybackService : MediaLibraryService() {
      */
     private var wasPlaying = false
 
+    /** Offers a way back in when the platform refuses a background start. */
+    private val refusalNotifier by lazy { PlaybackRefusalNotifier(this) }
+
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
     private var idleJob: Job? = null
     private var positionUpdateJob: Job? = null
@@ -742,11 +745,15 @@ class PlaybackService : MediaLibraryService() {
                     "Playback refused: audio focus denied while backgrounded. " +
                         "Check `adb shell dumpsys audio` for the AudioHardening entry."
                 }
-                errorBus.emit(
+                val refusal =
                     PlaybackError.BlockedInBackground(
                         debugInfo = "playWhenReady=false reason=AUDIO_FOCUS_LOSS before playback started",
-                    ),
-                )
+                    )
+                // The bus reaches the UI only when the app is already open — which is precisely
+                // when this can't happen. The notification is the path that actually reaches a
+                // listener staring at a lock-screen button that did nothing.
+                errorBus.emit(refusal)
+                refusalNotifier.notifyRefused(refusal)
             }
         }
 
@@ -759,6 +766,9 @@ class PlaybackService : MediaLibraryService() {
             val player = player
 
             if (isPlaying) {
+                // Audio is sounding, so any refusal notice is stale — clear it rather than leave
+                // the listener with a notification telling them to fix something already fixed.
+                refusalNotifier.clearRefusal()
                 cancelIdleTimer()
                 startPositionUpdates()
 

--- a/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
+++ b/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
@@ -65,14 +65,11 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import okhttp3.OkHttpClient
 import org.koin.android.ext.android.inject
 import com.calypsan.listenup.client.core.DurationFormatter
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
-import kotlin.time.Duration.Companion.seconds
-import kotlin.time.toJavaDuration
 
 private val logger = KotlinLogging.logger {}
 
@@ -227,16 +224,13 @@ class PlaybackService : MediaLibraryService() {
     }
 
     private fun initializePlayer() {
-        // Create OkHttp client with auth interceptor
+        // Create OkHttp client with auth interceptor. Timeouts — and why they are all
+        // finite — live in StallRecovery.kt.
         val okHttpClient =
-            OkHttpClient
-                .Builder()
-                .addInterceptor(tokenProvider.createInterceptor())
-                .authenticator(tokenProvider.createAuthenticator())
-                .connectTimeout(30.seconds.toJavaDuration())
-                .readTimeout(0.seconds.toJavaDuration()) // No read timeout for streaming
-                .writeTimeout(30.seconds.toJavaDuration())
-                .build()
+            buildStreamingHttpClient(
+                authInterceptor = tokenProvider.createInterceptor(),
+                tokenAuthenticator = tokenProvider.createAuthenticator(),
+            )
 
         // Create DataSource factory: OkHttp for HTTP(S) streaming, DefaultDataSource
         // wrapper to also handle file:// URIs for downloaded audiobooks
@@ -275,6 +269,9 @@ class PlaybackService : MediaLibraryService() {
                 // skip by the same amount the in-app buttons do.
                 .setSeekBackIncrementMs(SEEK_BACK_INCREMENT_MS)
                 .setSeekForwardIncrementMs(SEEK_FORWARD_INCREMENT_MS)
+                // Backstop for a stall the socket-read timeout can't see — see StallRecovery.kt.
+                // Media3's own default is ten minutes, which strands the listener.
+                .setStuckBufferingDetectionTimeoutMs(STUCK_BUFFERING_TIMEOUT_MS)
                 .build()
                 .apply {
                     addListener(PlayerListener())
@@ -695,6 +692,12 @@ class PlaybackService : MediaLibraryService() {
                     else -> "UNKNOWN"
                 }
             logger.debug { "Playback state: $stateName" }
+
+            // Reaching READY means whatever we last recovered from is behind us — refill the
+            // recovery budget so it is spent per incident, not per listening session.
+            if (playbackState == Player.STATE_READY) {
+                errorHandler.onPlaybackHealthy()
+            }
 
             when (playbackState) {
                 Player.STATE_ENDED -> {

--- a/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
+++ b/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
@@ -101,6 +101,14 @@ class PlaybackService : MediaLibraryService() {
     // idle timer learns to stand down while casting (see startIdleTimer).
     private var casting = false
 
+    /**
+     * Whether audio was actually sounding when the last transport change arrived.
+     *
+     * Read by [isPlaybackRefused] to separate a refused start from an ordinary interruption —
+     * Media3 reports both with `PLAY_WHEN_READY_CHANGE_REASON_AUDIO_FOCUS_LOSS`.
+     */
+    private var wasPlaying = false
+
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
     private var idleJob: Job? = null
     private var positionUpdateJob: Job? = null
@@ -721,8 +729,31 @@ class PlaybackService : MediaLibraryService() {
             }
         }
 
+        /**
+         * Detects a play request the platform refused outright, as opposed to one interrupted
+         * partway. See [isPlaybackRefused] for why the two need telling apart.
+         */
+        override fun onPlayWhenReadyChanged(
+            playWhenReady: Boolean,
+            reason: Int,
+        ) {
+            if (isPlaybackRefused(playWhenReady, reason, wasPlaying)) {
+                logger.warn {
+                    "Playback refused: audio focus denied while backgrounded. " +
+                        "Check `adb shell dumpsys audio` for the AudioHardening entry."
+                }
+                errorBus.emit(
+                    PlaybackError.BlockedInBackground(
+                        debugInfo = "playWhenReady=false reason=AUDIO_FOCUS_LOSS before playback started",
+                    ),
+                )
+            }
+        }
+
         override fun onIsPlayingChanged(isPlaying: Boolean) {
             logger.debug { "Is playing: $isPlaying" }
+
+            wasPlaying = isPlaying
 
             val bookId = currentBookId
             val player = player

--- a/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/StallRecovery.kt
+++ b/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/StallRecovery.kt
@@ -1,0 +1,82 @@
+package com.calypsan.listenup.client.playback
+
+import androidx.media3.common.Player
+import okhttp3.Authenticator
+import okhttp3.Interceptor
+import okhttp3.OkHttpClient
+import java.util.concurrent.TimeUnit
+
+/*
+ * The bounds that keep a stalled stream from stranding a listener mid-book.
+ *
+ * A stream can stop delivering bytes without ever failing — a Wi-Fi→cellular handover leaves a
+ * half-open socket that accepts a read and never answers it. Nothing in that story throws. Unless
+ * something imposes a deadline, OkHttp blocks forever, ExoPlayer stays in STATE_BUFFERING, no
+ * PlaybackException is raised, and PlaybackErrorHandler's network-retry path — correct, tested,
+ * and entirely unreachable — never runs. The listener sees a spinner until they force-quit.
+ *
+ * So there are deadlines at three layers, each catching what the one before it cannot:
+ *
+ * 1. STREAM_READ_TIMEOUT_MS bounds a single socket read. This is the one that catches the case
+ *    above, and it is where recovery is cheapest: OkHttp raises an IOException, ExoPlayer maps it
+ *    to ERROR_CODE_IO_NETWORK_CONNECTION_TIMEOUT, and the retry path takes over — usually before
+ *    the buffer drains, so the listener hears nothing at all.
+ * 2. STUCK_BUFFERING_TIMEOUT_MS is the backstop for a stall that isn't a socket read.
+ * 3. needsPrepareBeforePlay keeps the manual fallback working once automatic recovery gives up.
+ */
+
+/** Bounds establishing a connection to the audio source. */
+internal const val STREAM_CONNECT_TIMEOUT_MS = 30_000
+
+/**
+ * Bounds a single socket read, so a half-open connection surfaces as a retryable error.
+ *
+ * This does not fight ExoPlayer's backpressure. Once the buffer is full ExoPlayer stops calling
+ * `read()` altogether and the socket sits idle without any read in flight; the timeout only bounds
+ * a read already underway, and each new read starts a fresh window.
+ */
+internal const val STREAM_READ_TIMEOUT_MS = 30_000
+
+/** Bounds writing a request. Audio streaming requests are small, so this is a formality. */
+internal const val STREAM_WRITE_TIMEOUT_MS = 30_000
+
+/**
+ * How long the player may sit buffering before Media3 declares it stuck.
+ *
+ * Media3's own default (`ExoPlayer.Builder.DEFAULT_STUCK_BUFFERING_DETECTION_TIMEOUT_MS`) is ten
+ * minutes, which is abandonment rather than a backstop. Two minutes is the floor set by layer 1:
+ * this must clear one full [STREAM_READ_TIMEOUT_MS] *plus* the retry-and-backoff window that
+ * follows it, or the backstop would fire while a legitimate retry is still in flight and convert a
+ * recoverable blip into a user-visible error.
+ */
+internal const val STUCK_BUFFERING_TIMEOUT_MS = 120_000
+
+/**
+ * Whether a play command must re-prepare the player before it will produce audio.
+ *
+ * `play()` on an idle player sets `playWhenReady` and returns — the player stays idle and nothing
+ * is heard. A player is left idle by exactly the situations this file exists for: a terminal
+ * playback error, or the stop/prepare cycle [PlaybackErrorHandler] runs when recovering. So the
+ * manual "tap play to try again" that the listener is offered when automatic recovery gives up
+ * would itself do nothing without this check — the fallback behind the fallback.
+ */
+internal fun needsPrepareBeforePlay(playbackState: Int): Boolean = playbackState == Player.STATE_IDLE
+
+/**
+ * Builds the OkHttp client Media3 streams audio through, with every socket timeout bounded.
+ *
+ * [authInterceptor] stamps the bearer token onto each request; [tokenAuthenticator] refreshes it
+ * and re-issues on 401. Both come from [AndroidAudioTokenProvider].
+ */
+internal fun buildStreamingHttpClient(
+    authInterceptor: Interceptor,
+    tokenAuthenticator: Authenticator,
+): OkHttpClient =
+    OkHttpClient
+        .Builder()
+        .addInterceptor(authInterceptor)
+        .authenticator(tokenAuthenticator)
+        .connectTimeout(STREAM_CONNECT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS)
+        .readTimeout(STREAM_READ_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS)
+        .writeTimeout(STREAM_WRITE_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS)
+        .build()

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/error/CorrelationStamping.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/error/CorrelationStamping.kt
@@ -185,6 +185,7 @@ private fun AudioMetadataError.withCorrelationId(id: String?): AudioMetadataErro
 private fun PlaybackError.withCorrelationId(id: String?): PlaybackError =
     when (this) {
         is PlaybackError.Stalled -> copy(correlationId = id)
+        is PlaybackError.BlockedInBackground -> copy(correlationId = id)
     }
 
 private fun MetadataError.withCorrelationId(id: String?): MetadataError =

--- a/contract/src/commonMain/kotlin/com/calypsan/listenup/api/error/PlaybackError.kt
+++ b/contract/src/commonMain/kotlin/com/calypsan/listenup/api/error/PlaybackError.kt
@@ -18,11 +18,11 @@ import kotlinx.serialization.Serializable
 sealed interface PlaybackError : AppError {
     /**
      * Media3 detected the player stuck in `STATE_BUFFERING` past the watchdog threshold
-     * (default 10 minutes in Media3 1.9.0+).
+     * (`STUCK_BUFFERING_TIMEOUT_MS`, which the client sets well below Media3's ten-minute default).
      *
      * Surfaces via Media3's `PlaybackException.ERROR_CODE_TIMEOUT`.
-     * Recovery: the error handler re-prepares the player automatically; the
-     * accompanying snackbar lets the user retry manually if playback does not resume.
+     * Recovery: the error handler re-prepares the player automatically, within a bounded retry
+     * budget; the accompanying snackbar lets the user retry manually once that budget is spent.
      */
     @Serializable
     @SerialName("PlaybackError.Stalled")
@@ -33,5 +33,28 @@ sealed interface PlaybackError : AppError {
         override val message: String = "Playback stalled. Tap to retry."
         override val code: String = "PLAYBACK_STALLED"
         override val isRetryable: Boolean = true
+    }
+
+    /**
+     * The platform refused to let playback start because the app was in the background.
+     *
+     * Android 17's background audio hardening denies an audio-focus request outright when the app
+     * has neither a visible activity nor a running foreground service, and denies the foreground
+     * service start that would have made it eligible — a deadlock a background surface cannot
+     * break out of on its own. Nothing throws; without this value the refusal is silent.
+     *
+     * Not retryable in the middleware sense: re-firing the same request from the same background
+     * state is refused identically. It clears when the listener brings the app to the foreground,
+     * which is what the message asks for.
+     */
+    @Serializable
+    @SerialName("PlaybackError.BlockedInBackground")
+    data class BlockedInBackground(
+        override val correlationId: String? = null,
+        override val debugInfo: String? = null,
+    ) : PlaybackError {
+        override val message: String = "Playback can't start in the background. Open ListenUp to resume."
+        override val code: String = "PLAYBACK_BLOCKED_IN_BACKGROUND"
+        override val isRetryable: Boolean = false
     }
 }


### PR DESCRIPTION
Playback stopped mid-book on a walk and showed "buffering" indefinitely. Swiping the app away didn't clear it; a force-stop cleared the session but then nothing would play. Diagnosed from Android's own subsystems — the app itself emitted nothing.

## The stall

`PlaybackService` built the streaming OkHttp client with `readTimeout(0)` — infinite (dated 2025-12-20; not a regression). A half-open socket, which is what a Wi-Fi→cellular handover mid-walk produces, blocks `read()` forever. ExoPlayer stays in `STATE_BUFFERING` and **never raises a `PlaybackException`**, so `PlaybackErrorHandler` never runs. Silence, not failure, was the bug.

Fixing that alone would have made things worse, because of two more defects in the path it opens:

**`ClassifiedError.Network` was a no-op that believed it had delegated.** It logged "ExoPlayer handles retry internally" and returned `true`. But ExoPlayer's load-error retries are already spent by the time `onPlayerError` fires — the player is IDLE and nothing is buffering. So the fix alone would have traded "spinner forever" for "silently dead forever", and because it returned `handled = true` the caller didn't even start the idle timer.

**`AndroidPlaybackController.play()` never re-prepared.** `play()` on an idle player sets `playWhenReady` and returns. After any terminal error — or after the `Stuck` branch's `stop()` — tapping play did nothing. The manual fallback behind the automatic one was also broken.

## Changes

- **`StallRecovery.kt`** (new) — the three deadlines, each catching what the previous one can't: a finite socket read timeout, `setStuckBufferingDetectionTimeoutMs(120_000)` (Media3 1.10.1's default is **600_000** — verified against the AAR, not the code comment), and `needsPrepareBeforePlay`.
- **`PlaybackErrorHandler`** — `Network` re-prepares and resumes. It and `Stuck` share one 5-attempt budget with capped exponential backoff (1/2/4/8/16s ≈ 31s), refilled by `onPlaybackHealthy()`. On exhaustion the listener gets a message pointing at the manual retry.
- **`AndroidPlaybackController.play()`** — prepares first when the player is idle.
- **`PlaybackService`** — wires the budget reset on `STATE_READY`.

## Deliberate choices worth reviewing

**Reset-on-`STATE_READY` means a flapping connection retries indefinitely** rather than giving up after five attempts. For an audiobook on a walk, auto-resuming past every dead spot beats demanding a manual tap. The budget still bites in the case that caused this report, where recovery never gets audio back.

**Backoff is sized against the retry window, not the read timeout.** The stuck backstop has to clear one full read timeout *plus* ExoPlayer's own retry/backoff, or it fires while a legitimate retry is in flight and turns a recoverable blip into a visible error. That is why it's 2 minutes and not 45s.

## Tests

`StallRecoveryTest` (7, Kotest) and four new cases in `PlaybackErrorHandlerTest`. sharedUI `androidHostTest` lane: 311 tests, 0 failures. `verifyLocal` + `assembleDebug` green.

## Known deviations and follow-ups

- The new recovery tests went into `PlaybackErrorHandlerTest` in its existing JUnit4/Robolectric style rather than Kotest. Canon says new tests are Kotest and files migrate when touched, but that file's fakes are a chain of five file-private classes (`FakeExoPlayer` alone is ~400 lines of stubs), so migrating meant either reworking ~40 assertions inside a bugfix or duplicating the fakes. Flagging rather than diverging quietly; the migration folds naturally into the `PlaybackService` split below.
- **`PlaybackService.kt` is 1611 lines** against a ~300-line guideline. Real problem, deliberately not addressed here — splitting it would bury this fix in an unreviewable diff.
- **`AuthExpired` has no retry budget.** If a token refresh keeps succeeding while the server keeps 401ing, it loops unbounded. Pre-existing, out of scope.
- The background-refusal half surfaces the failure but cannot make background playback succeed — when Android refuses, it cannot be forced. A notification offering "Open ListenUp to resume" is the piece that turns a dead lock-screen button into a route through; `PlaybackError.BlockedInBackground` exists to hang it off. Not yet written.

---

# Second commit: background audio hardening

The same incident left the app unable to start playback at all until it was brought to the foreground. Android 17's background audio hardening refuses `requestAudioFocus()` when the app has neither a visible activity nor a running foreground service:

```
AudioHardening focus request for req 1 ignored for com.calypsan.listenup.client,
  level: partial  usage: 1  exemption: 0
```

Per [the Android 17 docs](https://developer.android.com/about/versions/17/changes/bg-audio), **`level: partial` means "not running a foreground service at all"**, and `exemption: 0` means no visible activity either. `dumpsys` corroborates with `startForegroundCount=0`. The foreground service that would have made us eligible was itself denied (`BFGS denied: true`, `tempAllowListReason:<null>`), so neither end of the deadlock could break it.

We are the only app on the device actually *enforced* against — every other app logs "**would be** ignored" (dry run), because enforcement is gated on target SDK and we target 37 while the rest of the phone targets ≤36. Expect this class of change to find us first.

**Changes:** `isPlaybackRefused` (pure, 6 test cases) separates a refused start from an ordinary interruption — both arrive as `PLAY_WHEN_READY_CHANGE_REASON_AUDIO_FOCUS_LOSS`, so conflating them means either silence when the listener is stuck or a spurious error on every incoming phone call. `wasPlaying` is the discriminator. `PlaybackError.BlockedInBackground` types it; `PlaybackService` logs it loudly and names the `dumpsys` command.

Adding the contract variant broke `CorrelationStamping` at compile time and the compiler walked to the missing branch — the integration boundary working as designed.

**Verification hook:** `adb shell cmd audio set-enable-hardening enable|disable|throw` reproduces this deterministically on an emulator. Not yet exercised — see below.
