### PR TITLE
✨ feat(iosApp): CarPlay — scene, and continue-listening browse

### DIFF
--- a/app/iosApp/CLAUDE.md
+++ b/app/iosApp/CLAUDE.md
@@ -129,7 +129,12 @@ inline below.
     activate/deactivate. **Playback persistence lifecycle:** save position on pause, on
     seek, *and* on `scenePhase`/background/termination (guarded by `beginBackgroundTask`) —
     never rely on periodic ticks alone. App Intents/Siri/interactive widgets/Control Center
-    controls where they serve audiobooks. *CarPlay: evaluate later — not a current requirement.*
+    controls where they serve audiobooks. **CarPlay is in scope** — the entitlement
+    (`com.apple.developer.carplay-audio`, type Audio) was granted 2026-08-05. Its now-playing
+    screen is `CPNowPlayingTemplate.shared` rendering straight from the same
+    `MPNowPlayingInfoCenter`/`MPRemoteCommandCenter` this rule already requires, so **fix car
+    display bugs in `SystemIntegration`, never with a CarPlay-only patch** — the lock screen
+    shares that code, and a local patch just makes the two surfaces disagree.
 14. **Swift Testing (not XCTest) for native code**; shared logic keeps Kotest. Same TDD
     discipline as the root `CLAUDE.md` — no fix without a failing test first, no feature
     without a test.

--- a/app/iosApp/ListenUp/Core/AppDelegate.swift
+++ b/app/iosApp/ListenUp/Core/AppDelegate.swift
@@ -1,0 +1,22 @@
+import UIKit
+
+/// Exists for exactly one reason: routing connecting scenes to their configuration.
+///
+/// SwiftUI's `App` lifecycle handles the window scene on its own, but it has no hook for the
+/// second scene role CarPlay introduces. `UIApplicationDelegateAdaptor` is the supported way to
+/// answer `configurationForConnecting` while leaving SwiftUI in charge of the window scene —
+/// more reliable than relying on the scene manifest alone to resolve both roles.
+///
+/// Keep it empty otherwise. App startup lives in `ListenUpApp.init()`.
+final class AppDelegate: NSObject, UIApplicationDelegate {
+    func application(
+        _ application: UIApplication,
+        configurationForConnecting connectingSceneSession: UISceneSession,
+        options: UIScene.ConnectionOptions
+    ) -> UISceneConfiguration {
+        UISceneConfiguration(
+            name: SceneRoleRouting.configurationName(for: connectingSceneSession.role),
+            sessionRole: connectingSceneSession.role
+        )
+    }
+}

--- a/app/iosApp/ListenUp/Core/CarPlayRows.swift
+++ b/app/iosApp/ListenUp/Core/CarPlayRows.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// One row in a CarPlay list.
+///
+/// A native value type on purpose: `CPListItem`s are rebuilt whenever a template is refreshed,
+/// and reading a Swift-Export-bridged Kotlin object per rebuild re-bridges every string across
+/// the boundary. Same rule as the phone's `ForEach` rows (`app/iosApp/CLAUDE.md` rule 8) — map
+/// once, at the boundary, into plain Swift.
+struct CarPlayRow: Equatable, Identifiable {
+    /// Book id — what selecting the row hands to `PlayerCoordinator.play(bookId:)`.
+    let id: String
+    let title: String
+    /// The secondary line: author and remaining time, whichever of them exist.
+    let detailText: String
+    let isPlayable: Bool
+}
+
+/// Builds [CarPlayRow]s from the app's existing native view data.
+enum CarPlayRows {
+    /// Mirrors Android Auto's `CONTINUE_LISTENING_LIMIT`. A curated shelf, not a truncated
+    /// library — the two car surfaces are deliberately kept at the same number.
+    static let continueListeningLimit = 8
+
+    /// Maps the continue-listening shelf to car rows.
+    ///
+    /// Placeholders are dropped before the cap, not after: a shelf padded with in-flight items
+    /// would otherwise offer a driver fewer than the eight real books the limit promises.
+    static func continueListening(from items: [ContinueItem]) -> [CarPlayRow] {
+        items
+            .lazy
+            .filter { !$0.isLoading }
+            .prefix(continueListeningLimit)
+            .map { item in
+                CarPlayRow(
+                    id: item.id,
+                    title: item.title,
+                    detailText: detailText(author: item.author, timeLeft: item.timeLeft),
+                    isPlayable: true
+                )
+            }
+    }
+
+    /// Joins the parts of a row's secondary line, skipping whichever are absent so a missing
+    /// author or an unknown remaining time never leaves a dangling separator.
+    static func detailText(author: String, timeLeft: String) -> String {
+        [author, timeLeft]
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+            .joined(separator: " • ")
+    }
+}

