### PR TITLE
🐛 fix(sharedUI): initialize WorkManager before Koin starts

### DIFF
--- a/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
+++ b/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/ListenUp.kt
@@ -278,26 +278,17 @@ class ListenUp :
         // Idempotent — safe to call on every startup.
         NotificationChannels.registerAll(this)
 
-        // Initialize Koin dependency injection
-        startKoin {
-            // INFO, not DEBUG: Koin's DEBUG level logs every dependency resolution, which floods
-            // logcat during sync (e.g. per-event SyncCursorStore lookups across a 1000-book scan).
-            androidLogger(Level.INFO)
-
-            // Provide Android Context to Koin
-            androidContext(this@ListenUp)
-
-            // Load all shared and Android-specific modules
-            modules(
-                androidSharedModules() + androidModule + playbackModule + androidPlaybackModule +
-                    androidPlaybackPresentationModule() + androidDownloadModule + downloadModule,
-            )
-        }
-
-        // Configure WorkManager with custom factory for dependency injection.
-        // Dependencies are wrapped in lazy { get() } so constructing the factory does not
-        // resolve DownloadRepository → DownloadEnqueuer → WorkManager.getInstance() before
-        // WorkManager.initialize() is called below.
+        // WorkManager must be initialized BEFORE startKoin, not after.
+        //
+        // The default WorkManagerInitializer is removed from the manifest so we can supply a
+        // custom worker factory, which makes this call the only thing that initializes WorkManager
+        // — and startKoin eagerly creates every `createdAtStart = true` single. One of those
+        // (PlaybackControllerActivator) transitively resolves
+        // DownloadRepository → DownloadEnqueuer → WorkManager.getInstance(), so initializing
+        // afterwards crashed the app on launch with "WorkManager is not initialized properly".
+        //
+        // The factory's own dependencies stay wrapped in `lazy { get() }`: they are resolved when
+        // a Worker is first constructed, long after startKoin below has run.
         val workerFactory =
             ListenUpWorkerFactory(
                 downloadRepository = lazy { get() },
@@ -313,6 +304,22 @@ class ListenUp :
                 .build()
 
         WorkManager.initialize(this, workManagerConfig)
+
+        // Initialize Koin dependency injection
+        startKoin {
+            // INFO, not DEBUG: Koin's DEBUG level logs every dependency resolution, which floods
+            // logcat during sync (e.g. per-event SyncCursorStore lookups across a 1000-book scan).
+            androidLogger(Level.INFO)
+
+            // Provide Android Context to Koin
+            androidContext(this@ListenUp)
+
+            // Load all shared and Android-specific modules
+            modules(
+                androidSharedModules() + androidModule + playbackModule + androidPlaybackModule +
+                    androidPlaybackPresentationModule() + androidDownloadModule + downloadModule,
+            )
+        }
 
         // Verify critical Koin bindings off the first-frame path.
         // Launching on Default keeps DI resolution (including Media3 session init and


### PR DESCRIPTION
**Release blocker.** `main` currently crashes on launch, deterministically, on every device.

## What happens

```
java.lang.RuntimeException: Unable to create application com.calypsan.listenup.client.ListenUp
Caused by: org.koin.core.error.InstanceCreationException: PlaybackControllerActivator
Caused by: ... PlaybackController → MediaControllerHolder → PlaybackStateWriter
         → PlaybackManager → ProgressTracker → DownloadRepository → AndroidDownloadEnqueuer
Caused by: java.lang.IllegalStateException: WorkManager is not initialized properly.
    at DownloadModule_androidKt.androidDownloadModule$lambda$0$2(DownloadModule.android.kt:48)
```

The default `WorkManagerInitializer` is removed from the manifest so we can supply a custom worker factory, which makes `WorkManager.initialize()` in `ListenUp.onCreate` the only thing that initializes it. That call sat *after* `startKoin`.

`startKoin` eagerly instantiates every `createdAtStart = true` single. #1234 added `PlaybackControllerActivator` as one, and it transitively resolves `DownloadEnqueuer`, whose provider calls `WorkManager.getInstance()`. So the graph reached WorkManager before WorkManager existed.

## Why it wasn't caught

- **Not in v0.8.3.** `PlaybackControllerActivator` arrived with #1234 on 2026-08-01, after the release tag. Devices on 0.8.3 are unaffected; anything cut from `main` since is not.
- The Koin graph tests verify module *definitions*, not `Application.onCreate` ordering against WorkManager — no JVM test exercises that sequence.
- App builds are post-merge only and don't launch the app.

Found by installing a debug build on an API 37 emulator while verifying #1247.

## The fix

Move `WorkManager.initialize()` above `startKoin`.

The hazard was already known — the worker factory's dependencies are wrapped in `lazy { get() }` with a comment about not resolving `DownloadEnqueuer` too early. What defeated that is that an eager single declared in a *module* bypasses the ordering in `onCreate` entirely. Initializing first removes the ordering dependency rather than restating it: no matter what any module declares `createdAtStart`, WorkManager is ready.

The factory's own dependencies stay lazy — they resolve when a Worker is first constructed, long after `startKoin`.

## Verification

- **Before:** `FATAL EXCEPTION: main`, process dead on launch.
- **After:** boots to onboarding, process alive, zero crashes.

Emulator: API 37 / Android 17, `sdk_gphone16k_x86_64`, clean install. `verifyLocal` green.

## Follow-up worth considering

No automated test covers this. A Robolectric test that boots the real `Application` would catch the whole class of startup-ordering bugs, but it drags in the full Koin graph, Room and Media3, so it needs care to not be flaky. Filing rather than bolting onto a release blocker.

A structural alternative: have `AndroidDownloadEnqueuer` take its `WorkManager` lazily, so no DI resolution can touch it at graph-construction time regardless of ordering.
