### PR TITLE
✅ test(sharedUI): backfill the tests blocking 0.8.4, and extend Kover to the client modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,13 +212,19 @@ jobs:
             echo 'No E2E auto-retries recorded (probe retries excluded).'
           fi
 
-      # Coverage signal (non-gating): Kover is applied on the JVM-pure modules only
-      # (:server, :tools:rpc-guard-ksp) — the androidKmpLibrary modules are unsupported
-      # upstream. The XML artifact enables future diff-coverage tooling; there is
-      # deliberately NO threshold/verify gate here.
+      # Coverage signal (non-gating): every module Kover can measure — the JVM-pure ones
+      # (:server, :tools:rpc-guard-ksp) plus the androidKmpLibrary ones (:contract,
+      # :app:sharedLogic, :app:sharedUI), which were long assumed unsupported upstream and
+      # verified working on 2026-08-04. Client code being unmeasured is how four launch
+      # bugs reached main on 2026-08-04 with no coverage signal at all.
+      # The XML artifacts enable diff-coverage tooling; there is deliberately NO
+      # threshold/verify gate here — this measures, it does not block.
       - name: Generate coverage reports (Kover, non-gating)
         continue-on-error: true
-        run: ./gradlew :server:koverXmlReport :tools:rpc-guard-ksp:koverXmlReport --no-daemon
+        run: >-
+          ./gradlew :server:koverXmlReport :tools:rpc-guard-ksp:koverXmlReport
+          :contract:koverXmlReport :app:sharedLogic:koverXmlReport :app:sharedUI:koverXmlReport
+          --no-daemon
 
       - name: Upload coverage reports
         uses: actions/upload-artifact@v7
@@ -228,6 +234,9 @@ jobs:
           path: |
             server/build/reports/kover/report.xml
             tools/rpc-guard-ksp/build/reports/kover/report.xml
+            contract/build/reports/kover/report.xml
+            app/sharedLogic/build/reports/kover/report.xml
+            app/sharedUI/build/reports/kover/report.xml
           retention-days: 7
           if-no-files-found: ignore
 

--- a/app/sharedLogic/build.gradle.kts
+++ b/app/sharedLogic/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     alias(libs.plugins.ksp)
     alias(libs.plugins.androidx.room)
     alias(libs.plugins.mokkery)
+    alias(libs.plugins.kover)
 }
 
 kotlin {

--- a/app/sharedUI/build.gradle.kts
+++ b/app/sharedUI/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     alias(libs.plugins.kotlinSerialization)
     alias(libs.plugins.mokkery)
     alias(libs.plugins.aboutlibraries)
+    alias(libs.plugins.kover)
 }
 
 // Mokkery is used in desktopTest and androidHostTest — see