--- a/app/iosApp/ListenUp/Core/CarPlaySceneDelegate.swift
+++ b/app/iosApp/ListenUp/Core/CarPlaySceneDelegate.swift
@@ -1,0 +1,42 @@
+import CarPlay
+import UIKit
+
+/// Hosts the CarPlay scene.
+///
+/// CarPlay's now-playing screen is not something this app draws: `CPNowPlayingTemplate.shared`
+/// renders straight from `MPNowPlayingInfoCenter` and `MPRemoteCommandCenter`, both of which
+/// `SystemIntegration` already keeps current and chapter-scoped. So the head unit shows the
+/// current chapter, its real duration, and working transport controls without a line of
+/// CarPlay-specific playback code. If something reads wrong in the car, fix
+/// `SystemIntegration.dictionary(from:)` — the lock screen shares it, and a CarPlay-only patch
+/// would just make the two disagree.
+///
+/// Browse templates are the next slice; this sets now-playing as the root so the scene, the
+/// entitlement and the existing now-playing plumbing can be verified end to end before any
+/// browse-tree volume is committed to.
+final class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
+    /// Valid only between connect and disconnect, so it is held weakly and every use is optional.
+    private weak var interfaceController: CPInterfaceController?
+
+    func templateApplicationScene(
+        _ templateApplicationScene: CPTemplateApplicationScene,
+        didConnect interfaceController: CPInterfaceController
+    ) {
+        self.interfaceController = interfaceController
+        interfaceController.setRootTemplate(CPNowPlayingTemplate.shared, animated: false) { done, error in
+            if let error {
+                Log.error("CarPlay root template failed", error: error)
+            } else {
+                Log.info("CarPlay connected (root set: \(done))")
+            }
+        }
+    }
+
+    func templateApplicationScene(
+        _ templateApplicationScene: CPTemplateApplicationScene,
+        didDisconnectInterfaceController interfaceController: CPInterfaceController
+    ) {
+        self.interfaceController = nil
+        Log.info("CarPlay disconnected")
+    }
+}

--- a/app/iosApp/ListenUp/Core/CarPlaySceneDelegate.swift
+++ b/app/iosApp/ListenUp/Core/CarPlaySceneDelegate.swift
@@ -9,25 +9,39 @@ import UIKit
 /// current chapter, its real duration, and working transport controls without a line of
 /// CarPlay-specific playback code. If something reads wrong in the car, fix
 /// `SystemIntegration.dictionary(from:)` — the lock screen shares it, and a CarPlay-only patch
-/// would just make the two disagree.
+/// would just make the two surfaces disagree.
 ///
-/// Browse templates are the next slice; this sets now-playing as the root so the scene, the
-/// entitlement and the existing now-playing plumbing can be verified end to end before any
-/// browse-tree volume is committed to.
+/// The browse tree mirrors the phone app (`MainTabView`), not Android Auto: Home is the
+/// continue-listening shelf, which is overwhelmingly what a driver wants. Library and Search are
+/// the next slice. Discover is deliberately absent — it is mostly a leaderboard and a friend
+/// activity feed, which is the wrong thing to put in front of someone driving.
+@MainActor
 final class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
     /// Valid only between connect and disconnect, so it is held weakly and every use is optional.
     private weak var interfaceController: CPInterfaceController?
