### PR TITLE
🔖 chore: sync the README version badge from VERSION on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,9 +54,16 @@ jobs:
           if [ -n "$INPUT" ]; then
             CLEAN="${INPUT#v}"
             echo "$CLEAN" > VERSION
+            # Keep the README status badge in step with VERSION. It is carried in the same
+            # commit deliberately: hand-updating it drifted six releases (0.6.0 while shipping
+            # 0.8.6), because nothing failed when it was forgotten.
+            sed -i -E \
+              -e "s|status-beta%20v[0-9]+\.[0-9]+\.[0-9]+-orange|status-beta%20v$CLEAN-orange|" \
+              -e "s|alt=\"Beta v[0-9]+\.[0-9]+\.[0-9]+\"|alt=\"Beta v$CLEAN\"|" \
+              README.md
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
-            git add VERSION
+            git add VERSION README.md
             git commit -m "🔖 chore: release v$CLEAN"
             git tag "v$CLEAN"
             git push origin HEAD:main

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@
   <a href="https://developer.android.com"><img src="https://img.shields.io/badge/Android-13%2B-3DDC84?logo=android&logoColor=white" alt="Android" /></a>
   <a href="https://developer.apple.com/ios/"><img src="https://img.shields.io/badge/iOS-26%2B-000000?logo=apple&logoColor=white" alt="iOS" /></a>
   <a href="https://www.jetbrains.com/compose-multiplatform/"><img src="https://img.shields.io/badge/Compose-Multiplatform-4285F4?logo=jetpackcompose&logoColor=white" alt="Compose Multiplatform" /></a>
-  <img src="https://img.shields.io/badge/status-beta%20v0.6.0-orange" alt="Beta v0.6.0" />
+  <!-- Rewritten automatically by the Release workflow's version-bump step. Do not hand-edit. -->
+  <img src="https://img.shields.io/badge/status-beta%20v0.8.6-orange" alt="Beta v0.8.6" />
   <img src="https://img.shields.io/badge/License-AGPL--3.0-blue" alt="License" />
 </p>
 


### PR DESCRIPTION
The README status badge read `v0.6.0` while we shipped `v0.8.6` — six releases of drift, because nothing failed when someone forgot to update it by hand.

Two changes:

- Badge corrected to `v0.8.6`.
- The Release workflow's version-bump step now rewrites the badge from the resolved version and carries it in the same `🔖 chore: release vX` commit as `VERSION`. Same commit deliberately — a separate step is a separate thing to forget.

The `sed` targets both the shields.io URL and the `alt` text, and only runs on the branch that takes a `version` input; a blank-input re-ship leaves the badge alone, which is correct since the version has not moved.

Verified the substitution against the real README before committing: `0.8.6` → `0.9.1` rewrote both fields.