--- a/app/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/ApplicationBootTest.kt
+++ b/app/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/ApplicationBootTest.kt
@@ -1,0 +1,82 @@
+package com.calypsan.listenup.client
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.WorkManager
+import io.kotest.matchers.shouldNotBe
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.koin.core.context.GlobalContext
+import org.koin.core.context.stopKoin
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Boots the real [ListenUp] `Application` and asserts `onCreate()` completes.
+ *
+ * ## Why this test exists
+ *
+ * The launch crash fixed in #1248 shipped through four green CI gates and human
+ * review. `startKoin` eagerly builds every `createdAtStart = true` single, one of
+ * which (`PlaybackControllerActivator`) transitively resolved
+ * `DownloadRepository` → `DownloadEnqueuer` → `WorkManager.getInstance()`. With
+ * `WorkManager.initialize()` still below the `startKoin` call, that threw on every
+ * device, every launch. Nothing caught it because nothing booted the Application.
+ *
+ * The existing graph test (`ClientKoinGraphE2ETest`, `:app:sharedLogic:jvmTest`)
+ * could not have: it loads `sharedModules` only — the Android platform modules
+ * where `DownloadEnqueuer` lives are absent by construction — and it deliberately
+ * swallows every non-cycle `Exception` while sweeping the singleton graph. This
+ * test closes both halves of that gap: the real Android module list, in the real
+ * `onCreate()` order, with nothing swallowed.
+ *
+ * ## How the assertion works
+ *
+ * Robolectric instantiates the `@Config(application = …)` class and runs
+ * `onCreate()` during test-environment setup, before the `@Test` body. A throw
+ * there fails the test during setup — so the boot *is* the assertion, and the
+ * body only confirms both subsystems came up live.
+ *
+ * The production manifest names `ListenUp`, but `androidHostTest`'s manifest
+ * replaces it with the empty `android.app.Application` so unrelated host tests
+ * stay isolated. `@Config` opts this one class back in.
+ *
+ * ## Why exactly one test method
+ *
+ * Robolectric builds a fresh Application per test method, but `WorkManager`'s
+ * delegate is a JVM static that outlives it — so a second method's `onCreate()`
+ * dies on "WorkManager is already initialized", an artifact of the harness rather
+ * than a defect in the code under test. Resetting it means reaching for
+ * `WorkManagerImpl.setDelegate`, which is `@RestrictTo(LIBRARY_GROUP)`. One boot,
+ * both assertions, no restricted API.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(application = ListenUp::class)
+class ApplicationBootTest {
+    /**
+     * `onCreate()` called `startKoin`, which registers a process-global context.
+     * A leaked global Koin poisons every test that runs after this class in the
+     * same JVM, so tear it down whether the body passed or failed.
+     */
+    @After
+    fun tearDown() {
+        stopKoin()
+    }
+
+    @Test
+    fun `the application boots with WorkManager live before the Koin graph`() {
+        // Reaching this line already means onCreate() ran to completion: notification
+        // channels registered, WorkManager initialized, and the full Android Koin
+        // graph built — every createdAtStart single constructed, nothing swallowed.
+        // Under the pre-#1248 ordering Robolectric fails this test during setup with
+        // "WorkManager is not initialized properly".
+        val app = ApplicationProvider.getApplicationContext<ListenUp>()
+
+        // State the ordering invariant directly rather than inferring it from the
+        // absence of a crash: both subsystems are live after onCreate(), and #1248
+        // proved the eager-singleton path from Koin into WorkManager.getInstance()
+        // is genuinely reachable.
+        WorkManager.getInstance(app) shouldNotBe null
+        GlobalContext.getOrNull() shouldNotBe null
+    }
+}

