### PR TITLE
🐛 fix(shared): resume playback in seconds, not a minute, after a long idle

### DIFF
--- a/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/connection/ConnectionEvidence.kt
+++ b/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/connection/ConnectionEvidence.kt
@@ -2,9 +2,27 @@ package com.calypsan.listenup.client.data.connection
 
 import com.calypsan.listenup.api.error.TransportError
 import com.calypsan.listenup.api.result.AppResult
+import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.updateAndGet
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Consecutive transport failures before calls start running under [OPEN_CIRCUIT_BOUND]. Two, not
+ * one: a single blip must not degrade every subsequent call.
+ */
+internal const val CONSECUTIVE_FAILURES_TO_OPEN = 2
+
+/**
+ * Bound applied while the breaker is open. Generous next to a healthy LAN round-trip (~20ms) so an
+ * ordinary call still succeeds and closes the breaker, but a small fraction of the 15s default.
+ */
+internal val OPEN_CIRCUIT_BOUND = 2.seconds
+
+/** While open, every Nth call goes out at the caller's full bound — see `ConnectionEvidence.boundFor`. */
+internal const val PROBE_EVERY = 5
 
 /**
  * Process-wide sink for server-reachability evidence observed by the transports.
@@ -31,14 +49,52 @@ internal class ConnectionEvidence {
     val lastDownAt: StateFlow<Long?>
         field = MutableStateFlow<Long?>(null)
 
+    /**
+     * Consecutive transport-class failures with no answer in between. Drives [boundFor]; see the
+     * class KDoc for why evidence and gating live together.
+     */
+    private val consecutiveFailures = atomic(0)
+
+    /** Calls issued while the breaker is open — paces the full-bound probe in [boundFor]. */
+    private val callsWhileOpen = atomic(0)
+
     /** Record proof the server answered. */
     fun reportUp() {
+        consecutiveFailures.value = 0
+        callsWhileOpen.value = 0
         lastUpAt.value = clock.updateAndGet { it + 1 }
     }
 
     /** Record a network-class failure to reach the server. */
     fun reportDown() {
+        consecutiveFailures.incrementAndGet()
         lastDownAt.value = clock.updateAndGet { it + 1 }
+    }
+
+    /**
+     * The timeout a call should actually run under, given what the transport has just proved.
+     *
+     * Evidence used to be write-only: the engine recorded that the socket was dead and then
+     * committed the next caller to the full 15s bound anyway. That is where the 2026-08-07 resume
+     * stall got its length — the firehose watchdog had ALREADY declared the connection half-open
+     * before the listener ever tapped play.
+     *
+     * Two invariants matter here:
+     * - **Never lengthen.** A caller that asked for less than [OPEN_CIRCUIT_BOUND] asked for a
+     *   reason — the resume fetch's 800ms is a latency budget on the path to audio.
+     * - **Never refuse.** Calls still go out, just bounded shorter, so an ordinary call doubles as
+     *   the recovery probe: the server answering inside the short bound closes the breaker via
+     *   [reportUp]. The one case that needs help is a link too slow to answer inside the short
+     *   bound at all, so every [PROBE_EVERY]th call goes out at the caller's full bound rather than
+     *   letting the breaker latch open forever.
+     */
+    fun boundFor(requested: Duration): Duration {
+        if (consecutiveFailures.value < CONSECUTIVE_FAILURES_TO_OPEN) return requested
+        // incrementAndGet, not getAndIncrement: the FIRST call after opening must be short-bounded.
+        // Handing it the probe slot would waste the full bound on exactly the call the breaker
+        // exists to protect — the next one after we just learned the socket is dead.
+        val isProbe = callsWhileOpen.incrementAndGet() % PROBE_EVERY == 0
+        return if (isProbe) requested else minOf(requested, OPEN_CIRCUIT_BOUND)
     }
 
     /**

--- a/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/RpcChannel.kt
+++ b/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/remote/RpcChannel.kt
@@ -131,8 +131,14 @@ internal class RpcChannel<S : Any> internal constructor(
         idempotent: Boolean = false,
         block: suspend (S) -> AppResult<T>,
     ): AppResult<T> =
-        catchingRpcResult { dispatch.call(timeout, idempotent) { service -> block(service) } }
-            .also { evidence?.recordOutcome(it) }
+        // The evidence sink is also the gate: when recent calls have proved the transport dead,
+        // boundFor collapses this call's timeout instead of committing the caller to the full
+        // bound on a socket we already know is not answering. One shared ConnectionEvidence means
+        // every channel — search, sync, admin, auth, playback — inherits this with no per-service
+        // wiring, which is the whole point of dispatching through one boundary.
+        catchingRpcResult {
+            dispatch.call(evidence?.boundFor(timeout) ?: timeout, idempotent) { service -> block(service) }
+        }.also { evidence?.recordOutcome(it) }
 
     /**
      * Run a mutation that returns a [Mutated] envelope, apply the sync frames it carries, and hand

--- a/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/PlaybackPositionRepositoryImpl.kt
+++ b/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/PlaybackPositionRepositoryImpl.kt
@@ -225,7 +225,11 @@ internal class PlaybackPositionRepositoryImpl(
                     RecordPositionRequest(
                         bookId = bookId.value,
                         positionMs = update.positionMs,
-                        lastPlayedAt = now,
+                        // The row's own value, which handlePlaybackStarted deliberately left at the
+                        // last REAL listening (see there). Sending `now` would push a stale position
+                        // as globally-newest and discard another device's newer progress. `?: now`
+                        // only covers the never-played row, where blank() has already stamped now.
+                        lastPlayedAt = entity?.lastPlayedAt ?: now,
                         finished = entity?.isFinished ?: false,
                         playbackSpeed = update.speed,
                         currentChapterId = null,
@@ -379,7 +383,12 @@ internal class PlaybackPositionRepositoryImpl(
                 positionMs = u.positionMs,
                 playbackSpeed = u.speed,
                 startedAt = existing.startedAt ?: now, // preserve original startedAt if set
-                lastPlayedAt = now,
+                // NOT `now`. lastPlayedAt is the conflict key, so writing it claims "this is the
+                // newest truth about where the listener is" — and starting playback is not that.
+                // Stamping here made a locally-stale row instantly outrank newer progress from
+                // another device that catch-up had not yet delivered. The claim belongs to the
+                // writes that follow from real listening (periodic at 30s, and pause).
+                lastPlayedAt = existing.lastPlayedAt,
                 updatedAt = now,
                 syncedAt = null,
             ) ?: blank(bookId, now).copy(

--- a/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/PlaybackPrepareRepositoryImpl.kt
+++ b/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/repository/PlaybackPrepareRepositoryImpl.kt
@@ -7,6 +7,7 @@ import com.calypsan.listenup.api.sync.PlaybackPositionSyncPayload
 import com.calypsan.listenup.client.data.remote.RpcChannel
 import com.calypsan.listenup.client.domain.repository.PlaybackPrepareRepository
 import com.calypsan.listenup.core.BookId
+import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * Routes [prepare] through the bounded, single-flight, self-healing [RpcChannel] — the one dispatch
@@ -19,7 +20,24 @@ internal class PlaybackPrepareRepositoryImpl(
 ) : PlaybackPrepareRepository {
     override suspend fun prepare(bookId: BookId): AppResult<PreparedPlayback> = channel.call { it.prepare(bookId) }
 
-    // idempotent read — safe for the channel to retry / single-flight.
+    /**
+     * Bounded SHORT and never retried, because this call sits between a listener tapping play and
+     * hearing anything.
+     *
+     * It ran on the 15s channel default with `idempotent = true`, which licensed
+     * [com.calypsan.listenup.client.data.remote.RpcProxyCache] to re-fire on timeout — so a
+     * half-open socket cost 15s + 15s and a fully-downloaded book took 30 seconds to start.
+     *
+     * A healthy socket answers in ~20ms, so the resume point is still server-correct in the case
+     * that matters. A degraded one gives up here and resume falls back to the local Room row, which
+     * is survivable in a way waiting is not: starting playback no longer claims position authority,
+     * so a stale local row can no longer discard another device's progress.
+     */
     override suspend fun getPosition(bookId: BookId): AppResult<PlaybackPositionSyncPayload?> =