+
+    /// Built on connect and released on disconnect: its `isolated deinit` closes the underlying
+    /// Kotlin ViewModel, whose stream jobs would otherwise outlive the car session (#1192).
+    private var home: HomeViewModelWrapper?
+
+    private let homeTemplate = CPListTemplate(title: "Home", sections: [])
 
     func templateApplicationScene(
         _ templateApplicationScene: CPTemplateApplicationScene,
         didConnect interfaceController: CPInterfaceController
     ) {
         self.interfaceController = interfaceController
-        interfaceController.setRootTemplate(CPNowPlayingTemplate.shared, animated: false) { done, error in
+
+        let home = HomeViewModelWrapper()
+        self.home = home
+        observeHome(home)
+
+        let tabBar = CPTabBarTemplate(templates: [homeTemplate, CPNowPlayingTemplate.shared])
+        interfaceController.setRootTemplate(tabBar, animated: false) { _, error in
             if let error {
                 Log.error("CarPlay root template failed", error: error)
             } else {
-                Log.info("CarPlay connected (root set: \(done))")
+                Log.info("CarPlay connected")
             }
         }
     }
@@ -37,6 +51,55 @@ final class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegat
         didDisconnectInterfaceController interfaceController: CPInterfaceController
     ) {
         self.interfaceController = nil
+        home = nil
         Log.info("CarPlay disconnected")
+    }
+
+    /// Re-render the Home list whenever the shared Home state changes.
+    ///
+    /// `withObservationTracking` fires once per change, so it re-arms itself — the Observation
+    /// equivalent of what SwiftUI does implicitly for a view body. There is no view here to do
+    /// it for us, and without re-arming the car would show whatever the library looked like at
+    /// the moment the driver plugged in.
+    private func observeHome(_ home: HomeViewModelWrapper) {
+        withObservationTracking {
+            render(home.phase)
+        } onChange: { [weak self, weak home] in
+            Task { @MainActor in
+                guard let self, let home else { return }
+                self.observeHome(home)
+            }
+        }
+    }
+
+    private func render(_ phase: HomePhase) {
+        let items: [CPListItem]
+        switch phase {
+        case .loading:
+            items = []
+        case .ready(let ready):
+            items = CarPlayRows.continueListening(from: ready.continueItems).map(listItem(for:))
+        case .error(let message):
+            // Honest over silent: a driver seeing an empty list cannot tell "nothing to resume"
+            // from "we failed to load". Untappable, so it cannot lead anywhere.
+            let row = CPListItem(text: message, detailText: nil)
+            row.handler = { _, completion in completion() }
+            items = [row]
+        }
+        homeTemplate.updateSections([CPListSection(items: items)])
+    }
+
+    private func listItem(for row: CarPlayRow) -> CPListItem {
+        let item = CPListItem(text: row.title, detailText: row.detailText)
+        item.handler = { [weak self] _, completion in
+            Dependencies.shared.playerCoordinator.play(bookId: row.id)
+            // Push now-playing so the driver lands on transport controls rather than staying in
+            // a list they have to navigate out of.
+            self?.interfaceController?.pushTemplate(CPNowPlayingTemplate.shared, animated: true) { _, error in
+                if let error { Log.error("CarPlay now-playing push failed", error: error) }
+                completion()
+            }
+        }
+        return item
     }
 }

--- a/app/iosApp/ListenUp/Core/SceneRoleRouting.swift
+++ b/app/iosApp/ListenUp/Core/SceneRoleRouting.swift
@@ -1,0 +1,30 @@
+import CarPlay
+import UIKit
+
+/// Maps a connecting scene's role to the scene configuration that should serve it.
+///
+/// The app has two scenes: the SwiftUI window scene the phone shows, and the CarPlay template
+/// scene a head unit connects to. Both names below must match the `UISceneConfigurationName`
+/// entries in `Info.plist` exactly — a typo is not a build error, it is a scene that never
+/// connects.
+///
+/// Pure and free of any scene object so the mapping is testable on its own; `AppDelegate` does
+/// nothing but ask this and hand back a configuration.
+enum SceneRoleRouting {
+    /// Serves the SwiftUI `WindowGroup`. No delegate class — SwiftUI owns this scene.
+    static let defaultConfigurationName = "Default Configuration"
+
+    /// Serves CarPlay, delegated to `CarPlaySceneDelegate`.
+    static let carPlayConfigurationName = "CarPlay Configuration"
+
+    /// The configuration name for `role`.
+    ///
+    /// Anything that is not explicitly the CarPlay role gets the window configuration. That
+    /// direction of defaulting is deliberate: an unexpected window scene is inert, whereas
+    /// handing a non-CarPlay scene the CarPlay configuration leaves SwiftUI with no window to
+    /// place `RootView` in — which presents as the app launching to a black screen, with
+    /// nothing in the build or the logs to say why.
+    static func configurationName(for role: UISceneSession.Role) -> String {
+        role == .carTemplateApplication ? carPlayConfigurationName : defaultConfigurationName
+    }
+}

--- a/app/iosApp/ListenUp/Info.plist
+++ b/app/iosApp/ListenUp/Info.plist
@@ -37,5 +37,38 @@
 	</array>
 	<key>NSSupportsLiveActivities</key>
 	<true/>