--- a/app/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/ListenUpSessionCallbackTest.kt
+++ b/app/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/ListenUpSessionCallbackTest.kt
@@ -1,0 +1,294 @@
+package com.calypsan.listenup.client.playback
+
+import android.os.Bundle
+import androidx.media3.common.Player
+import androidx.media3.session.MediaSession
+import androidx.media3.session.SessionCommand
+import androidx.media3.session.SessionResult
+import androidx.test.core.app.ApplicationProvider
+import com.calypsan.listenup.client.automotive.BrowseTreeProvider
+import com.calypsan.listenup.client.domain.model.Chapter
+import com.calypsan.listenup.client.domain.playback.PlaybackTimeline
+import com.calypsan.listenup.client.domain.repository.AuthSession
+import com.calypsan.listenup.client.domain.repository.BookRepository
+import com.calypsan.listenup.client.domain.repository.ContributorRepository
+import com.calypsan.listenup.client.domain.repository.DownloadRepository
+import com.calypsan.listenup.client.domain.repository.HomeRepository
+import com.calypsan.listenup.client.domain.repository.ImageStorage
+import com.calypsan.listenup.client.domain.repository.PlaybackPositionRepository
+import com.calypsan.listenup.client.domain.repository.SearchRepository
+import com.calypsan.listenup.client.domain.repository.SeriesRepository
+import com.calypsan.listenup.client.voice.VoiceIntentResolver
+import com.calypsan.listenup.core.BookId
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.mock
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Pins the transport-command behaviour of [ListenUpSessionCallback], extracted from
+ * `PlaybackService` in #1249 as a pure move with no tests of its own.
+ *
+ * ## What is actually at risk here
+ *
+ * Every seek in `onCustomCommand` crosses between two coordinate spaces:
+ *
+ * - **book-relative** — a position in the whole audiobook, which is what
+ *   [PlaybackTransport.bookRelativePositionMs] reports and what
+ *   [PlaybackTimeline.resolve] consumes.
+ * - **file-relative** — a position within the current media item, which is what
+ *   `Player.currentPosition` reports and what the single-argument `seekTo` consumes.
+ *
+ * Confusing the two is the #1241 bug class: the numbers stay plausible, nothing throws,
+ * and playback simply lands somewhere wrong. So these tests deliberately keep the fake's
+ * book position and file position far apart — a test where both are 5_000 would pass on
+ * exactly the defect it exists to catch.
+ *
+ * The `timeline == null` branch is the sharpest edge: it is the *only* path that legitimately
+ * seeks file-relatively, so it is asserted through [FakeExoPlayer.fileRelativeSeekCalls]
+ * rather than [FakeExoPlayer.seekCalls], and each case checks that the *other* list stayed
+ * empty.
+ */
+@RunWith(RobolectricTestRunner::class)
+class ListenUpSessionCallbackTest {
+    // ── Skip back ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun `skip back 30 resolves the book-relative target through the timeline`() {
+        val player = FakeExoPlayer()
+        val callback = callbackWith(player = player, bookPositionMs = 120_000L, timeline = threeFileTimeline())
+
+        callback.invokeCustomCommand(AudiobookNotificationProvider.COMMAND_SKIP_BACK_30)
+
+        // 120_000 − 30_000 = 90_000 book-relative, which lands 30_000 into the second
+        // 60_000 ms file. Both halves of the pair matter: an index-only or offset-only
+        // regression is still a wrong seek.
+        player.seekCalls shouldBe listOf(1 to 30_000L)
+        player.fileRelativeSeekCalls.shouldBeEmpty()
+    }
+
+    @Test
+    fun `skip back 30 clamps at the start of the book`() {
+        val player = FakeExoPlayer()
+        val callback = callbackWith(player = player, bookPositionMs = 10_000L, timeline = threeFileTimeline())
+
+        callback.invokeCustomCommand(AudiobookNotificationProvider.COMMAND_SKIP_BACK_30)
+
+        // 10_000 − 30_000 would be −20_000. Clamped to 0, which resolves to the very
+        // start of the first file rather than a negative offset ExoPlayer would reject.
+        player.seekCalls shouldBe listOf(0 to 0L)
+    }
+
+    // ── Skip forward ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `skip forward 30 clamps at the total duration of the book`() {
+        val player = FakeExoPlayer()
+        val callback = callbackWith(player = player, bookPositionMs = 170_000L, timeline = threeFileTimeline())
+
+        callback.invokeCustomCommand(AudiobookNotificationProvider.COMMAND_SKIP_FORWARD_30)
+
+        // 170_000 + 30_000 = 200_000, past the 180_000 ms end. Clamped to totalDurationMs,
+        // which resolve() maps to the end of the final file — never a fourth index.
+        //
+        // Scope note: this pins the observable outcome, not the clamp itself. resolve()
+        // independently maps any past-the-end position to the last file, so deleting
+        // `coerceAtMost(maxPosition)` would leave this green (verified by mutation). It does
+        // catch a *wrong* clamp — halving the bound fails here — which is the likelier defect.
+        player.seekCalls shouldBe listOf(2 to 60_000L)
+        player.fileRelativeSeekCalls.shouldBeEmpty()
+    }
+
+    // ── The timeline == null fallback ─────────────────────────────────────────
+
+    @Test
+    fun `skip back 30 without a timeline seeks FILE-relatively, not book-relatively`() {
+        // The fake reports a file position of 40_000 while sitting at 160_000 in the book.
+        // With no timeline there is nothing to translate between them, so the only correct
+        // answer is the file-relative one.
+        val player = FakeExoPlayer(stubbedPosition = 40_000L)
+        val callback = callbackWith(player = player, bookPositionMs = 160_000L, timeline = null)
+
+        callback.invokeCustomCommand(AudiobookNotificationProvider.COMMAND_SKIP_BACK_30)
+
+        // 40_000 − 30_000 = 10_000, file-relative. Had the fallback reached for the book
+        // position instead, this would be 130_000 — a seek far past the end of the file.
+        player.fileRelativeSeekCalls shouldBe listOf(10_000L)
+        player.seekCalls.shouldBeEmpty()
+    }
+
+    @Test
+    fun `skip forward 30 without a timeline clamps to the file duration`() {
+        val player = FakeExoPlayer(stubbedPosition = 40_000L, stubbedDuration = 50_000L)
+        val callback = callbackWith(player = player, bookPositionMs = 160_000L, timeline = null)
+
+        callback.invokeCustomCommand(AudiobookNotificationProvider.COMMAND_SKIP_FORWARD_30)
+
+        // 40_000 + 30_000 = 70_000, past the file's 50_000 ms end, so it clamps to the
+        // file duration — the file's end, not the book's.
+        player.fileRelativeSeekCalls shouldBe listOf(50_000L)
+        player.seekCalls.shouldBeEmpty()
+    }
+
+    // ── No transport player ───────────────────────────────────────────────────
+
+    @Test
+    fun `a custom command with no transport player errors instead of seeking`() {
+        val player = FakeExoPlayer()
+        // activeTransportPlayer() is null between a cast handoff and the receiver being
+        // ready — the callback must refuse rather than fall back to some other player.
+        val callback = callbackWith(player = null, bookPositionMs = 120_000L, timeline = threeFileTimeline())
+
+        val result = callback.invokeCustomCommand(AudiobookNotificationProvider.COMMAND_SKIP_BACK_30)
+
+        result.resultCode shouldBe SessionResult.RESULT_ERROR_UNKNOWN
+        player.seekCalls.shouldBeEmpty()
+        player.fileRelativeSeekCalls.shouldBeEmpty()
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /**
+     * Blocking, because `onCustomCommand` returns an already-completed immediate future.
+     *
+     * `onCustomCommand` reads neither `session` nor `controller`, but Kotlin emits a
+     * non-null intrinsic on both, so real instances are required: Media3 ships
+     * [MediaSession.ControllerInfo.createTestOnlyControllerInfo] for exactly this, and the
+     * session is built over [sessionPlayer] and released before returning.
+     */
+    private fun ListenUpSessionCallback.invokeCustomCommand(action: String): SessionResult {
+        val session = MediaSession.Builder(context, sessionPlayer).build()
+        try {
+            return onCustomCommand(
+                session,
+                MediaSession.ControllerInfo.createTestOnlyControllerInfo(
+                    "com.calypsan.listenup.test",
+                    // pid =
+                    0,
+                    // uid =
+                    0,
+                    // libraryVersion =
+                    0,
+                    // interfaceVersion =
+                    0,
+                    // trusted =
+                    true,
+                    Bundle.EMPTY,
+                    // isPackageNameVerified =
+                    true,
+                ),
+                SessionCommand(action, Bundle.EMPTY),
+                Bundle.EMPTY,
+            ).get()
+        } finally {
+            session.release()
+        }
+    }
+
+    private val context get() = ApplicationProvider.getApplicationContext<android.content.Context>()
+
+    /**
+     * The player the [MediaSession] is built over — deliberately a separate instance from the
+     * one under assertion, so a seek accidentally routed to the session player instead of the
+     * transport player shows up as a missing call rather than passing unnoticed.
+     */
+    private val sessionPlayer = FakeExoPlayer(canAdvertiseSession = true)
+
+    /**
+     * Three 60_000 ms files, so the book runs 0..180_000 ms and every file boundary is a
+     * round number — a wrong index or a wrong offset reads as an obvious wrong number
+     * rather than an arithmetic coincidence.
+     */
+    private fun threeFileTimeline(): PlaybackTimeline =
+        PlaybackTimeline(
+            bookId = BookId("book1"),
+            totalDurationMs = 180_000L,
+            files =
+                (0..2).map { index ->
+                    PlaybackTimeline.FileSegment(
+                        audioFileId = "af-$index",
+                        filename = "file$index.mp3",
+                        format = "mp3",
+                        startOffsetMs = index * 60_000L,
+                        durationMs = 60_000L,
+                        size = 1_000L,
+                        streamingUrl = "https://example.invalid/file$index.mp3",
+                        localPath = null,
+                        mediaItemIndex = index,
+                    )
+                },
+        )
+
+    /**
+     * Builds the callback with only the two dependencies `onCustomCommand` touches wired for
+     * real — the transport seam and [PlaybackManager]. The other seven are browse, search,
+     * voice and persistence collaborators that this path never reaches: those mokkery can
+     * mock are mocked with no stubbed answers, and the two final classes it cannot are
+     * [unreachable]. Either way a call fails loudly rather than quietly returning a default.
+     */
+    private fun callbackWith(
+        player: Player?,
+        bookPositionMs: Long,
+        timeline: PlaybackTimeline?,
+    ): ListenUpSessionCallback {
+        val playbackManager = mock<PlaybackManager>()
+        every { playbackManager.chapters } returns MutableStateFlow(emptyList<Chapter>())
+        every { playbackManager.currentTimeline } returns MutableStateFlow(timeline)
+
+        return ListenUpSessionCallback(
+            context = context,
+            playbackManager = playbackManager,
+            browseTreeProvider = unreachedBrowseTreeProvider(),
+            voiceIntentResolver = unreachedVoiceIntentResolver(),
+            homeRepository = mock<HomeRepository>(),
+            authSession = mock<AuthSession>(),
+            positionRepository = mock<PlaybackPositionRepository>(),
+            serviceScope = CoroutineScope(Dispatchers.Unconfined),
+            transport = FakePlaybackTransport(player, bookPositionMs),
+        )
+    }
+
+    /**
+     * `BrowseTreeProvider` and `VoiceIntentResolver` are final classes mokkery cannot mock,
+     * and Kotlin's non-null intrinsic rules out a placeholder — but both take nothing except
+     * repository interfaces, so a real instance over unstubbed mocks is cheap. Neither is
+     * reached by `onCustomCommand`; if that ever changes, the unstubbed mocks underneath fail
+     * loudly rather than quietly answering.
+     */
+    private fun unreachedBrowseTreeProvider(): BrowseTreeProvider =
+        BrowseTreeProvider(
+            homeRepository = mock<HomeRepository>(),
+            bookRepository = mock<BookRepository>(),
+            seriesRepository = mock<SeriesRepository>(),
+            contributorRepository = mock<ContributorRepository>(),
+            downloadRepository = mock<DownloadRepository>(),
+            imageStorage = mock<ImageStorage>(),
+        )
+
+    private fun unreachedVoiceIntentResolver(): VoiceIntentResolver =
+        VoiceIntentResolver(
+            searchRepository = mock<SearchRepository>(),
+            homeRepository = mock<HomeRepository>(),
+            seriesRepository = mock<SeriesRepository>(),
+            bookRepository = mock<BookRepository>(),
+        )
+}
+
+/** Records nothing: these tests assert on the player the transport hands out, not on the seam itself. */
+private class FakePlaybackTransport(
+    private val player: Player?,
+    private val bookPositionMs: Long,
+) : PlaybackTransport {
+    override fun activeTransportPlayer(): Player? = player
+
+    override fun bookRelativePositionMs(): Long = bookPositionMs
+
+    override fun applyResumeSpeed(speed: Float) = Unit
+}