-        channel.call(idempotent = true) { it.getPosition(bookId) }
+        channel.call(timeout = RESUME_POSITION_FETCH_BOUND, idempotent = false) { it.getPosition(bookId) }
+
+    private companion object {
+        /** Latency budget for the resume reconcile — see [getPosition]. */
+        private val RESUME_POSITION_FETCH_BOUND = 800.milliseconds
+    }
 }

--- a/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/ClientSyncDomainRegistry.kt
+++ b/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/data/sync/ClientSyncDomainRegistry.kt
@@ -1,5 +1,6 @@
 package com.calypsan.listenup.client.data.sync
 
+import com.calypsan.listenup.api.sync.SyncDomains
 import kotlinx.atomicfu.locks.SynchronizedObject
 import kotlinx.atomicfu.locks.synchronized
 
@@ -42,11 +43,36 @@ internal class ClientSyncDomainRegistry : SynchronizedObject() {
             handlers[domainName]
         }
 
-    /** All registered domain names, sorted alphabetically for stable iteration. */
+    /**
+     * All registered domain names in catch-up order: [CATCH_UP_PRIORITY] first, then everything
+     * else alphabetically. Deterministic either way, so iteration stays stable.
+     *
+     * Order here is latency, not cosmetics. [SyncCatchUpClient.catchUpAll] walks this list
+     * **strictly sequentially**, one full round-trip per domain, so a domain's position is how
+     * long it waits to become correct.
+     */
     fun registeredDomains(): List<String> =
         synchronized(this) {
-            handlers.keys.sorted()
+            val prioritised = CATCH_UP_PRIORITY.filter { it in handlers }
+            prioritised + (handlers.keys - prioritised.toSet()).sorted()
         }