+	<!-- Two scenes: the SwiftUI window the phone shows, and the CarPlay template scene a head
+	     unit connects to. The window role is declared with NO delegate class on purpose —
+	     SwiftUI owns that scene, and naming a delegate here takes it away from SwiftUI. The
+	     configuration names must match SceneRoleRouting's constants exactly; a mismatch is not
+	     a build error, just a scene that never connects.
+
+	     UIApplicationSupportsMultipleScenes is required by CarPlay (the car scene is a second
+	     simultaneous scene). It also permits multiple windows on iPad, which suits the
+	     responsive direction rather than working against it. -->
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<true/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+				</dict>
+			</array>
+			<key>CPTemplateApplicationSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>CarPlay Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).CarPlaySceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/app/iosApp/ListenUp/ListenUp.entitlements
+++ b/app/iosApp/ListenUp/ListenUp.entitlements
@@ -10,5 +10,11 @@
 	<array>
 		<string>applinks:link.listenup.audio</string>
 	</array>
+	<!-- Granted by Apple 2026-08-05 (type Audio / "Play Music & Audio Content"). The CarPlay
+	     Simulator renders templates without it, but a signed build needs the provisioning
+	     profile regenerated after the grant — otherwise signing fails with a profile mismatch
+	     that reads like an unrelated codesign error. -->
+	<key>com.apple.developer.carplay-audio</key>
+	<true/>
 </dict>
 </plist>