--- a/app/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/PlaybackErrorHandlerTest.kt
+++ b/app/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/PlaybackErrorHandlerTest.kt
@@ -712,13 +712,22 @@ private object ThrowingDownloadRepository : DownloadRepository {
 // ── Stubs ─────────────────────────────────────────────────────────────────────
 
 /**
- * [ExoPlayer] stub that records the calls made by [PlaybackErrorHandler.handle].
+ * Hand-written [ExoPlayer] fake that records the calls made against it.
  * All other methods are no-ops or return sensible defaults.
+ *
+ * `internal` rather than file-private so [ListenUpSessionCallbackTest] can drive the
+ * session callback's transport seam against it too. Implementing ExoPlayer's full surface
+ * costs ~400 lines, so one fake serves both suites rather than each growing its own.
  */
 @OptIn(UnstableApi::class)
-private class FakeExoPlayer(
+internal class FakeExoPlayer(
     stubbedPosition: Long = 5_000L,
     stubbedMediaItemIndex: Int = 0,
+    private val stubbedDuration: Long = 0L,
+    // Opt-in, because MediaSession.Builder rejects a player that answers `false` here.
+    // Defaults to false to keep the fake honest about what it is — only a fake standing in
+    // as a session's player needs to claim otherwise.
+    private val canAdvertiseSession: Boolean = false,
 ) : ExoPlayer {
     private val _currentPosition = stubbedPosition
     private val _currentMediaItemIndex = stubbedMediaItemIndex
@@ -726,7 +735,17 @@ private class FakeExoPlayer(
     var playCount = 0
     var stopCount = 0
     var prepareCount = 0
+
+    /** `seekTo(mediaItemIndex, positionMs)` calls — the book-relative, timeline-resolved path. */
     val seekCalls = mutableListOf<Pair<Int, Long>>()
+
+    /**
+     * `seekTo(positionMs)` calls — the single-argument overload, which seeks
+     * FILE-relatively within the current item. Recorded separately from [seekCalls]
+     * because conflating the two coordinate spaces is the #1241 bug class: a test that
+     * could not tell them apart would pass on exactly the defect it exists to catch.
+     */
+    val fileRelativeSeekCalls = mutableListOf<Long>()
 
     // ── Methods called by PlaybackErrorHandler.handle ──────────────────────────
     override fun pause() {
@@ -835,7 +854,7 @@ private class FakeExoPlayer(
 
     override fun isCommandAvailable(command: Int): Boolean = false
 
-    override fun canAdvertiseSession(): Boolean = false
+    override fun canAdvertiseSession(): Boolean = canAdvertiseSession
 
     override fun getAvailableCommands(): Player.Commands = Player.Commands.EMPTY
 
@@ -865,7 +884,9 @@ private class FakeExoPlayer(
 
     override fun seekToDefaultPosition(mediaItemIndex: Int) = Unit
 
-    override fun seekTo(positionMs: Long) = Unit
+    override fun seekTo(positionMs: Long) {
+        fileRelativeSeekCalls += positionMs
+    }
 
     override fun getSeekBackIncrement(): Long = 0L
 
@@ -931,7 +952,7 @@ private class FakeExoPlayer(
 
     override fun getMediaItemAt(index: Int): MediaItem = MediaItem.EMPTY
 
-    override fun getDuration(): Long = 0L
+    override fun getDuration(): Long = stubbedDuration
 
     override fun getBufferedPosition(): Long = 0L
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,11 +15,14 @@ plugins {
     // Quality Tools
     alias(libs.plugins.detekt)
     alias(libs.plugins.spotless)
-    // Note: Kover coverage is applied per-module on the JVM-pure modules only
-    // (:server, :tools:rpc-guard-ksp — see their build files). The androidKmpLibrary
-    // modules (:contract, :app:sharedLogic, :app:sharedUI) remain uncovered: Kover is
-    // incompatible with the com.android.kotlin.multiplatform.library plugin.
-    // Extend coverage to them when upstream Kover supports that plugin.
+    // Note: Kover coverage is applied per-module — see each module's build file.
+    // It now covers the androidKmpLibrary modules (:contract, :app:sharedLogic,
+    // :app:sharedUI) alongside the JVM-pure ones (:server, :tools:rpc-guard-ksp).
+    // The long-standing note here claimed Kover was incompatible with the
+    // com.android.kotlin.multiplatform.library plugin; that stopped being true at some
+    // point before Kover 0.9.9, which generates per-variant artifacts (Android, JVM,
+    // Desktop) for those modules — verified 2026-08-04 by applying it and reading the
+    // reports. Coverage is a signal, not a gate: there is deliberately no verify rule.
 }
 
 // =============================================================================

--- a/contract/build.gradle.kts
+++ b/contract/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     alias(libs.plugins.kotlinSerialization)
     alias(libs.plugins.ksp)
     alias(libs.plugins.kotlinxRpc)
+    alias(libs.plugins.kover)
 }
 
 kotlin {


### PR DESCRIPTION
Backfills the three test/coverage items that were holding 0.8.4. #1249 was merged as a pure move on the understanding tests would follow; #1248 shipped a deterministic launch crash through four green gates and a human review with no regression test at all.

## 1. `ApplicationBootTest` — the #1248 net

Boots the real `ListenUp` Application under Robolectric via `@Config(application = ListenUp::class)`, which overrides `androidHostTest`'s deliberate `android.app.Application` replacement for this one class.

**Verified red under the reverted ordering** — moving `WorkManager.initialize()` back below `startKoin` fails the test during setup with `InstanceCreationException: PlaybackControllerActivator`, the exact crash. The fix was then restored to a byte-identical file.

Why nothing caught this before: `ClientKoinGraphE2ETest` (`:app:sharedLogic:jvmTest`) loads `sharedModules` **only** — the Android platform modules where `DownloadEnqueuer` lives are absent by construction — and it deliberately swallows every non-cycle `Exception` while sweeping the singleton graph. This test closes both halves: the real Android module list, in the real `onCreate()` order, with nothing swallowed.

Deliberately **one test method**: WorkManager's delegate is a JVM static that outlives Robolectric's per-method Application, so a second boot dies on "WorkManager is already initialized". Resetting it needs `@RestrictTo(LIBRARY_GROUP)` API. This is documented in the file so nobody helpfully splits it later.

## 2. `ListenUpSessionCallbackTest` — the #1249 seam, used

Six tests over `onCustomCommand`, all crossing the book-relative ↔ file-relative boundary that `PlaybackTransport` exists to make testable. The fake's book position and file position are kept far apart on purpose — a test where both are `5_000` would pass on exactly the #1241 defect class it exists to catch.

**Mutation-tested rather than trusted green:** pointing the `timeline == null` fallback at the book position, and halving the forward clamp, each fail exactly one test and only that test. One limitation is recorded in the file honestly — deleting `coerceAtMost(maxPosition)` outright would *not* be caught, because `resolve()` independently maps past-the-end positions to the last file.

`FakeExoPlayer` becomes `internal` and gains `fileRelativeSeekCalls`, recording the single-argument `seekTo` separately from the timeline-resolved one. Its behaviour for the existing suite is unchanged (both new constructor flags default to the old values).

## 3. Kover on the KMP-Android modules — the "unsupported upstream" note was stale

`build.gradle.kts` and `ci.yml` both claimed Kover was incompatible with `com.android.kotlin.multiplatform.library`. It is not, and no version bump was needed — applying the already-pinned **0.9.9** to `:contract`, `:app:sharedLogic` and `:app:sharedUI` just works, emitting per-variant artifacts (`Android`, `Jvm`, `Desktop`). `:app:sharedUI` coverage therefore includes the Robolectric `testAndroidHostTest` lane, not just desktop.

First baselines:

| module | LINE coverage |
|---|---|
| `:app:sharedLogic` | 74% (25,997/34,781) |
| `:app:sharedUI` | 19% (7,163/37,591) |

That 19% is the concrete shape of the blind spot: every defect fixed on 2026-08-04 lived in code nothing was measuring.

**Measurement, not a gate.** The CI step keeps `continue-on-error: true` and there is still deliberately no threshold or verify rule — a percentage gate over Android glue produces tests written for the number rather than the risk.

## Verification

- `:app:sharedUI:testAndroidHostTest` — 324 tests / 58 classes, 0 failures (up from 318/57)
- `spotlessCheck`, `detekt` — green
- `:contract:koverXmlReport`, `:app:sharedLogic:koverXmlReport`, `:app:sharedUI:koverXmlReport` — each verified green individually under instrumentation

⚠️ **Not verified locally: `:server:jvmTest`.** It OOMs on this machine (worker OOM + `JPLISAgent ASSERTION FAILED`). This is pre-existing and unrelated — `:server:koverXmlReport` **alone**, a command already in CI and untouched by this branch, reproduces it, and nothing here changes `:server` compilation or test execution. Leaving it to CI.
