### PR TITLE
🔥 chore(sharedUI): drop browse nodes for features we don't have

### DIFF
--- a/app/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/automotive/BrowseTreeMediaIdTest.kt
+++ b/app/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/automotive/BrowseTreeMediaIdTest.kt
@@ -25,6 +25,8 @@ class BrowseTreeMediaIdTest :
         test("the other browse prefixes are not book ids") {
             BrowseTree.extractBookId("${BrowseTree.PREFIX_SERIES}series-1") shouldBe null
             BrowseTree.extractBookId("${BrowseTree.PREFIX_AUTHOR}author-1") shouldBe null
-            BrowseTree.extractBookId("${BrowseTree.PREFIX_COLLECTION}collection-1") shouldBe null
+            // An unrecognised prefix must not be mistaken for a book id either — the guard is
+            // "starts with the book prefix", not "isn't one of the prefixes we know about".
+            BrowseTree.extractBookId("/__something_else__/thing-1") shouldBe null
         }
     })

--- a/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/automotive/BrowseTree.kt
+++ b/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/automotive/BrowseTree.kt
@@ -3,17 +3,18 @@ package com.calypsan.listenup.client.automotive
 /**
  * Constants for Android Auto browse tree media IDs.
  *
- * The browse tree structure:
+ * The browse tree structure — this is what [BrowseTreeProvider] actually serves, and the two
+ * are meant to stay in step. It previously also listed COLLECTIONS and BOOKMARKS nodes, which
+ * no code ever built: bookmarks are not a feature ListenUp has, and collections are an
+ * admin-side access-control mechanism rather than something to browse by in a car.
  * ```
  * ROOT
  * ├── RESUME (playable) - most recent in-progress book
- * ├── LIBRARY (browsable)
- * │   ├── RECENT - recently played books
- * │   ├── DOWNLOADED - offline-available books
- * │   ├── SERIES - series list
- * │   └── AUTHORS - author list
- * ├── COLLECTIONS (browsable, if any exist)
- * └── BOOKMARKS (browsable, if any exist)
+ * └── LIBRARY (browsable)
+ *     ├── RECENT - recently played books
+ *     ├── DOWNLOADED - offline-available books
+ *     ├── SERIES - series list
+ *     └── AUTHORS - author list
  * ```
  */
 object BrowseTree {
@@ -21,8 +22,6 @@ object BrowseTree {
     const val ROOT = "/__root__"
     const val RESUME = "/__resume__"
     const val LIBRARY = "/__library__"
-    const val COLLECTIONS = "/__collections__"
-    const val BOOKMARKS = "/__bookmarks__"
 
     // Library sub-nodes
     const val LIBRARY_RECENT = "/__library__/recent"
@@ -34,7 +33,6 @@ object BrowseTree {
     const val PREFIX_SERIES = "/__library__/series/"
     const val PREFIX_AUTHOR = "/__library__/authors/"
     const val PREFIX_BOOK = "/__book__/"
-    const val PREFIX_COLLECTION = "/__collections__/"
 
     /**
      * Extract book ID from a media ID.


### PR DESCRIPTION
`BrowseTree` declared `COLLECTIONS`, `BOOKMARKS` and `PREFIX_COLLECTION`, and its KDoc drew all three into the tree diagram. No code ever built any of them — `BrowseTreeProvider.getChildren` serves ROOT, LIBRARY, RECENT, DOWNLOADED, SERIES, AUTHORS and the dynamic series/author/book nodes, and nothing else. The only surviving reference was one test using `PREFIX_COLLECTION` as a sample non-book id.

They shouldn't come back:

- **Bookmarks are not a feature ListenUp has.** The node was aspirational.
- **Collections are an admin-side access-control mechanism**, not a browsing axis — surfacing them as a car browse node would misrepresent what they are.

Found while designing the CarPlay browse tree: the diagram was being read as the spec for what the car should offer, and it described an app that doesn't exist. A doc comment that outranks the code it documents is worse than no doc comment.

The test that used `PREFIX_COLLECTION` now asserts the same property against an arbitrary unrecognised prefix, which is what it was really checking — `extractBookId`'s guard is "starts with the book prefix", not "isn't one of the prefixes we know about".

`:app:sharedUI:testAndroidHostTest`, `spotlessCheck` and `detekt` green locally. (GitHub Actions is in a major outage as of this writing, so CI may not report.)