--- a/app/iosApp/ListenUp/ListenUpApp.swift
+++ b/app/iosApp/ListenUp/ListenUpApp.swift
@@ -6,6 +6,10 @@ import UIKit
 
 @main
 struct ListenUpApp: App {
+    /// Present solely to answer `configurationForConnecting` for the CarPlay scene role;
+    /// see `AppDelegate`. SwiftUI still owns the window scene.
+    @UIApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
+
     init() {
         // Koin must be initialised before any UI (or observer) accesses it.
         ExportedKotlinPackages.com.calypsan.listenup.client.di.startDependencyInjection()

--- a/app/iosApp/ListenUpTests/CarPlayRowTests.swift
+++ b/app/iosApp/ListenUpTests/CarPlayRowTests.swift
@@ -1,0 +1,108 @@
+import Testing
+@testable import ListenUp
+
+/// Rows shown in the car are built from the same app data the phone shows, mapped to a native
+/// value type at the boundary. These tests pin that mapping — the templates themselves are not
+/// unit-testable, so every decision worth checking lives here rather than in the delegate.
+@Suite("CarPlayRow")
+struct CarPlayRowTests {
+    // ── continue listening ────────────────────────────────────────────────────
+
+    @Test func aReadyItemBecomesAPlayableRowWithAuthorAndTimeLeft() {
+        let rows = CarPlayRows.continueListening(from: [item(id: "b1", title: "The Way of Kings")])
+
+        #expect(rows.count == 1)
+        #expect(rows[0].id == "b1")
+        #expect(rows[0].title == "The Way of Kings")
+        #expect(rows[0].detailText == "Brandon Sanderson • 12h 4m left")
+        #expect(rows[0].isPlayable)
+    }
+
+    /// A book with no remaining-time string still names its author rather than trailing a
+    /// separator into nothing.
+    @Test func aMissingTimeLeftLeavesNoDanglingSeparator() {
+        let rows = CarPlayRows.continueListening(from: [item(id: "b1", timeLeft: "")])
+
+        #expect(rows[0].detailText == "Brandon Sanderson")
+    }
+
+    @Test func aMissingAuthorFallsBackToTimeLeftAlone() {
+        let rows = CarPlayRows.continueListening(from: [item(id: "b1", author: "")])
+
+        #expect(rows[0].detailText == "12h 4m left")
+    }
+
+    /// Loading placeholders are skeleton cards on the phone. In a car they would be blank,
+    /// untappable rows, so they are dropped rather than rendered.
+    @Test func loadingPlaceholdersAreDropped() {
+        let rows = CarPlayRows.continueListening(from: [
+            item(id: "b1"),
+            loadingItem(id: "b2"),
+            item(id: "b3")
+        ])
+
+        #expect(rows.map(\.id) == ["b1", "b3"])
+    }
+
+    /// Mirrors Android Auto's `CONTINUE_LISTENING_LIMIT` — a curated shelf, not a truncated
+    /// library. Keeping the two surfaces at the same number is deliberate.
+    @Test func theShelfIsCappedAtTheCuratedLimit() {
+        let many = (1...20).map { item(id: "b\($0)") }
+
+        let rows = CarPlayRows.continueListening(from: many)
+
+        #expect(rows.count == CarPlayRows.continueListeningLimit)
+        #expect(CarPlayRows.continueListeningLimit == 8)
+        #expect(rows.first?.id == "b1")
+    }
+
+    /// The cap must apply to what a driver can actually see — dropping placeholders first, so a
+    /// shelf padded with in-flight items still offers eight real books.
+    @Test func theCapCountsRealBooksNotPlaceholders() {
+        let padded = (1...6).map { loadingItem(id: "loading\($0)") } + (1...10).map { item(id: "b\($0)") }
+
+        let rows = CarPlayRows.continueListening(from: padded)
+
+        #expect(rows.count == 8)
+        #expect(rows.first?.id == "b1")
+    }
+
+    @Test func anEmptyShelfProducesNoRows() {
+        #expect(CarPlayRows.continueListening(from: []).isEmpty)
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private func item(
+        id: String,
+        title: String = "A Book",
+        author: String = "Brandon Sanderson",
+        timeLeft: String = "12h 4m left"
+    ) -> ContinueItem {
+        ContinueItem(
+            id: id,
+            title: title,
+            author: author,
+            coverPath: nil,
+            coverHash: nil,
+            progress: 0.3,
+            progressPercent: 30,
+            timeLeft: timeLeft,
+            isLoading: false
+        )
+    }
+
+    private func loadingItem(id: String) -> ContinueItem {
+        ContinueItem(
+            id: id,
+            title: "",
+            author: "",
+            coverPath: nil,
+            coverHash: nil,
+            progress: 0,
+            progressPercent: 0,
+            timeLeft: "",
+            isLoading: true
+        )
+    }
+}

--- a/app/iosApp/ListenUpTests/SceneRoleRoutingTests.swift
+++ b/app/iosApp/ListenUpTests/SceneRoleRoutingTests.swift
@@ -1,3 +1,4 @@
+import CarPlay
 import Testing
 import UIKit
 @testable import ListenUp
@@ -12,12 +13,16 @@ import UIKit
 @Suite("SceneRoleRouting")
 struct SceneRoleRoutingTests {
     @Test func windowRoleUsesTheDefaultConfiguration() {
-        #expect(SceneRoleRouting.configurationName(for: .windowApplication) == SceneRoleRouting.defaultConfigurationName)
+        #expect(
+            SceneRoleRouting.configurationName(for: .windowApplication)
+                == SceneRoleRouting.defaultConfigurationName
+        )
     }
 
     @Test func carPlayRoleUsesTheCarPlayConfiguration() {
         #expect(
-            SceneRoleRouting.configurationName(for: .templateApplication) == SceneRoleRouting.carPlayConfigurationName
+            SceneRoleRouting.configurationName(for: .carTemplateApplication)
+                == SceneRoleRouting.carPlayConfigurationName
         )
     }
 
@@ -31,7 +36,7 @@ struct SceneRoleRoutingTests {
     /// failure than an unused window scene.
     @Test func anUnknownRoleFallsBackToTheDefaultConfiguration() {
         #expect(
-            SceneRoleRouting.configurationName(for: UISceneSession.Role("UIUnknownFutureRole"))
+            SceneRoleRouting.configurationName(for: UISceneSession.Role(rawValue: "UIUnknownFutureRole"))
                 == SceneRoleRouting.defaultConfigurationName
         )
     }

--- a/app/iosApp/ListenUpTests/SceneRoleRoutingTests.swift
+++ b/app/iosApp/ListenUpTests/SceneRoleRoutingTests.swift
@@ -1,0 +1,38 @@
+import Testing
+import UIKit
+@testable import ListenUp
+
+/// The app declares two scene roles once CarPlay exists: the SwiftUI window scene the phone
+/// shows, and the CarPlay template scene the head unit connects to. `configurationForConnecting`
+/// has to hand back the right one for each.
+///
+/// Worth pinning because the failure is silent. Returning the CarPlay configuration for the
+/// window role does not fail to build and does not throw — the phone app simply launches to a
+/// black screen, because SwiftUI never gets a window scene to put `RootView` in.
+@Suite("SceneRoleRouting")
+struct SceneRoleRoutingTests {
+    @Test func windowRoleUsesTheDefaultConfiguration() {
+        #expect(SceneRoleRouting.configurationName(for: .windowApplication) == SceneRoleRouting.defaultConfigurationName)
+    }
+
+    @Test func carPlayRoleUsesTheCarPlayConfiguration() {
+        #expect(
+            SceneRoleRouting.configurationName(for: .templateApplication) == SceneRoleRouting.carPlayConfigurationName
+        )
+    }
+
+    /// The two must never collide — a shared name would give one role the other's delegate.
+    @Test func theTwoConfigurationsAreDistinct() {
+        #expect(SceneRoleRouting.defaultConfigurationName != SceneRoleRouting.carPlayConfigurationName)
+    }
+
+    /// An unrecognised role (external display, a future Apple role) falls back to the window
+    /// configuration rather than the CarPlay one: a stray CarPlay template scene is a far worse
+    /// failure than an unused window scene.
+    @Test func anUnknownRoleFallsBackToTheDefaultConfiguration() {
+        #expect(
+            SceneRoleRouting.configurationName(for: UISceneSession.Role("UIUnknownFutureRole"))
+                == SceneRoleRouting.defaultConfigurationName
+        )
+    }
+}


