### PR TITLE
🐛 fix(sharedUI): auto-rewind seeks the transport player, not the chapter window

### DIFF
--- a/app/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/AutoRewindSeekTest.kt
+++ b/app/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/AutoRewindSeekTest.kt
@@ -1,0 +1,150 @@
+package com.calypsan.listenup.client.playback
+
+import androidx.media3.common.Player
+import com.calypsan.listenup.client.domain.playback.PlaybackTimeline
+import com.calypsan.listenup.client.domain.playback.TimelineFileInput
+import com.calypsan.listenup.core.BookId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * Pins the in-session auto-rewind actuator (#1220/#1237) to the TRANSPORT player and to
+ * book-timeline coordinates.
+ *
+ * ## The regression this exists to prevent
+ *
+ * #1237 wired the actuator to `mediaLibrarySession?.player`, which was the raw local player at
+ * the time and therefore correct. #1241 then made the session player [ChapterWindowPlayer] — a
+ * chapter-scoped presentation wrapper — without revisiting the actuator, so from that commit on
+ * every resume-after-a-pause handed BOOK coordinates to a player that reads them as CHAPTER
+ * coordinates and clamps them to the current chapter. Instead of stepping back five seconds,
+ * playback jumped to the next chapter boundary. `ChapterWindowPlayerSeekTest` demonstrates that
+ * reinterpretation directly.
+ *
+ * [AutoRewindSeeker] closes the hole by construction rather than by convention: it holds a
+ * [PlaybackTransport], whose only player accessor is
+ * [PlaybackTransport.activeTransportPlayer]. There is no session player in reach to get wrong.
+ *
+ * The numbers below are the ones from the production incident (2026-08-05): position
+ * 2_980_000 ms inside a chapter running 2_782_000..3_155_000 ms, resumed after a ~56 minute
+ * pause, which earns the 5 s rung of [autoRewindMs].
+ */
+class AutoRewindSeekTest :
+    FunSpec({
+
+        // A single-file m4b — the shape every book in the reporting library takes, and the shape
+        // that makes the coordinate confusion maximally wrong (positionInFileMs IS the book
+        // position, so it always overshoots a chapter window and clamps to its far edge).
+        val singleFileTimeline =
+            PlaybackTimeline.build(
+                bookId = BookId("zen-mind"),
+                files =
+                    listOf(
+                        TimelineFileInput("af-1", "book.m4b", "m4b", 5_000_000L, 1L, null, "https://s/1"),
+                    ),
+            )
+
+        val twoFileTimeline =
+            PlaybackTimeline.build(
+                bookId = BookId("two-parter"),
+                files =
+                    listOf(
+                        TimelineFileInput("af-1", "part1.mp3", "mp3", 600_000L, 1L, null, "https://s/1"),
+                        TimelineFileInput("af-2", "part2.mp3", "mp3", 600_000L, 1L, null, "https://s/2"),
+                    ),
+            )
+
+        test("seeks the transport player, never the session player") {
+            val player = FakeExoPlayer()
+            val transport = FakeTransport(player = player, bookPositionMs = 2_980_000L)
+            val seeker = AutoRewindSeeker(transport) { singleFileTimeline }
+
+            seeker.seekBack(5_000L)
+
+            withClue("the actuator must resolve its player through the transport seam") {
+                transport.activeTransportPlayerCalls shouldBe 1
+            }
+            player.seekCalls.size shouldBe 1
+        }
+
+        test("seeks in book-timeline coordinates, not chapter-relative ones") {
+            val player = FakeExoPlayer()
+            val transport = FakeTransport(player = player, bookPositionMs = 2_980_000L)
+            val seeker = AutoRewindSeeker(transport) { singleFileTimeline }
+
+            val applied = seeker.seekBack(5_000L)
+
+            // 2_980_000 - 5_000. NOT 3_155_000, which is where the chapter-window wrapper
+            // would have clamped this same request (see ChapterWindowPlayerSeekTest).
+            player.seekCalls shouldBe listOf(0 to 2_975_000L)
+            applied shouldBe 2_975_000L
+        }
+
+        test("resolves the rewound position across a multi-file book") {
+            val player = FakeExoPlayer()
+            val transport = FakeTransport(player = player, bookPositionMs = 905_000L)
+            val seeker = AutoRewindSeeker(transport) { twoFileTimeline }
+
+            val applied = seeker.seekBack(5_000L)
+
+            // 900_000 book-relative is 300_000 into the second file.
+            player.seekCalls shouldBe listOf(1 to 300_000L)
+            applied shouldBe 900_000L
+        }
+
+        test("clamps at the start of the book rather than seeking negative") {
+            val player = FakeExoPlayer()
+            val transport = FakeTransport(player = player, bookPositionMs = 2_000L)
+            val seeker = AutoRewindSeeker(transport) { singleFileTimeline }
+
+            val applied = seeker.seekBack(30_000L)
+
+            player.seekCalls shouldBe listOf(0 to 0L)
+            applied shouldBe 0L
+        }
+
+        test("falls back to a file-relative seek when no timeline is prepared") {
+            val player = FakeExoPlayer(stubbedPosition = 40_000L)
+            val transport = FakeTransport(player = player, bookPositionMs = 40_000L)
+            val seeker = AutoRewindSeeker(transport) { null }
+
+            seeker.seekBack(5_000L)
+
+            // The single-argument overload — file-relative — recorded separately from the
+            // (index, position) calls precisely so this test can tell the two apart.
+            player.fileRelativeSeekCalls shouldBe listOf(35_000L)
+            player.seekCalls shouldBe emptyList()
+        }
+
+        test("does nothing when no transport player is available") {
+            val transport = FakeTransport(player = null, bookPositionMs = 2_980_000L)
+            val seeker = AutoRewindSeeker(transport) { singleFileTimeline }
+
+            seeker.seekBack(5_000L).shouldBeNull()
+        }
+    })
+
+/**
+ * [PlaybackTransport] fake that counts transport-player lookups.
+ *
+ * It exposes no session player at all — the point of routing the actuator through this seam is
+ * that the wrong player is not reachable, so the fake models exactly that.
+ */
+private class FakeTransport(
+    private val player: Player?,
+    private val bookPositionMs: Long,
+) : PlaybackTransport {
+    var activeTransportPlayerCalls = 0
+        private set
+
+    override fun activeTransportPlayer(): Player? {
+        activeTransportPlayerCalls++
+        return player
+    }
+
+    override fun bookRelativePositionMs(): Long = bookPositionMs
+
+    override fun applyResumeSpeed(speed: Float) = Unit
+}

--- a/app/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/ChapterWindowPlayerSeekTest.kt
+++ b/app/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/ChapterWindowPlayerSeekTest.kt
@@ -1,0 +1,127 @@
+package com.calypsan.listenup.client.playback
+
+import androidx.media3.common.Player
+import com.calypsan.listenup.client.domain.model.Chapter
+import com.calypsan.listenup.client.domain.playback.PlaybackTimeline
+import com.calypsan.listenup.client.domain.playback.TimelineFileInput
+import com.calypsan.listenup.core.BookId
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Demonstrates, against the real [ChapterWindowPlayer], why book coordinates must never be sent
+ * to the session player — the production defect behind [AutoRewindSeeker].
+ *
+ * ## What this reproduces
+ *
+ * On 2026-08-05 a listener resumed a single-file audiobook after a ~56 minute pause at book
+ * position 2_980_000 ms, inside a chapter running 2_782_000..3_155_000 ms. The 5 s rung of
+ * [autoRewindMs] applied, so the actuator asked for 2_975_000 ms — and playback jumped forward to
+ * the start of the *next* chapter. The recorded listening span shows exactly that: +177 s of
+ * content in 2 s of wall clock, landing on the chapter boundary.
+ *
+ * The cause is not a bug in this class — the reinterpretation below is precisely its job, and is
+ * correct for the system surfaces (Auto, notification, lock screen) it presents to. The bug was
+ * aiming a book-coordinate seek at it. This test pins the hazard so the reinterpretation is
+ * visible in a test rather than only in a KDoc paragraph, and so anyone tempted to route a
+ * book-relative seek through the session player meets it here first.
+ *
+ * ## Note on testability
+ *
+ * [ChapterWindowPlayer]'s KDoc long claimed it could not be constructed in this source set for
+ * want of a real `Looper`. That is not true under Robolectric, which this lane has: `FakeExoPlayer`
+ * returns `Looper.getMainLooper()`, and `SimpleBasePlayer`'s constructor is satisfied. The claim is
+ * corrected in that KDoc.
+ */
+@RunWith(RobolectricTestRunner::class)
+class ChapterWindowPlayerSeekTest {
+    private val chapterStartMs = 2_782_000L
+    private val nextChapterStartMs = 3_155_000L
+    private val bookPositionMs = 2_980_000L
+
+    /** Single-file m4b — the shape that makes the coordinate confusion maximally wrong. */
+    private val timeline =
+        PlaybackTimeline.build(
+            bookId = BookId("zen-mind"),
+            files = listOf(TimelineFileInput("af-1", "book.m4b", "m4b", 5_000_000L, 1L, null, "https://s/1")),
+        )
+
+    private val chapters =
+        listOf(
+            Chapter(id = "ch-8", title = "Bowing", duration = 488_000L, startTime = 2_294_000L),
+            Chapter(id = "ch-9", title = "Nothing Special", duration = 373_000L, startTime = chapterStartMs),
+            Chapter(id = "ch-10", title = "Part 2: Right Attitude", duration = 156_000L, startTime = nextChapterStartMs),
+        )
+
+    private fun wrapperOver(fake: FakeExoPlayer) =
+        ChapterWindowPlayer(
+            player = fake,
+            chaptersProvider = { chapters },
+            timelineProvider = { timeline },
+        )
+
+    private fun seekableFake() =
+        FakeExoPlayer(
+            stubbedPosition = bookPositionMs,
+            stubbedMediaItemIndex = 0,
+            availableCommands =
+                Player.Commands
+                    .Builder()
+                    .addAll(Player.COMMAND_SEEK_TO_MEDIA_ITEM, Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM)
+                    .build(),
+        )
+
+    @Test
+    fun `a book-coordinate seek aimed at the session wrapper lands on the next chapter boundary`() {
+        val fake = seekableFake()
+        val wrapper = wrapperOver(fake)
+
+        // Exactly what the pre-fix actuator did: resolve the rewound BOOK position through the
+        // timeline, then seek the session player with it.
+        val rewound = timeline.resolve(bookPositionMs - 5_000L)
+        wrapper.seekTo(rewound.mediaItemIndex, rewound.positionInFileMs)
+
+        // The wrapper read 2_975_000 as a position WITHIN the current chapter, clamped it to the
+        // chapter's 373 s length, and turned a 5-second step back into a jump to the next chapter.
+        assertEquals(
+            "book-coordinate seek through the chapter wrapper must be shown clamping to the window end",
+            listOf(0 to nextChapterStartMs),
+            fake.seekCalls,
+        )
+    }
+
+    @Test
+    fun `the same rewind aimed at the transport player lands five seconds back`() {
+        val fake = seekableFake()
+        val transport = TransportOver(fake, bookPositionMs)
+
+        AutoRewindSeeker(transport) { timeline }.seekBack(5_000L)
+
+        assertEquals(listOf(0 to bookPositionMs - 5_000L), fake.seekCalls)
+    }
+
+    @Test
+    fun `a chapter-relative seek through the wrapper is still interpreted chapter-relatively`() {
+        val fake = seekableFake()
+        val wrapper = wrapperOver(fake)
+
+        // 60 s into the current chapter — the coordinate space a system surface's seek bar speaks.
+        wrapper.seekTo(0, 60_000L)
+
+        assertEquals(listOf(0 to chapterStartMs + 60_000L), fake.seekCalls)
+    }
+}
+
+/** Minimal [PlaybackTransport] over a fake, for the contrast case above. */
+private class TransportOver(
+    private val player: Player,
+    private val bookPositionMs: Long,
+) : PlaybackTransport {
+    override fun activeTransportPlayer(): Player = player
+
+    override fun bookRelativePositionMs(): Long = bookPositionMs
+
+    override fun applyResumeSpeed(speed: Float) = Unit
+}

--- a/app/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/PlaybackErrorHandlerTest.kt
+++ b/app/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/PlaybackErrorHandlerTest.kt
@@ -728,6 +728,10 @@ internal class FakeExoPlayer(
     // Defaults to false to keep the fake honest about what it is — only a fake standing in
     // as a session's player needs to claim otherwise.
     private val canAdvertiseSession: Boolean = false,
+    // Opt-in for the same reason: SimpleBasePlayer drops any command its state does not
+    // advertise, so a fake wrapped by ChapterWindowPlayer must declare the seek commands it
+    // wants exercised or handleSeek is never reached (see ChapterWindowPlayerSeekTest).
+    private val availableCommands: Player.Commands = Player.Commands.EMPTY,
 ) : ExoPlayer {
     private val _currentPosition = stubbedPosition
     private val _currentMediaItemIndex = stubbedMediaItemIndex
@@ -856,7 +860,7 @@ internal class FakeExoPlayer(
 
     override fun canAdvertiseSession(): Boolean = canAdvertiseSession
 
-    override fun getAvailableCommands(): Player.Commands = Player.Commands.EMPTY
+    override fun getAvailableCommands(): Player.Commands = availableCommands
 
     override fun getPlaybackState(): Int = Player.STATE_IDLE
 

--- a/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/AutoRewindSeeker.kt
+++ b/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/AutoRewindSeeker.kt
@@ -1,0 +1,65 @@
+package com.calypsan.listenup.client.playback
+
+import com.calypsan.listenup.client.domain.playback.PlaybackTimeline
+import io.github.oshai.kotlinlogging.KotlinLogging
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * Applies the in-session pause→resume rewind (#1220/#1237) to the player that is actually
+ * producing audio.
+ *
+ * [PlaybackProgressReporter] owns the decision — how long the listener was away, and which rung of
+ * the [autoRewindMs] ladder that earns. This owns the actuation, and specifically owns *which
+ * player the seek is aimed at*, which is the part that has been wrong in production.
+ *
+ * ## Why this is a class and not four lines in `PlaybackService.onCreate`
+ *
+ * It was four lines in `PlaybackService.onCreate`, and it reached for
+ * `mediaLibrarySession?.player`. That was correct when #1237 wrote it — the session player was the
+ * raw local player. #1241 then made the session player [ChapterWindowPlayer], a chapter-scoped
+ * presentation wrapper that reads incoming seeks as chapter-relative and clamps them to the current
+ * chapter. From that commit onwards the actuator handed BOOK coordinates to a chapter-relative
+ * player, so every resume after a pause of a minute or more jumped the listener to the next chapter
+ * boundary instead of stepping back five seconds.
+ *
+ * The invariant that would have prevented it was already written down — [PlaybackTransport]'s KDoc
+ * says transport commands must resolve against [PlaybackTransport.activeTransportPlayer], never the
+ * session player — but a rule that lives in prose is enforced only by whoever is reading. Holding a
+ * [PlaybackTransport] instead of the service makes the wrong player unreachable: there is no
+ * session player in scope to aim at. That is the actual fix; the seek arithmetic is unchanged.
+ *
+ * @property transport The seam exposing the raw transport player and the book-relative position.
+ * @property timelineProvider Snapshot of the playing book's file/offset timeline, or null before
+ *   playback has been prepared.
+ */
+internal class AutoRewindSeeker(
+    private val transport: PlaybackTransport,
+    private val timelineProvider: () -> PlaybackTimeline?,
+) {
+    /**
+     * Steps playback back by [rewindMs] and returns the new BOOK-relative position, or null when
+     * no player is available to seek (nothing is playing, so there is nothing to rewind).
+     *
+     * The returned value is the caller's cue to update [PlaybackManager]'s position — reported
+     * rather than written here so this class stays a pure actuator over the transport seam.
+     */
+    fun seekBack(rewindMs: Long): Long? {
+        val player = transport.activeTransportPlayer() ?: return null
+        val timeline = timelineProvider()
+        val newPositionMs = (transport.bookRelativePositionMs() - rewindMs).coerceAtLeast(0L)
+
+        if (timeline == null) {
+            // No timeline yet, so book coordinates cannot be resolved. Fall back to a
+            // file-relative step within the current item — the same degradation
+            // `onCustomCommand`'s skip-back uses, and correct within a single file.
+            player.seekTo((player.currentPosition - rewindMs).coerceAtLeast(0L))
+        } else {
+            val resolved = timeline.resolve(newPositionMs)
+            player.seekTo(resolved.mediaItemIndex, resolved.positionInFileMs)
+        }
+
+        logger.debug { "Auto-rewind on resume: backed up ${rewindMs}ms to ${newPositionMs}ms" }
+        return newPositionMs
+    }
+}

--- a/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/ChapterWindowPlayer.kt
+++ b/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/ChapterWindowPlayer.kt
@@ -75,17 +75,17 @@ private data class ChapterSeekContext(
  * [currentChapterWindow] presents the whole book as one window — no special-casing is visible to
  * controllers; they simply see a single "chapter" spanning the whole book.
  *
- * **No androidHostTest for this class.** Unlike `SpeedAwareCastPlayer`
- * (`playback/cast/SpeedAwareCastPlayer.kt`), which can be constructed with a bare
- * `mock<Player>()`, this class can't be instantiated at all in this Robolectric-free lane:
- * `SimpleBasePlayer`'s constructor calls `player.getApplicationLooper()` and builds a real
- * `Handler` from it immediately, and even stubbing that call with Mokkery to return
- * `Looper.getMainLooper()` throws `RuntimeException: Method getMainLooper in android.os.Looper
- * not mocked` (verified empirically) — there is no way to hand it a working `Looper` without
- * Robolectric. Every chapter-window calculation this class depends on lives in
- * [ChapterWindow.kt][ChapterWindow] and is fully covered by `ChapterWindowTest`; this adapter
- * layer (state/metadata assembly, command gating, seek dispatch) is exercised on a real device
- * instead.
+ * **Testing.** `SimpleBasePlayer`'s constructor calls `player.getApplicationLooper()` and builds a
+ * real `Handler` from it immediately, so a Mokkery `mock<Player>()` cannot construct this class —
+ * stubbing that call throws `RuntimeException: Method getMainLooper in android.os.Looper not
+ * mocked`. That much is still true, and is why this class is not built from a mock the way
+ * `SpeedAwareCastPlayer` (`playback/cast/SpeedAwareCastPlayer.kt`) is. It does NOT mean the class
+ * is untestable here: `androidHostTest` runs Robolectric, under which a hand-written fake returning
+ * `Looper.getMainLooper()` satisfies the constructor. `ChapterWindowPlayerSeekTest` drives this
+ * adapter's seek dispatch that way. (An earlier revision of this KDoc called the lane
+ * "Robolectric-free" and sent this layer to device-only verification; that was wrong, and the gap
+ * it left is where the #1237/#1241 auto-rewind regression hid.) The pure chapter-window
+ * calculations live in [ChapterWindow.kt][ChapterWindow], covered by `ChapterWindowTest`.
  *
  * @param player The local ExoPlayer instance to wrap.
  * @param chaptersProvider Synchronous snapshot of the current book's chapters (empty when the

--- a/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
+++ b/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
@@ -217,22 +217,12 @@ class PlaybackService :
         // Auto-rewind-on-resume actuator (#1220): PlaybackManagerImpl.setPlaying feeds every
         // Playing/Paused transition (from the Player.Listener below, via MediaControllerHolder)
         // into the reporter, which owns the pause-window/ladder decision and calls back here
-        // with a relative rewind once one applies. Mirrors COMMAND_SKIP_BACK_30's book-relative
-        // seek — routes to the active session player so it also seeks correctly while casting.
+        // with a relative rewind once one applies. The seek itself lives in AutoRewindSeeker,
+        // which holds only the PlaybackTransport seam — see its KDoc for why aiming this at the
+        // session player was a production bug, and why "unreachable" beats "documented".
+        val autoRewindSeeker = AutoRewindSeeker(this) { playbackManager.currentTimeline.value }
         reporter.onAutoRewindSeek = { rewindMs ->
-            val p = mediaLibrarySession?.player ?: player
-            if (p != null) {
-                val timeline = playbackManager.currentTimeline.value
-                val newPosition = (getBookRelativePosition() - rewindMs).coerceAtLeast(0)
-                if (timeline != null) {
-                    val resolved = timeline.resolve(newPosition)
-                    p.seekTo(resolved.mediaItemIndex, resolved.positionInFileMs)
-                } else {
-                    p.seekTo((p.currentPosition - rewindMs).coerceAtLeast(0))
-                }
-                playbackManager.updatePosition(newPosition)
-                logger.debug { "Auto-rewind on resume: backed up ${rewindMs}ms to ${newPosition}ms" }
-            }
+            autoRewindSeeker.seekBack(rewindMs)?.let { playbackManager.updatePosition(it) }
         }
     }
 

--- a/tools/scripts/playback-smoke.sh
+++ b/tools/scripts/playback-smoke.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Playback smoke test — the pause/resume behaviour no unit test can see.
+#
+# WHY THIS EXISTS
+#
+# 0.8.4 shipped a defect where every resume after a pause of a minute or more jumped the
+# listener to the next chapter boundary instead of stepping back a few seconds (#1237's
+# auto-rewind actuator aimed at #1241's chapter-scoped session player). It survived the
+# release gate because the gate boots the app and stops: it never plays anything, and app
+# builds are post-merge-only. A ninety-second run of this script would have caught it.
+#
+# It asserts the one property that matters on resume: you land slightly BEHIND where you
+# paused, in the SAME chapter. A jump to a chapter boundary — in either direction — fails.
+#
+# USAGE
+#   tools/scripts/playback-smoke.sh [pause_seconds]
+#
+# Start a book playing on the connected device first (any book, any position, but not
+# within a minute of a chapter edge). Default pause is 70s — comfortably over the 60s
+# threshold for the first rung of the auto-rewind ladder, which is what arms the actuator.
+#
+# EXIT CODES
+#   0 pass   1 assertion failed   2 setup/environment problem
+
+set -u -o pipefail
+
+PKG="com.calypsan.listenup.client"
+PAUSE_SECONDS="${1:-70}"
+# The ladder's first rung is 5s. Allow generous slack for playback drift across the
+# pause/resume round trip and for the position poll's own cadence.
+MAX_EXPECTED_REWIND_MS=20000
+
+fail() {
+	echo "FAIL: $*" >&2
+	exit 1
+}
+setup_fail() {
+	echo "SETUP: $*" >&2
+	exit 2
+}
+
+command -v adb >/dev/null 2>&1 || setup_fail "adb not on PATH"
+[ -n "$(adb devices | sed -n '2p')" ] || setup_fail "no device connected"
+
+# The ListenUp session block from dumpsys, up to the start of the next session's block.
+session_block() {
+	adb shell dumpsys media_session 2>/dev/null |
+		awk -v pkg="$PKG" '
+			$0 ~ pkg"/" { inblock = 1 }
+			inblock && /^    [A-Za-z]/ && $0 !~ pkg { if (seen) inblock = 0 }
+			inblock { print; seen = 1 }
+		'
+}
+
+position_ms() { session_block | grep -o 'position=[0-9-]*' | head -1 | cut -d= -f2; }
+play_state() { session_block | grep -o 'state=[A-Z_]*([0-9])' | head -1; }
+# The wrapper reports the CURRENT CHAPTER as the session's media item, so its title is a
+# direct read-out of which chapter the listener is in. That is the signal here: the title
+# must not change across a pause/resume.
+chapter() { session_block | grep -o 'description=.*' | head -1; }
+
+[ -n "$(session_block)" ] || setup_fail "no ListenUp media session — start a book playing first"
+
+STATE_BEFORE="$(play_state)"
+case "$STATE_BEFORE" in
+*PLAYING*) ;;
+*) setup_fail "expected playback to be running, found ${STATE_BEFORE:-none}. Start a book playing first." ;;
+esac
+
+POS_BEFORE="$(position_ms)"
+CHAPTER_BEFORE="$(chapter)"
+[ -n "$POS_BEFORE" ] || setup_fail "could not read a position from the session"
+echo "before pause: position=${POS_BEFORE}ms  ${CHAPTER_BEFORE}"
+
+echo "pausing for ${PAUSE_SECONDS}s (must exceed the 60s auto-rewind threshold)..."
+adb shell cmd media_session dispatch pause >/dev/null 2>&1 || setup_fail "could not dispatch pause"
+sleep 3
+POS_PAUSED="$(position_ms)"
+sleep "$PAUSE_SECONDS"
+
+adb shell cmd media_session dispatch play >/dev/null 2>&1 || setup_fail "could not dispatch play"
+# Let the resume settle: the actuator seeks after the isPlaying transition propagates.
+sleep 5
+
+POS_AFTER="$(position_ms)"
+CHAPTER_AFTER="$(chapter)"
+[ -n "$POS_AFTER" ] || fail "no position after resume — playback did not come back"
+echo "after resume: position=${POS_AFTER}ms  ${CHAPTER_AFTER}"
+
+if [ "$CHAPTER_BEFORE" != "$CHAPTER_AFTER" ]; then
+	fail "chapter changed across a pause/resume: '${CHAPTER_BEFORE}' -> '${CHAPTER_AFTER}'. A resume must never cross a chapter boundary (this is the 0.8.4 regression)."
+fi
+
+DELTA=$((POS_PAUSED - POS_AFTER))
+if [ "$DELTA" -lt 0 ]; then
+	fail "resumed AHEAD of the pause point by $((-DELTA))ms — a resume must never skip forward."
+fi
+if [ "$DELTA" -gt "$MAX_EXPECTED_REWIND_MS" ]; then
+	fail "rewound ${DELTA}ms on resume, far more than the ladder's rungs allow (max ${MAX_EXPECTED_REWIND_MS}ms)."
+fi
+
+echo "PASS: resumed ${DELTA}ms behind the pause point, same chapter."
+exit 0


### PR DESCRIPTION
Fixes the position jump reported from a walk on 2026-08-05: playback resumed, then jumped to the start of a chapter.

## Root cause

`PlaybackService.onCreate`'s auto-rewind actuator (#1237) aimed its seek at `mediaLibrarySession?.player` while passing **book-timeline** coordinates. That was correct when written — the session player *was* the raw local player. #1241 then made the session player `ChapterWindowPlayer`, which reads incoming seeks as **chapter-relative** and clamps them to the current chapter, and the actuator was not revisited.

Net effect since #1241: every resume after a pause of a minute or more jumped to the next chapter boundary instead of stepping back 5s.

## Evidence

From the reporter's own synced listening spans, book `e221069a`:

| time (UTC) | position | |
|---|---|---|
| 14:12:49–14:22:12 | 1855 → 2980s | normal playback, then paused |
| 15:18:48–15:18:51 | 2980 → **3158s** | +177s of content in 2s of wall clock |

Position 2980s sits in a chapter running 2782–3155s. The buggy arithmetic is `2782 + clamp(2975, 0, 373)` = **3155s** — the next chapter's start. `ChapterWindowPlayerSeekTest` reproduces that number against the real wrapper.

## The fix

`AutoRewindSeeker` holds only the `PlaybackTransport` seam, whose sole player accessor is `activeTransportPlayer()`. The session player is not reachable from it, so the wrong player cannot be chosen. The seek arithmetic is unchanged.

The invariant was already written down in `PlaybackTransport`'s KDoc — "never the session player" — but a rule that lives in prose is enforced only by whoever is reading it. This makes it structural.

## Tests

- `ChapterWindowPlayerSeekTest` (Robolectric, 3 tests) — reproduces the production jump through the real `ChapterWindowPlayer`, and pins the corrected path against it.
- `AutoRewindSeekTest` (6 tests) — transport-seam routing, book-coordinate resolution, multi-file resolution, start-of-book clamp, timeline-absent fallback. Mutation-tested: swapping the seek to the file-relative overload fails 4 of the 6.
- `tools/scripts/playback-smoke.sh` — asserts a resume lands slightly behind the pause point, in the same chapter. The release gate boots the app but never plays anything, which is why this class of defect reaches users; this run takes ~90s.

`ChapterWindowPlayer`'s KDoc claimed this lane was "Robolectric-free" and sent the class to device-only verification. It is not, and that gap is where this regression hid. Corrected.

## Gates

`spotlessCheck` · `detekt` · `:app:sharedUI:testAndroidHostTest` (333 tests / 60 classes, was 324/58) · `:app:sharedLogic:jvmTest` (Konsist) · `:app:androidApp:assembleDebug` — all green.