+
+    private companion object {
+        /**
+         * Domains that gate a correctness decision and must not queue behind decoration.
+         *
+         * `playback_positions` decides **where a book resumes**. Plain alphabetical order put it
+         * ~14th of 22, behind `activities`, `admin_user_roster`, `book_moods`, `book_tags` and the
+         * rest — purely because "p" sorts late. Until it lands, opening a book on a second device
+         * resolves against a stale local row, which is exactly the race the resume reconcile has
+         * to defend against; catching it up first means the reconcile usually has nothing to
+         * correct.
+         *
+         * Keep this list short. A domain belongs here only if being stale makes the app *wrong*,
+         * not merely out of date.
+         */
+        private val CATCH_UP_PRIORITY = listOf(SyncDomains.PLAYBACK_POSITIONS.name)
+    }
 
     /**
      * The registered handlers whose domain is access-gated (those implementing

--- a/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/CachedAudioTokenProvider.kt
+++ b/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/CachedAudioTokenProvider.kt
@@ -48,8 +48,12 @@ private val PROACTIVE_CHECK_CADENCE = 5.minutes
  * interface via delegation.
  *
  * Threading: the cached fields are `@Volatile` so [getToken] never blocks an
- * OkHttp dispatcher / URLSession thread. The refresh path serialises through
- * a [Mutex] so concurrent triggers (init, proactive loop, on-401) coalesce.
+ * OkHttp dispatcher / URLSession thread. The refresh path serialises through a
+ * [Mutex]. Serialising is not the same as coalescing, and the difference is
+ * load-bearing: [prepareForPlayback] re-checks the cache *after* taking the lock
+ * and adopts whatever an in-flight refresh produced, while [refreshToken] always
+ * rotates. Without that re-check every waiter ran its own full round-trip, which
+ * on a half-open socket is the 15s RPC bound each — the resume-latency bug.
  *
  * Concurrency note: this is a *separate* refresh authority from the Ktor
  * bearer plugin. Both write to [AuthSession.saveAuthTokens]. When two
@@ -94,39 +98,60 @@ class CachedAudioTokenProvider(
     override fun getToken(): String? = cachedToken?.value
 
     override suspend fun prepareForPlayback() {
-        if (cachedToken != null &&
-            tokenExpiresAt - now() > PREPARE_PLAYBACK_FAST_PATH.inWholeMilliseconds
-        ) {
-            return
+        if (hasUsableToken()) return
+        refreshMutex.withLock {
+            // Re-check under the lock. A refresh that landed while we waited has already produced a
+            // usable token — or installed the stored-token fallback — so firing our own would only
+            // queue a second full round-trip behind the first. On a half-open socket each one costs
+            // the entire 15s RPC bound, which is how a resume after a long idle spent 24s here
+            // before playing a book that was already downloaded.
+            if (hasUsableToken()) return
+            performRefresh()
         }
-        refreshToken()
     }
 
     /**
-     * Refreshes the cached token, blocking on the [refreshMutex] so concurrent
-     * triggers coalesce. Public because it's the synchronous seam for OkHttp's
-     * [okhttp3.Authenticator] contract — the Android Authenticator wraps this
-     * in `runBlocking` to satisfy OkHttp's blocking-thread expectation while
-     * still routing through the shared refresh path used by the proactive loop
-     * and `prepareForPlayback`. On success, [getToken] returns the new token;
-     * on failure, [fallbackToStored] surfaces whatever's in [AuthSession].
+     * Whether the cache holds a token with enough life left to start playback on — the shared
+     * predicate behind [prepareForPlayback]'s fast path and its re-check under the lock.
+     */
+    private fun hasUsableToken(): Boolean =
+        cachedToken != null &&
+            tokenExpiresAt - now() > PREPARE_PLAYBACK_FAST_PATH.inWholeMilliseconds
+
+    /**
+     * Force a token rotation, serialising on [refreshMutex]. Callers that merely need a *usable*
+     * token should use [prepareForPlayback], which coalesces onto an in-flight refresh instead;
+     * this entry point is for callers that know the cached token is bad (a 401) or due (the
+     * proactive loop), where re-checking the cache would defeat the point.
+     *
+     * The mutex **serialises — it does not dedupe.** Two forced rotations queue, and each performs
+     * its own upstream refresh; single-flight dedup of the rotation RPC itself lives one layer down,
+     * in [AuthRepository.refreshAccessToken].
+     *
+     * Public because it's the synchronous seam for OkHttp's [okhttp3.Authenticator] contract — the
+     * Android Authenticator wraps this in `runBlocking` to satisfy OkHttp's blocking-thread
+     * expectation while still routing through the shared refresh path. On success, [getToken]
+     * returns the new token; on failure, [fallbackToStored] surfaces whatever's in [AuthSession].
      */
     suspend fun refreshToken() {
-        refreshMutex.withLock {
-            when (val result = authRepository.refreshAccessToken()) {
-                is AppResult.Success -> {
-                    // Persistence already happened inside the single-flight refresh (C1); here we only
-                    // update this provider's in-memory cache so getToken() serves the fresh token.
-                    val session = result.data
-                    cachedToken = session.accessToken
-                    tokenExpiresAt = session.accessTokenExpiresAt
-                    logger.info { "Token refreshed successfully" }
-                }
+        refreshMutex.withLock { performRefresh() }
+    }
 
-                is AppResult.Failure -> {
-                    logger.warn { "Token refresh failed (${result.error}), falling back to stored" }
-                    fallbackToStored()
-                }
+    /** Rotate the token and cache it, or fall back to stored. Caller holds [refreshMutex]. */
+    private suspend fun performRefresh() {
+        when (val result = authRepository.refreshAccessToken()) {
+            is AppResult.Success -> {
+                // Persistence already happened inside the single-flight refresh (C1); here we only
+                // update this provider's in-memory cache so getToken() serves the fresh token.
+                val session = result.data
+                cachedToken = session.accessToken
+                tokenExpiresAt = session.accessTokenExpiresAt
+                logger.info { "Token refreshed successfully" }
+            }
+
+            is AppResult.Failure -> {
+                logger.warn { "Token refresh failed (${result.error}), falling back to stored" }
+                fallbackToStored()
             }
         }
     }

--- a/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackPreparer.kt
+++ b/app/sharedLogic/src/commonMain/kotlin/com/calypsan/listenup/client/playback/PlaybackPreparer.kt
@@ -356,13 +356,19 @@ class PlaybackPreparer internal constructor(
     }
 
     /**
-     * Best-effort, non-blocking fetch of the server-authoritative resume position for the
-     * fully-downloaded path (where [buildTimeline] skips `prepare()` and never sees it).
+     * Fetch the server-authoritative resume position for the fully-downloaded path (where
+     * [buildTimeline] skips `prepare()` and never sees it).
      *
-     * Routed through the bounded, self-healing [PlaybackPrepareRepository] so a dead-socket transport
-     * fault surfaces as a typed, time-bounded [AppResult.Failure] rather than an exception. On ANY
-     * failure — offline, RPC error — it returns null so resume resolves from the local Room row
-     * exactly as before: it never blocks or fails playback.
+     * **This DOES block — it is awaited, on the path between tapping play and hearing audio.** An
+     * earlier version of this KDoc claimed it was "non-blocking"; it never was, and that sentence
+     * is why a 30-second stall hid here in plain sight (15s bound + 15s idempotent retry on a
+     * half-open socket). The honest statement is that it is bounded SHORT — see
+     * [PlaybackPrepareRepository.getPosition] — so the cost is sub-second even when the socket is
+     * dead, and any failure returns null so resume resolves from the local Room row.
+     *
+     * If you are tempted to widen that bound, note what it buys: only a resume point that is
+     * server-fresher than Room. Losing it starts the listener a little behind; waiting for it
+     * starts them in silence.
      */
     private suspend fun fetchAuthoritativePosition(bookId: BookId): PlaybackPositionSyncPayload? =
         when (val result = prepareRepository.getPosition(bookId)) {

--- a/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/connection/ConnectionBreakerTest.kt
+++ b/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/connection/ConnectionBreakerTest.kt
@@ -1,0 +1,125 @@
+package com.calypsan.listenup.client.data.connection
+
+import com.calypsan.listenup.api.error.AuthError
+import com.calypsan.listenup.api.error.TransportError
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.client.data.remote.RpcChannel
+import com.calypsan.listenup.client.data.remote.RpcDispatch
+import com.calypsan.listenup.client.data.remote.RpcPolicy
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.runTest
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * The transport already KNOWS when it is dead — [ConnectionEvidence] classifies every unary outcome
+ * at the [com.calypsan.listenup.client.data.remote.RpcChannel] boundary. Until now it was a pure
+ * sink: nothing consulted it before committing a caller to a 15-second wait.
+ *
+ * That is how the 2026-08-07 resume stall got its length. The firehose watchdog had already logged
+ * "silent for 75000ms — treating as half-open" at 08:32:28.972, and the app then issued call after
+ * call, each paying the full bound, for another minute.
+ *
+ * The breaker is deliberately NOT a classic open/half-open state machine. Calls are never refused —
+ * they are merely bounded shorter, which means an ordinary call IS the probe: if the server is back,
+ * it answers inside the short bound and the breaker closes on the success. The only case that needs
+ * explicit help is a link slow enough that every short-bounded call times out, so every Nth call
+ * while open goes out at the caller's full bound.
+ */
+class ConnectionBreakerTest :
+    FunSpec({
+
+        fun transportFailure() = AppResult.Failure(TransportError.Timeout())
+
+        test("a healthy channel gets the caller's bound untouched") {
+            val evidence = ConnectionEvidence()
+
+            evidence.recordOutcome(AppResult.Success(Unit))
+
+            evidence.boundFor(15.seconds) shouldBe 15.seconds
+        }
+
+        test("consecutive transport failures collapse the bound") {
+            val evidence = ConnectionEvidence()
+
+            repeat(CONSECUTIVE_FAILURES_TO_OPEN) { evidence.recordOutcome(transportFailure()) }
+
+            evidence.boundFor(15.seconds) shouldBe OPEN_CIRCUIT_BOUND
+        }
+
+        test("a single failure is not enough — one blip must not degrade every call") {
+            val evidence = ConnectionEvidence()
+
+            evidence.recordOutcome(transportFailure())
+
+            evidence.boundFor(15.seconds) shouldBe 15.seconds
+        }
+
+        test("any answer from the server re-closes the breaker") {
+            val evidence = ConnectionEvidence()
+            repeat(CONSECUTIVE_FAILURES_TO_OPEN) { evidence.recordOutcome(transportFailure()) }
+
+            // Not a success — an auth rejection. It still proves the server ANSWERED.
+            evidence.recordOutcome(AppResult.Failure(AuthError.SessionExpired()))
+
+            evidence.boundFor(15.seconds) shouldBe 15.seconds
+        }
+
+        test("the breaker never lengthens a caller's shorter bound") {
+            val evidence = ConnectionEvidence()
+            repeat(CONSECUTIVE_FAILURES_TO_OPEN) { evidence.recordOutcome(transportFailure()) }
+
+            // The resume-position fetch asks for 800ms precisely because it is on the path to audio.
+            // An open breaker must not hand it something longer.
+            evidence.boundFor(800.milliseconds) shouldBe 800.milliseconds
+        }
+
+        test("the breaker is applied at the RpcChannel boundary, so EVERY service inherits it") {
+            runTest {
+                val evidence = ConnectionEvidence()
+                repeat(CONSECUTIVE_FAILURES_TO_OPEN) { evidence.recordOutcome(transportFailure()) }
+                val dispatch = BoundRecordingDispatch()
+                // Deliberately not a real service: the guarantee is a property of the boundary, not
+                // of any one @Rpc interface. One shared ConnectionEvidence + one dispatch path means
+                // search, sync, admin, auth and playback all inherit this with no per-service wiring.
+                val channel = RpcChannel(dispatch, RpcPolicy.Authed, evidence = evidence)
+
+                channel.call { AppResult.Success(Unit) }
+
+                dispatch.lastTimeout shouldBe OPEN_CIRCUIT_BOUND
+            }
+        }
+
+        test("every Nth call while open probes at the full bound, so a merely-slow link recovers") {
+            val evidence = ConnectionEvidence()
+            repeat(CONSECUTIVE_FAILURES_TO_OPEN) { evidence.recordOutcome(transportFailure()) }
+
+            val bounds = List(PROBE_EVERY * 2) { evidence.boundFor(15.seconds) }
+
+            // Without this, a link whose RTT exceeds OPEN_CIRCUIT_BOUND could never answer in time,
+            // so the breaker would latch open forever and the app would look permanently offline.
+            bounds.count { it == 15.seconds } shouldBe 2
+        }
+    })
+
+/** Records the timeout the channel actually handed down, for the boundary-wiring test. */
+private class BoundRecordingDispatch : RpcDispatch<Unit> {
+    var lastTimeout: Duration? = null
+
+    override suspend fun <R> call(
+        timeout: Duration,
+        idempotent: Boolean,
+        block: suspend (Unit) -> R,
+    ): R {
+        lastTimeout = timeout
+        return block(Unit)
+    }
+
+    override fun <R> streaming(subscribe: suspend (Unit) -> Flow<R>): Flow<R> = emptyFlow()
+
+    override suspend fun invalidate() = Unit
+}

--- a/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/ResumePositionFetchBoundTest.kt
+++ b/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/ResumePositionFetchBoundTest.kt
@@ -95,13 +95,11 @@ private class RecordingDispatch<S : Any>(
 
 /** Minimal [PlaybackService] stand-in — the tests assert on dispatch policy, not on payloads. */
 private object NoOpPlaybackService : PlaybackService {
-    override suspend fun prepare(bookId: BookId): AppResult<PreparedPlayback> =
-        AppResult.Success(PreparedPlayback(bookId = bookId.value, audioFiles = emptyList(), resumePosition = null))
+    override suspend fun prepare(bookId: BookId): AppResult<PreparedPlayback> = AppResult.Success(PreparedPlayback(bookId = bookId.value, audioFiles = emptyList(), resumePosition = null))
 
     override suspend fun getPosition(bookId: BookId): AppResult<PlaybackPositionSyncPayload?> = AppResult.Success(null)
 
-    override suspend fun recordPosition(request: RecordPositionRequest): AppResult<PlaybackPositionSyncPayload> =
-        throw NotImplementedError()
+    override suspend fun recordPosition(request: RecordPositionRequest): AppResult<PlaybackPositionSyncPayload> = throw NotImplementedError()
 
     override suspend fun getStats(): AppResult<UserStatsSyncPayload?> = throw NotImplementedError()
 

--- a/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/ResumePositionFetchBoundTest.kt
+++ b/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/repository/ResumePositionFetchBoundTest.kt
@@ -1,0 +1,111 @@
+package com.calypsan.listenup.client.data.repository
+
+import com.calypsan.listenup.api.PlaybackService
+import com.calypsan.listenup.api.dto.PreparedPlayback
+import com.calypsan.listenup.api.dto.RecordListeningEventRequest
+import com.calypsan.listenup.api.dto.RecordPositionRequest
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.api.sync.ListeningEventSyncPayload
+import com.calypsan.listenup.api.sync.PlaybackPositionSyncPayload
+import com.calypsan.listenup.api.sync.UserStatsSyncPayload
+import com.calypsan.listenup.client.data.remote.DEFAULT_RPC_TIMEOUT
+import com.calypsan.listenup.client.data.remote.RpcChannel
+import com.calypsan.listenup.client.data.remote.RpcDispatch
+import com.calypsan.listenup.client.data.remote.RpcPolicy
+import com.calypsan.listenup.core.BookId
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.runTest
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * The resume-position fetch sits between a listener tapping play and hearing anything, so its
+ * timeout is a latency budget, not a reliability knob.
+ *
+ * On 2026-08-07 it ran on the channel default (15s) AND declared itself idempotent, so a half-open
+ * socket cost 15s plus a 15s retry — **30 seconds of silence before a fully-downloaded book began
+ * to play**. Its own KDoc claimed it "never blocks or fails playback"; it was an awaited suspend
+ * call in the middle of the critical path.
+ *
+ * It is now bounded short and never retried. A healthy socket answers in ~20ms so the resume point
+ * is still server-correct; a degraded one gives up quickly and resumes from the local Room row.
+ * Losing the reconcile is survivable — starting playback no longer claims position authority
+ * (`PlaybackStartedAuthorityTest`), so a stale local row can no longer discard another device's
+ * progress. Waiting was the only unsurvivable option.
+ */
+class ResumePositionFetchBoundTest :
+    FunSpec({
+
+        test("getPosition is bounded well under a second and never retries") {
+            runTest {
+                val dispatch = RecordingDispatch<PlaybackService>(NoOpPlaybackService)
+                val repo = PlaybackPrepareRepositoryImpl(RpcChannel(dispatch, RpcPolicy.Authed))
+
+                repo.getPosition(BookId("book-1"))
+
+                val bound = dispatch.lastTimeout
+                withClue("resume fetch must stay inside the playback-start budget") {
+                    (bound != null && bound <= 1.seconds) shouldBe true
+                }
+                // idempotent=true would license RpcProxyCache to re-fire on a timeout, doubling the
+                // bound. For a read whose failure degrades to the local row, one attempt is enough.
+                dispatch.lastIdempotent shouldBe false
+            }
+        }
+
+        test("prepare keeps the full default bound — its result is required, not optional") {
+            runTest {
+                val dispatch = RecordingDispatch<PlaybackService>(NoOpPlaybackService)
+                val repo = PlaybackPrepareRepositoryImpl(RpcChannel(dispatch, RpcPolicy.Authed))
+
+                repo.prepare(BookId("book-1"))
+
+                // Unlike getPosition, prepare() returns the signed streaming URLs. There is no local
+                // fallback for a book that is not downloaded, so cutting it short would strand it.
+                dispatch.lastTimeout shouldBe DEFAULT_RPC_TIMEOUT
+            }
+        }
+    })
+
+/** Records the dispatch policy each call was issued under, then delegates to the service. */
+private class RecordingDispatch<S : Any>(
+    private val service: S,
+) : RpcDispatch<S> {
+    var lastTimeout: Duration? = null
+    var lastIdempotent: Boolean? = null
+
+    override suspend fun <R> call(
+        timeout: Duration,
+        idempotent: Boolean,
+        block: suspend (S) -> R,
+    ): R {
+        lastTimeout = timeout
+        lastIdempotent = idempotent
+        return block(service)
+    }
+
+    override fun <R> streaming(subscribe: suspend (S) -> Flow<R>): Flow<R> = emptyFlow()
+
+    override suspend fun invalidate() = Unit
+}
+
+/** Minimal [PlaybackService] stand-in — the tests assert on dispatch policy, not on payloads. */
+private object NoOpPlaybackService : PlaybackService {
+    override suspend fun prepare(bookId: BookId): AppResult<PreparedPlayback> =
+        AppResult.Success(PreparedPlayback(bookId = bookId.value, audioFiles = emptyList(), resumePosition = null))
+
+    override suspend fun getPosition(bookId: BookId): AppResult<PlaybackPositionSyncPayload?> = AppResult.Success(null)
+
+    override suspend fun recordPosition(request: RecordPositionRequest): AppResult<PlaybackPositionSyncPayload> =
+        throw NotImplementedError()
+
+    override suspend fun getStats(): AppResult<UserStatsSyncPayload?> = throw NotImplementedError()
+
+    override suspend fun recordListeningEvent(
+        request: RecordListeningEventRequest,
+    ): AppResult<ListeningEventSyncPayload> = throw NotImplementedError()
+}

--- a/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/ClientSyncDomainRegistryTest.kt
+++ b/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/data/sync/ClientSyncDomainRegistryTest.kt
@@ -50,6 +50,25 @@ class ClientSyncDomainRegistryTest :
             registry.registeredDomains() shouldContainExactlyInAnyOrder listOf("alpha", "mu", "zeta")
         }
 
+        test("playback_positions catches up first, ahead of alphabetically-earlier decoration") {
+            val registry = ClientSyncDomainRegistry()
+            // Registration order deliberately does not favour playback_positions.
+            listOf("activities", "admin_user_roster", "book_moods", "book_tags", "playback_positions", "tags")
+                .forEach { registry.register(handler(it)) }
+
+            // Catch-up is strictly sequential and each domain costs a full round-trip, so position
+            // in this list is latency. playback_positions decides WHERE A BOOK RESUMES; plain
+            // alphabetical order queued it behind four domains of decoration.
+            registry.registeredDomains().first() shouldBe "playback_positions"
+        }
+
+        test("domains with no declared priority stay alphabetical after the prioritised ones") {
+            val registry = ClientSyncDomainRegistry()
+            listOf("zeta", "alpha", "playback_positions", "mu").forEach { registry.register(handler(it)) }
+
+            registry.registeredDomains() shouldBe listOf("playback_positions", "alpha", "mu", "zeta")
+        }
+
         test("re-registering the same instance for the same domain is idempotent") {
             val registry = ClientSyncDomainRegistry()
             val h = handler("tags")

--- a/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/playback/CachedAudioTokenProviderTest.kt
+++ b/app/sharedLogic/src/commonTest/kotlin/com/calypsan/listenup/client/playback/CachedAudioTokenProviderTest.kt
@@ -39,16 +39,18 @@ import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 
 /**
- * Characterization suite for [CachedAudioTokenProvider]. Pins the current
- * behavior of the shared streaming-token authority under virtual time:
- * init refresh + persistence, the [prepareForPlayback] fast path, mutex
- * serialization of concurrent refreshes (WITHOUT dedup — see test 4), the
- * stored-token grace fallback, the proactive expiry loop, and the awaited
+ * Suite for [CachedAudioTokenProvider], driven under virtual time: init refresh
+ * + persistence, the [prepareForPlayback] fast path, the stored-token grace
+ * fallback, the proactive expiry loop, and the awaited
  * [CachedAudioTokenProvider.refreshToken] path.
  *
- * This is characterization, not verification of "correct" behavior — if a
- * test surfaces a real bug, that's a signal for a follow-up plan, not a
- * license to change production behavior here.
+ * Mostly characterization, with one regression test. The characterization noted
+ * that concurrent refreshes serialize WITHOUT dedup (test 4) and left that as a
+ * signal for a follow-up plan; the follow-up found it on the critical path to
+ * audio, where each serialized waiter paid the full 15s RPC bound on a half-open
+ * socket. "prepareForPlayback coalesces onto an in-flight refresh" pins the fix.
+ * Test 4 still holds — [CachedAudioTokenProvider.refreshToken] is a *forced*
+ * rotation and deliberately still does not dedupe.
  */
 class CachedAudioTokenProviderTest :
     FunSpec({
@@ -146,6 +148,39 @@ class CachedAudioTokenProviderTest :
                 // down, in AuthRepositoryImpl.refreshAccessToken (lines 47-83), not
                 // in this class.
                 repo.calls shouldBe 4
+            }
+        }
+
+        test("prepareForPlayback coalesces onto an in-flight refresh instead of serialising its own") {
+            runTest {
+                val clock = VirtualClock(testScheduler)
+                val repo =
+                    FakeAudioAuthRepository {
+                        delay(1.seconds)
+                        AppResult.Failure(AuthError.SessionExpired())
+                    }
+                val storage = FakeStorageAuthSession(stored = AccessToken("stored"))
+                val provider = CachedAudioTokenProvider(storage, repo, backgroundScope, clock)
+
+                // init's refresh is parked inside the 1s delay, holding refreshMutex.
+                runCurrent()
+                repo.calls shouldBe 1
+
+                // The play tap lands while that refresh is still in flight. Launch it in the
+                // FOREGROUND scope (see test 4) and let it reach the mutex and park.
+                launch { provider.prepareForPlayback() }
+                runCurrent()
+
+                // init's refresh completes and releases the mutex; the tap then proceeds.
+                advanceTimeBy(2.seconds)
+                advanceUntilIdle()
+
+                // It must adopt whatever the in-flight refresh installed — here the stored-token
+                // fallback — NOT queue a second full round-trip behind it. On a half-open socket
+                // each round-trip costs the full 15s RPC bound, and two of them serialised are
+                // 24s of the 54s tap-to-audio delay reproduced on 2026-08-07.
+                repo.calls shouldBe 1
+                provider.getToken() shouldBe "stored"
             }
         }
 

--- a/app/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/PlaybackStartedAuthorityTest.kt
+++ b/app/sharedLogic/src/jvmTest/kotlin/com/calypsan/listenup/client/data/repository/PlaybackStartedAuthorityTest.kt
@@ -1,0 +1,123 @@
+package com.calypsan.listenup.client.data.repository
+
+import com.calypsan.listenup.api.contractJson
+import com.calypsan.listenup.api.dto.RecordPositionRequest
+import com.calypsan.listenup.api.result.AppResult
+import com.calypsan.listenup.client.data.local.db.ListenUpDatabase
+import com.calypsan.listenup.client.data.local.db.PlaybackPositionEntity
+import com.calypsan.listenup.client.data.local.db.RoomTransactionRunner
+import com.calypsan.listenup.client.data.sync.PendingOperationQueue
+import com.calypsan.listenup.client.domain.repository.PlaybackUpdate
+import com.calypsan.listenup.client.test.db.createInMemoryTestDatabase
+import com.calypsan.listenup.client.test.fake.FakeAuthSession
+import com.calypsan.listenup.core.BookId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.longs.shouldBeGreaterThan
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+
+/**
+ * `lastPlayedAt` is the conflict key for the `playback_positions` domain — whichever side carries
+ * the greater value wins, on this device and on the server. So writing it means claiming "this is
+ * the most recent truth about where the listener is."
+ *
+ * Starting playback is not that claim. It is evidence the listener OPENED a book, not that they
+ * heard any of it. Stamping `lastPlayedAt = now` at start made a locally-stale row instantly the
+ * newest thing in the system, which is how opening a book on a second device — before its
+ * playback-positions catch-up had drained — could permanently discard newer progress made
+ * elsewhere. The 2026-08-07 resume-latency investigation found the synchronous server-position
+ * fetch existed to defend against exactly this write.
+ *
+ * The claim is made by the writes that follow from real listening: the periodic save (30s in) and
+ * the pause save. A start that never becomes listening — audio focus refused, app killed at once —
+ * now claims nothing, which is the truth.
+ *
+ * A never-played book is the exception: there is no prior value to preserve and it must surface in
+ * Continue Listening, so the fresh row stamps `now`.
+ */
+class PlaybackStartedAuthorityTest :
+    FunSpec({
+
+        val bookId = BookId("book-1")
+
+        fun playedEntity() =
+            PlaybackPositionEntity(
+                bookId = bookId,
+                positionMs = 90_000L,
+                playbackSpeed = 1.25f,
+                hasCustomSpeed = true,
+                updatedAt = 1_000L,
+                syncedAt = 1_000L,
+                lastPlayedAt = 1_000L,
+                isFinished = false,
+                finishedAt = null,
+                startedAt = 500L,
+            )
+
+        fun repoAgainst(db: ListenUpDatabase): PlaybackPositionRepositoryImpl =
+            PlaybackPositionRepositoryImpl(
+                dao = db.playbackPositionDao(),
+                transactionRunner = RoomTransactionRunner(db),
+                pendingQueue =
+                    PendingOperationQueue(
+                        dao = db.pendingOperationV2Dao(),
+                        sender = { AppResult.Success(Unit) },
+                    ),
+                authSession = FakeAuthSession(userId = "u1"),
+            )
+
+        suspend fun singleQueuedRequest(db: ListenUpDatabase): RecordPositionRequest {
+            val ops = db.pendingOperationV2Dao().observePending().first()
+            ops shouldHaveSize 1
+            return contractJson.decodeFromString(RecordPositionRequest.serializer(), ops.single().payload)
+        }
+
+        test("PlaybackStarted preserves the existing lastPlayedAt in Room") {
+            runTest {
+                val db = createInMemoryTestDatabase()
+                db.playbackPositionDao().save(playedEntity())
+
+                repoAgainst(db).savePlaybackState(
+                    bookId = bookId,
+                    update = PlaybackUpdate.PlaybackStarted(positionMs = 95_000L, speed = 1.25f),
+                )
+
+                val row = db.playbackPositionDao().get(bookId).shouldNotBeNull()
+                // The position moved — we did start playing there...
+                row.positionMs shouldBe 95_000L
+                // ...but authority did not, because nothing has been listened to yet.
+                row.lastPlayedAt shouldBe 1_000L
+            }
+        }
+
+        test("PlaybackStarted pushes the preserved lastPlayedAt, so a stale row cannot outrank the server") {
+            runTest {
+                val db = createInMemoryTestDatabase()
+                db.playbackPositionDao().save(playedEntity())
+
+                repoAgainst(db).savePlaybackState(
+                    bookId = bookId,
+                    update = PlaybackUpdate.PlaybackStarted(positionMs = 95_000L, speed = 1.25f),
+                )
+
+                singleQueuedRequest(db).lastPlayedAt shouldBe 1_000L
+            }
+        }
+
+        test("a never-played book stamps now, so it still surfaces in Continue Listening") {
+            runTest {
+                val db = createInMemoryTestDatabase()
+
+                repoAgainst(db).savePlaybackState(
+                    bookId = bookId,
+                    update = PlaybackUpdate.PlaybackStarted(positionMs = 0L, speed = 1.0f),
+                )
+
+                val row = db.playbackPositionDao().get(bookId).shouldNotBeNull()
+                row.lastPlayedAt.shouldNotBeNull() shouldBeGreaterThan 1_000L
+            }
+        }
+    })

--- a/app/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/PlaybackRefusalTest.kt
+++ b/app/sharedUI/src/androidHostTest/kotlin/com/calypsan/listenup/client/playback/PlaybackRefusalTest.kt
@@ -24,6 +24,7 @@ class PlaybackRefusalTest :
             // The hardening case: play was requested, focus was denied, nothing ever sounded.
             isPlaybackRefused(
                 playWhenReady = false,
+                playRequested = true,
                 reason = Player.PLAY_WHEN_READY_CHANGE_REASON_AUDIO_FOCUS_LOSS,
                 wasPlaying = false,
             ) shouldBe true
@@ -33,6 +34,7 @@ class PlaybackRefusalTest :
             // A phone call. Routine, and playback resumes on its own afterwards.
             isPlaybackRefused(
                 playWhenReady = false,
+                playRequested = true,
                 reason = Player.PLAY_WHEN_READY_CHANGE_REASON_AUDIO_FOCUS_LOSS,
                 wasPlaying = true,
             ) shouldBe false
@@ -41,12 +43,14 @@ class PlaybackRefusalTest :
         test("the listener pausing is never a refusal") {
             isPlaybackRefused(
                 playWhenReady = false,
+                playRequested = true,
                 reason = Player.PLAY_WHEN_READY_CHANGE_REASON_USER_REQUEST,
                 wasPlaying = true,
             ) shouldBe false
 
             isPlaybackRefused(
                 playWhenReady = false,
+                playRequested = true,
                 reason = Player.PLAY_WHEN_READY_CHANGE_REASON_USER_REQUEST,
                 wasPlaying = false,
             ) shouldBe false
@@ -55,6 +59,7 @@ class PlaybackRefusalTest :
         test("unplugging headphones is not a refusal") {
             isPlaybackRefused(
                 playWhenReady = false,
+                playRequested = true,
                 reason = Player.PLAY_WHEN_READY_CHANGE_REASON_AUDIO_BECOMING_NOISY,
                 wasPlaying = true,
             ) shouldBe false
@@ -63,6 +68,7 @@ class PlaybackRefusalTest :
         test("reaching the end of the book is not a refusal") {
             isPlaybackRefused(
                 playWhenReady = false,
+                playRequested = true,
                 reason = Player.PLAY_WHEN_READY_CHANGE_REASON_END_OF_MEDIA_ITEM,
                 wasPlaying = true,
             ) shouldBe false
@@ -72,6 +78,25 @@ class PlaybackRefusalTest :
             // playWhenReady = true means the player is going; nothing was refused.
             isPlaybackRefused(
                 playWhenReady = true,
+                playRequested = true,
+                reason = Player.PLAY_WHEN_READY_CHANGE_REASON_AUDIO_FOCUS_LOSS,
+                wasPlaying = false,
+            ) shouldBe false
+        }
+
+        test("a stale focus loss replayed on process unfreeze is NOT a refusal") {
+            // 2026-08-07, 08:32:29.011 — 79ms after the Android freezer thawed the process, and SIX
+            // SECONDS BEFORE the listener tapped anything, this fired and posted
+            // PLAYBACK_BLOCKED_IN_BACKGROUND. The loss it described was real but 45 minutes old: at
+            // 07:47:09 another app took focus. Frozen processes do not receive callbacks, so Media3
+            // delivered it on thaw and the old predicate could not tell "just refused" from "queued
+            // since breakfast".
+            //
+            // playRequested is what separates them: a genuine refusal is always PRECEDED by
+            // playWhenReady going true. A replay has no such edge.
+            isPlaybackRefused(
+                playWhenReady = false,
+                playRequested = false,
                 reason = Player.PLAY_WHEN_READY_CHANGE_REASON_AUDIO_FOCUS_LOSS,
                 wasPlaying = false,
             ) shouldBe false

--- a/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackRefusal.kt
+++ b/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackRefusal.kt
@@ -14,16 +14,28 @@ import androidx.media3.common.Player
  * We are the first app on a device to meet this: enforcement is gated on target SDK, so while we
  * target 37 the rest of the phone is still in dry-run and logs "would be ignored".
  *
- * [wasPlaying] is what separates the two cases that share
- * [Player.PLAY_WHEN_READY_CHANGE_REASON_AUDIO_FOCUS_LOSS]. Audio that was already sounding and then
- * stopped is an interruption — a phone call — which resolves itself and must stay silent. Audio
- * that never started is a refusal the listener is stuck behind, and needs a way out.
+ * Three inputs, because three situations share
+ * [Player.PLAY_WHEN_READY_CHANGE_REASON_AUDIO_FOCUS_LOSS] and only one of them is a dead end:
+ *
+ * - [wasPlaying] separates a refusal from an **interruption**. Audio that was already sounding and
+ *   then stopped is a phone call — routine, self-healing, and must stay silent.
+ * - [playRequested] separates a refusal from a **replay**. Android freezes backgrounded processes,
+ *   and a frozen process receives no callbacks; on thaw, Media3 delivers whatever queued up. On
+ *   2026-08-07 a focus loss from 07:47:09 arrived at 08:32:29.011 — 79ms after unfreeze and six
+ *   seconds before the listener touched anything — and the old two-input predicate reported it as a
+ *   refusal, posting a notification about a play nobody had attempted.
+ *
+ * [playRequested] is an EDGE, not a level: a genuine refusal is always preceded by `playWhenReady`
+ * going true, because that is the app asking to play. A replayed loss has no such edge. (Same
+ * lesson as the listening-span START fix: level-triggered state cannot survive a replay.)
  */
 internal fun isPlaybackRefused(
     playWhenReady: Boolean,
+    playRequested: Boolean,
     reason: Int,
     wasPlaying: Boolean,
 ): Boolean =
     !playWhenReady &&
+        playRequested &&
         reason == Player.PLAY_WHEN_READY_CHANGE_REASON_AUDIO_FOCUS_LOSS &&
         !wasPlaying

--- a/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
+++ b/app/sharedUI/src/androidMain/kotlin/com/calypsan/listenup/client/playback/PlaybackService.kt
@@ -104,6 +104,18 @@ class PlaybackService :
     private var casting = false
 
     /**
+     * Whether a play request is outstanding — `playWhenReady` went true and has not yet resolved
+     * into either audio or a refusal.
+     *
+     * This is the EDGE that arms [isPlaybackRefused]. Android freezes backgrounded processes and a
+     * frozen process receives no callbacks, so on thaw Media3 delivers whatever queued up while it
+     * slept. Without this flag a focus loss from 45 minutes earlier is indistinguishable from a
+     * refusal happening now — which is exactly what fired a spurious "playback blocked"
+     * notification 79ms after unfreeze on 2026-08-07.
+     */
+    private var playRequested = false
+
+    /**
      * Whether audio was actually sounding when the last transport change arrived.
      *
      * Read by [isPlaybackRefused] to separate a refused start from an ordinary interruption —
@@ -863,21 +875,29 @@ class PlaybackService :
             playWhenReady: Boolean,
             reason: Int,
         ) {
-            if (isPlaybackRefused(playWhenReady, reason, wasPlaying)) {
+            if (playWhenReady) {
+                // The app asking to play is the edge that arms the refusal check. Without it, a
+                // focus loss replayed on process unfreeze reads exactly like a fresh refusal.
+                playRequested = true
+                return
+            }
+            if (isPlaybackRefused(playWhenReady, playRequested, reason, wasPlaying)) {
                 logger.warn {
-                    "Playback refused: audio focus denied while backgrounded. " +
+                    "Playback refused: the platform denied audio focus for a play we just requested. " +
                         "Check `adb shell dumpsys audio` for the AudioHardening entry."
                 }
                 val refusal =
                     PlaybackError.BlockedInBackground(
                         debugInfo = "playWhenReady=false reason=AUDIO_FOCUS_LOSS before playback started",
                     )
-                // The bus reaches the UI only when the app is already open — which is precisely
-                // when this can't happen. The notification is the path that actually reaches a
-                // listener staring at a lock-screen button that did nothing.
+                // The bus reaches the UI when the app is open; the notification is the path that
+                // reaches a listener staring at a lock-screen button that did nothing. Both are
+                // wanted — a refusal is now known to happen with the app plainly on screen.
                 errorBus.emit(refusal)
                 refusalNotifier.notifyRefused(refusal)
             }
+            // Resolved either way: the next refusal needs its own play request to arm it.
+            playRequested = false
         }
 
         override fun onIsPlayingChanged(isPlaying: Boolean) = handleIsPlayingChanged(source, isPlaying)


### PR DESCRIPTION
Reproduced on device 2026-08-07: tap play at `08:32:35.145`, audio at `08:33:29.411` — **54.3s**, on a book that was **already fully downloaded**. Decomposed from logcat with no gaps:

| Window | Cost | Cause |
|---|---|---|
| 08:32:35.1 → 08:32:59.3 | 24.1s | two serialised token refreshes |
| 08:32:59.3 → 08:33:29.3 | 30.0s | `getPosition` at 15s + 15s idempotent retry |

The offline-first branch was the slow one: a streaming book gets its resume position free from `prepare()`; a downloaded book paid a dedicated blocking RPC.

## Changes

- **`0ccabf9e3` coalesce token refresh** — `prepareForPlayback` re-checks under `refreshMutex` and adopts an in-flight refresh instead of queueing its own. `refreshToken()` remains a forced rotation, so the 401 and proactive-loop paths are unchanged.
- **`a59cb470d` catch up `playback_positions` first** — `registeredDomains()` was alphabetical, putting the domain that decides *where a book resumes* ~14th of 22, behind `book_moods` and `book_tags`. Catch-up is strictly sequential at one round-trip each, so list position is latency.
- **`b5dc42677` starting playback no longer claims position authority** — `PlaybackStarted` preserved `lastPlayedAt` rather than stamping `now`. It is the conflict key; opening a book is not evidence of listening. This is what makes the bounded fetch safe, and it also stops a play that never produced audio from claiming a session.
- **`25fb478b8` bound the resume fetch** — 800ms, no retry, down from 15s + retry.
- **`9c370f48e` circuit breaker** — `ConnectionEvidence` was a write-only sink; it now gates timeouts at the `RpcChannel` boundary, so every service inherits it. Not a state machine: calls are bounded shorter, never refused, so an ordinary call doubles as the recovery probe.
- **`802cadca1` no refusal notice for a replayed focus loss** — at `08:32:29.011`, 79ms after process unfreeze and six seconds *before* any tap, a focus loss from `07:47:09` was reported as a refused play. `isPlaybackRefused` now requires the play-request edge.

## Notes

Two KDocs asserted invariants the code did not hold, and both hid a bug in plain sight: `fetchAuthoritativePosition` claimed it "never blocks or fails playback" while being awaited on the critical path, and the refusal emit site claimed the case "can't happen" with the app open. Both corrected.

The remaining Android 17 focus denial (a foreground, on-screen play refused at `08:32:58.893`) is deliberately not addressed here — the mechanism isn't established, and Media3 1.11 fixes a `ForegroundServiceStartNotAllowedException` of the same shape, so it should be investigated against that build.

## Verification

`verifyLocal` green. `:app:sharedLogic:jvmTest` 3,527 tests, `:app:sharedUI:testAndroidHostTest` green, `spotlessCheck` + `detekt` clean. Not yet verified on device.