### PR DESCRIPTION
CarPlay, now that the entitlement is granted (2026-08-05, type Audio). Plan: `docs/2026-08-06-carplay-implementation-plan.md`.

Two slices: the scene wiring, and the Home tab. Library and Search follow.

### The now-playing screen came for free

`CPNowPlayingTemplate.shared` renders straight from `MPNowPlayingInfoCenter` and `MPRemoteCommandCenter`, both of which `SystemIntegration` already keeps current and chapter-scoped as of #1252. The head unit gets the current chapter, its real duration and working transport controls without a line of CarPlay-specific playback code.

The corollary is now in `app/iosApp/CLAUDE.md`, whose "CarPlay: evaluate later" line was stale: **a car display bug gets fixed in `SystemIntegration`, never with a CarPlay-only patch** — the lock screen shares that code, and a local patch would just make the two surfaces disagree.

### The actual risk was scenes, not templates

`ListenUpApp` is a pure SwiftUI-lifecycle `App` and `Info.plist` had no `UIApplicationSceneManifest` at all. CarPlay needs a second scene role, and declaring any manifest changes how the main window scene resolves — get it wrong and the phone app launches to a black screen, with nothing in the build or the logs to say why.

So `SceneRoleRouting` is a pure function with its own tests, `AppDelegate` exists only to call it from `configurationForConnecting`, and the window role is declared with **no** delegate class so SwiftUI keeps that scene. Unknown roles default to the window configuration deliberately: an unused window scene is inert, a stray CarPlay scene is the black screen.

(The Swift name is `UISceneSession.Role.carTemplateApplication` — the ObjC global is now a hard "has been renamed" error.)

### Browse mirrors the phone, not Android Auto

The phone app is the mental model a driver already has, and per `app/iosApp/CLAUDE.md` rules 1–2 Android parity is a guide rather than a requirement. So the tab bar follows `MainTabView`: **Home** (continue listening) now, Library (Books/Series/Authors, per `LibraryTab`) and Search next.

**Discover is deliberately absent.** It is mostly a leaderboard and a friend activity feed — the wrong thing to put in front of someone driving, and driver distraction is exactly the axis the CarPlay entitlement is reviewed on.

Row mapping is a pure function with tests (the templates themselves are not unit-testable, so every real decision lives there): placeholders are dropped **before** the 8-item cap, so a shelf padded with in-flight items still offers eight real books; and the detail line joins author and remaining time, skipping whichever is missing rather than trailing a separator. Rows are native Swift values, not bridged Kotlin objects — same reason as the phone's `ForEach` rows (rule 8), since templates rebuild on every refresh.

An `.error` phase renders an untappable row carrying the message: a driver seeing an empty list cannot otherwise tell "nothing to resume" from "we failed to load".

### Verification

- `xcodebuild test` on kit (iPhone 17 sim, iOS 26.5): **555 passed, 0 failed**, including 11 new cases.
- **The phone app was installed and launched in the simulator** and renders normally. Tests would not catch a black screen — that failure is runtime scene resolution.
- `swiftlint` clean for the new files (kit runs 0.65.0 against CI's pinned 0.63.3).

### Not verified here

The CarPlay Simulator is an Xcode menu action and cannot be driven over ssh, so **the car-side render is unverified** — worth one manual check (Xcode ▸ I/O ▸ External Displays ▸ CarPlay). Signing is also unexercised: the entitlement is declared, but a signed build needs the provisioning profile regenerated after the grant propagates.

Depends on nothing; stacked on neither #1253 nor #1255.