### PR TITLE
✨ feat(webApp): Book Detail — a Files tab and a way out of the bookless states

### DIFF
--- a/app/webApp/src/jsMain/kotlin/com/calypsan/listenup/web/features/bookdetail/BookDetailPage.kt
+++ b/app/webApp/src/jsMain/kotlin/com/calypsan/listenup/web/features/bookdetail/BookDetailPage.kt
@@ -6,6 +6,7 @@ import com.calypsan.listenup.api.error.BookError
 import com.calypsan.listenup.client.presentation.bookdetail.BookDetailUiState
 import com.calypsan.listenup.web.design.Breadcrumb
 import com.calypsan.listenup.web.design.Cover
+import com.calypsan.listenup.web.design.Icon
 import com.calypsan.listenup.web.design.MetaEntry
 import com.calypsan.listenup.web.design.MetaList
 import com.calypsan.listenup.web.design.Panel
@@ -13,6 +14,8 @@ import com.calypsan.listenup.web.design.Pill
 import com.calypsan.listenup.web.design.ProgressLine
 import com.calypsan.listenup.web.design.TabItem
 import com.calypsan.listenup.web.design.Tabs
+import com.calypsan.listenup.web.design.WebIcon
+import org.jetbrains.compose.web.dom.Button
 import org.jetbrains.compose.web.dom.Div
 import org.jetbrains.compose.web.dom.H1
 import org.jetbrains.compose.web.dom.H3
@@ -46,12 +49,22 @@ fun BookDetailPage(
 
         when (state) {
             is BookDetailUiState.Loading -> {
-                Notice("Loading", "Reading this book from your library.")
+                EmptyState(WebIcon.Clock, "Loading", "Reading this book from your library.")
             }
 
             is BookDetailUiState.Error -> {
                 val (heading, body) = explain(state.error)
-                Notice(heading, body)
+                // A state that can't show what was asked for still owes the reader somewhere to
+                // go. Library is the only honest destination: web sync is unwritten, so a "sync
+                // this browser" button would be a control with nothing behind it.
+                EmptyState(WebIcon.Book, heading, body) {
+                    Button(attrs = {
+                        classes("btn-c")
+                        onClick { onOpenLibrary() }
+                    }) {
+                        Text("Back to Library")
+                    }
+                }
             }
 
             is BookDetailUiState.Ready -> {
@@ -62,19 +75,34 @@ fun BookDetailPage(
                         listOf(
                             TabItem("overview", "Overview"),
                             TabItem("chapters", "Chapters", count = state.chapters.size.toString()),
+                            TabItem(
+                                "files",
+                                "Files",
+                                count =
+                                    state.book.audioFiles.size
+                                        .toString(),
+                            ),
                         ),
                     active = tab,
                     onSelect = onSelectTab,
                 )
 
-                if (tab == "chapters") {
-                    ChaptersPane(
-                        chapters = state.chapters.toWebChapters(),
-                        selection = selection,
-                        onSelectionChange = onSelectionChange,
-                    )
-                } else {
-                    OverviewPane(state)
+                when (tab) {
+                    "chapters" -> {
+                        ChaptersPane(
+                            chapters = state.chapters.toWebChapters(),
+                            selection = selection,
+                            onSelectionChange = onSelectionChange,
+                        )
+                    }
+
+                    "files" -> {
+                        FilesPane(state)
+                    }
+
+                    else -> {
+                        OverviewPane(state)
+                    }
                 }
             }
         }
@@ -129,7 +157,7 @@ private fun OverviewPane(state: BookDetailUiState.Ready) {
                     }
                 }
                 if (state.descriptionText.isBlank() && state.genres.isEmpty()) {
-                    Hint("No description has been written for this book.")
+                    PaneHint("No description has been written for this book.")
                 }
             }
         }
@@ -182,19 +210,28 @@ private fun explain(error: AppError): Pair<String, String> =
         "This book can't be shown" to error.message
     }
 
+/**
+ * The shape every state with no book takes: a mark, what happened, and — when there is somewhere
+ * honest to go — the way out. The `.empty` rule in the sheet has always carried an `.ico` slot;
+ * drawing it is what turns a bare sentence into a page.
+ */
 @Composable
-private fun Notice(
+private fun EmptyState(
+    icon: WebIcon,
     heading: String,
     body: String,
+    action: (@Composable () -> Unit)? = null,
 ) {
     Div(attrs = { classes("empty") }) {
+        Div(attrs = { classes("ico") }) { Icon(icon, size = ICON_SIZE) }
         H3 { Text(heading) }
         P { Text(body) }
+        action?.let { it() }
     }
 }
 
 @Composable
-private fun Hint(text: String) {
+internal fun PaneHint(text: String) {
     P(attrs = {
         style {
             property("margin", "0")
@@ -212,3 +249,5 @@ private const val PERCENT = 100
 private const val COVER_SIZE = 180
 
 private const val COVER_RADIUS = 16
+
+private const val ICON_SIZE = 24

--- a/app/webApp/src/jsMain/kotlin/com/calypsan/listenup/web/features/bookdetail/FilesPane.kt
+++ b/app/webApp/src/jsMain/kotlin/com/calypsan/listenup/web/features/bookdetail/FilesPane.kt
@@ -1,0 +1,132 @@
+package com.calypsan.listenup.web.features.bookdetail
+
+import androidx.compose.runtime.Composable
+import com.calypsan.listenup.client.domain.model.AudioFile
+import com.calypsan.listenup.client.presentation.bookdetail.BookDetailUiState
+import com.calypsan.listenup.client.presentation.bookdetail.audioFormatDisplay
+import com.calypsan.listenup.web.design.ColumnAlign
+import com.calypsan.listenup.web.design.DataTable
+import com.calypsan.listenup.web.design.MetaEntry
+import com.calypsan.listenup.web.design.MetaList
+import com.calypsan.listenup.web.design.Panel
+import com.calypsan.listenup.web.design.TableColumn
+import org.jetbrains.compose.web.dom.Div
+import org.jetbrains.compose.web.dom.Span
+import org.jetbrains.compose.web.dom.Text
+
+/**
+ * What is actually on disk: one row per audio file, and the primary file's specs beside them.
+ *
+ * This is the pane a self-hoster opens the web client to check, and it is a render rather than a
+ * new capability — every value comes off [AudioFile] and the shared `audioFormatDisplay`, which
+ * the mobile Details section already reads.
+ *
+ * There is deliberately no filesystem path. [com.calypsan.listenup.client.domain.model.BookDetail]
+ * carries a `folderId`, and a library folder's `rootPath` is the library root rather than this
+ * book's directory — showing the root under a "Path" label would send someone to the wrong
+ * directory. A per-book path is a contract change, not a web edit.
+ */
+@Composable
+internal fun FilesPane(state: BookDetailUiState.Ready) {
+    val files = state.book.audioFiles
+
+    if (files.isEmpty()) {
+        Panel(title = "Audio files") {
+            PaneHint("This book has no audio files on record — the scanner hasn't indexed it yet.")
+        }
+        return
+    }
+
+    Div(attrs = { classes("bd-cols") }) {
+        Div(attrs = { classes("bd-main") }) {
+            Panel(
+                title = "Audio files",
+                flush = true,
+                trailing = { MachineNote(formatBytes(files.sumOf { it.size })) },
+            ) {
+                DataTable(columns = FILE_COLUMNS, rows = files)
+            }
+        }
+        Div(attrs = { classes("bd-side") }) {
+            Panel(title = "Audio") {
+                MetaList(audioEntries(files))
+            }
+        }
+    }
+}
+
+/**
+ * The specs panel. Every row but the totals comes from the primary file, and each field is
+ * dropped when the scanner couldn't determine it — a row reading "Unknown" is a row that
+ * shouldn't be drawn.
+ */
+private fun audioEntries(files: List<AudioFile>): List<MetaEntry> {
+    val display = audioFormatDisplay(files)
+    return buildList {
+        display.format?.let { add(MetaEntry("Format", it, machine = true)) }
+        display.bitrate?.let { add(MetaEntry("Bitrate", it, machine = true)) }
+        display.sampleRate?.let { add(MetaEntry("Sample rate", it, machine = true)) }
+        display.channels?.let { add(MetaEntry("Channels", it, machine = true)) }
+        add(MetaEntry("Size", formatBytes(files.sumOf { it.size }), machine = true))
+        add(MetaEntry("Files", files.size.toString(), machine = true))
+    }
+}
+
+private val FILE_COLUMNS =
+    listOf(
+        TableColumn<AudioFile>("file", "File", mono = true) { Text(it.filename) },
+        TableColumn("duration", "Duration", width = 96, align = ColumnAlign.End, mono = true) {
+            Text(formatClock((it.duration / MILLIS_PER_SECOND).toInt()))
+        },
+        TableColumn("size", "Size", width = 88, align = ColumnAlign.End, mono = true) {
+            Text(formatBytes(it.size))
+        },
+        TableColumn("codec", "Codec", width = 108, align = ColumnAlign.End, mono = true) {
+            Text(codecLabel(it))
+        },
+    )
+
+/** "AAC 64k" — the codec and, when the file knows it, the bitrate that distinguishes two rips. */
+private fun codecLabel(file: AudioFile): String {
+    val codec = file.codec.takeIf { it.isNotBlank() }?.uppercase() ?: return "—"
+    val kbps = file.bitrate?.let { it / BITS_PER_KILOBIT } ?: return codec
+    return "$codec ${kbps}k"
+}
+
+/**
+ * Binary megabytes, no decimals: these sit in a scannable column, and a self-hoster comparing
+ * "178 MB" against their filesystem wants the number their file manager shows.
+ */
+private fun formatBytes(bytes: Long): String {
+    if (bytes < BYTES_PER_MEGABYTE) return "${bytes / BYTES_PER_KILOBYTE} KB"
+    if (bytes < BYTES_PER_GIGABYTE) return "${bytes / BYTES_PER_MEGABYTE} MB"
+    // Integer tenths rather than floating point: one decimal is all a size column can use, and
+    // this cannot render "1.0000000000000002 GB".
+    val tenths = bytes * TENTHS / BYTES_PER_GIGABYTE
+    return "${tenths / TENTHS}.${tenths % TENTHS} GB"
+}
+
+@Composable
+private fun MachineNote(text: String) {
+    Span(attrs = {
+        classes("mono")
+        style {
+            property("font-size", "11.5px")
+            property("color", "var(--ink-3)")
+        }
+    }) {
+        Text(text)
+    }
+}
+
+private const val MILLIS_PER_SECOND = 1000L
+
+private const val BITS_PER_KILOBIT = 1000
+
+private const val BYTES_PER_KILOBYTE = 1024L
+
+private const val BYTES_PER_MEGABYTE = 1024L * 1024
+
+private const val BYTES_PER_GIGABYTE = 1024L * 1024 * 1024
+
+private const val TENTHS = 10L

--- a/app/webApp/src/jsTest/kotlin/com/calypsan/listenup/web/features/bookdetail/BookDetailFixtures.kt
+++ b/app/webApp/src/jsTest/kotlin/com/calypsan/listenup/web/features/bookdetail/BookDetailFixtures.kt
@@ -1,5 +1,6 @@
 package com.calypsan.listenup.web.features.bookdetail
 
+import com.calypsan.listenup.client.domain.model.AudioFile
 import com.calypsan.listenup.client.domain.model.BookContributor
 import com.calypsan.listenup.client.domain.model.BookDetail
 import com.calypsan.listenup.client.domain.model.Genre
@@ -17,7 +18,10 @@ import com.calypsan.listenup.core.Timestamp
  * ViewModel gives it, and a fixture in the source set would be a fixture users could reach. That
  * the real ViewModel produces this shape is proven separately by `ClientGraphProbeTest`.
  */
-internal fun readyBook(chapters: List<ChapterUiModel> = sampleChapters()): BookDetailUiState.Ready =
+internal fun readyBook(
+    chapters: List<ChapterUiModel> = sampleChapters(),
+    audioFiles: List<AudioFile> = sampleAudioFiles(),
+): BookDetailUiState.Ready =
     BookDetailUiState.Ready(
         book =
             BookDetail(
@@ -35,6 +39,7 @@ internal fun readyBook(chapters: List<ChapterUiModel> = sampleChapters()): BookD
                 publishYear = 2019,
                 publisher = "Scribner",
                 genres = listOf(Genre(id = "g1", name = "Horror", slug = "horror", path = "/horror")),
+                audioFiles = audioFiles,
             ),
         descriptionText = "He wakes up at The Institute, in a room that looks just like his own.",
         narrators = "Santino Fontana",
@@ -66,6 +71,26 @@ internal fun sampleChapters(): List<ChapterUiModel> {
     }
 }
 
+/**
+ * Three parts, the shape a real M4B rip has. Sizes and bitrates differ per file so a spec can
+ * tell one row from another rather than passing on a table of identical values.
+ */
+internal fun sampleAudioFiles(): List<AudioFile> =
+    PART_MEGABYTES.mapIndexed { index, megabytes ->
+        AudioFile(
+            id = "af-${index + 1}",
+            index = index,
+            filename = "the-institute-part-${index + 1}.m4b",
+            format = "m4b",
+            codec = "aac",
+            duration = TOTAL_SECONDS * MILLIS_PER_SECOND / PART_MEGABYTES.size,
+            size = megabytes * BYTES_PER_MEGABYTE,
+            bitrate = SAMPLE_BITRATE_KBPS * BITS_PER_KILOBIT,
+            sampleRate = SAMPLE_RATE_HZ,
+            channels = SAMPLE_CHANNELS,
+        )
+    }
+
 /** 9:14:06 — the runtime the Details panel reports. */
 private const val TOTAL_SECONDS = 9L * 3600 + 14 * 60 + 6
 
@@ -78,3 +103,16 @@ private const val BASE_SECONDS = 700
 private const val VARIATION_STEP = 137
 
 private const val VARIATION_RANGE = 600
+
+private const val BYTES_PER_MEGABYTE = 1024L * 1024
+
+private const val BITS_PER_KILOBIT = 1000
+
+/** Three parts summing to 512 MB — the size the Files panel reports as the book's total. */
+private val PART_MEGABYTES = listOf(178L, 182L, 152L)
+
+private const val SAMPLE_BITRATE_KBPS = 64
+
+private const val SAMPLE_RATE_HZ = 44_100
+
+private const val SAMPLE_CHANNELS = 2

--- a/app/webApp/src/jsTest/kotlin/com/calypsan/listenup/web/features/bookdetail/BookDetailPanesTest.kt
+++ b/app/webApp/src/jsTest/kotlin/com/calypsan/listenup/web/features/bookdetail/BookDetailPanesTest.kt
@@ -1,0 +1,148 @@
+package com.calypsan.listenup.web.features.bookdetail
+
+import com.calypsan.listenup.api.error.BookError
+import com.calypsan.listenup.client.presentation.bookdetail.BookDetailUiState
+import com.calypsan.listenup.web.WebAppRoot
+import com.calypsan.listenup.web.nav.Router
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import kotlinx.browser.document
+import kotlinx.browser.window
+import org.jetbrains.compose.web.renderComposable
+import org.w3c.dom.HTMLElement
+
+/**
+ * The Files pane and the states with no book.
+ *
+ * Both are renders of what the contract already carries — `BookDetail.audioFiles` and the shared
+ * `audioFormatDisplay` — rather than new capability. The absences are the other half of the
+ * design: no Resume or Download (web has no playback, and its download enqueuer refuses by
+ * design), no filesystem path (the contract carries `folderId`, not a per-book path), no sync
+ * button (web sync is unwritten), and no linked contributors (web has no contributor route). Each
+ * would be a control that cannot keep its promise, so each is pinned absent here.
+ */
+class BookDetailPanesTest :
+    FunSpec({
+
+        var originalUrl = ""
+
+        beforeTest { originalUrl = window.location.pathname + window.location.search }
+
+        afterTest { window.history.replaceState(null, "", originalUrl) }
+
+        fun mountAt(
+            path: String,
+            source: OpenBookDetail = fixedBookDetail(readyBook()),
+        ): Pair<HTMLElement, Router> {
+            window.history.replaceState(null, "", path)
+            val router = Router()
+            val host = document.createElement("div") as HTMLElement
+            document.body!!.appendChild(host)
+            renderComposable(root = host) { WebAppRoot(router, source) }
+            return host to router
+        }
+
+        fun tabText(host: HTMLElement): String =
+            (0 until host.querySelectorAll(".tab").length)
+                .mapNotNull { index -> (host.querySelectorAll(".tab").item(index) as? HTMLElement)?.textContent }
+                .joinToString(" ")
+
+        test("the page offers exactly the panes it has data for") {
+            val (host, router) = mountAt("/book/42")
+
+            try {
+                val tabs = tabText(host)
+                host.querySelectorAll(".tab").length shouldBe 3
+                tabs shouldContain "Overview"
+                tabs shouldContain "Chapters"
+                tabs shouldContain "Files"
+                // No activity source exists, and Readers needs a second ViewModel that isn't wired.
+                tabs.contains("Activity") shouldBe false
+            } finally {
+                router.dispose()
+            }
+        }
+
+        test("the files pane lists every file with the numbers an operator came to check") {
+            val (host, router) = mountAt("/book/42?tab=files")
+
+            try {
+                host.querySelectorAll(".bd-main .tbl tbody tr").length shouldBe 3
+                val main = (host.querySelector(".bd-main") as HTMLElement).textContent.orEmpty()
+                main shouldContain "the-institute-part-1.m4b"
+                main shouldContain "178 MB"
+            } finally {
+                router.dispose()
+            }
+        }
+
+        test("the files rail reports the audio specs the primary file carries") {
+            val (host, router) = mountAt("/book/42?tab=files")
+
+            try {
+                val rail = (host.querySelector(".bd-side") as HTMLElement).textContent.orEmpty()
+                rail shouldContain "64 kbps"
+                rail shouldContain "Files"
+            } finally {
+                router.dispose()
+            }
+        }
+
+        test("a book whose files never got scanned says so rather than drawing an empty table") {
+            val (host, router) =
+                mountAt("/book/42?tab=files", fixedBookDetail(readyBook(audioFiles = emptyList())))
+
+            try {
+                (host.querySelector(".bd .tblwrap") == null) shouldBe true
+                (host.querySelector(".bd") as HTMLElement)
+                    .textContent
+                    .orEmpty() shouldContain "no audio files"
+            } finally {
+                router.dispose()
+            }
+        }
+
+        test("a missing book offers the way back rather than only naming the problem") {
+            val (host, router) =
+                mountAt("/book/99", fixedBookDetail(BookDetailUiState.Error(BookError.NotFound())))
+
+            try {
+                val empty = host.querySelector(".bd .empty") as HTMLElement
+                (empty.querySelector(".ico") != null) shouldBe true
+                empty.textContent.orEmpty() shouldContain "Not in this browser's library"
+                (empty.querySelector("button") as HTMLElement)
+                    .textContent
+                    .orEmpty() shouldContain "Back to Library"
+            } finally {
+                router.dispose()
+            }
+        }
+
+        test("the way back out of a missing book actually goes to the library") {
+            val (host, router) =
+                mountAt("/book/99", fixedBookDetail(BookDetailUiState.Error(BookError.NotFound())))
+
+            try {
+                (host.querySelector(".bd .empty button") as HTMLElement).click()
+
+                window.location.pathname shouldBe "/library"
+            } finally {
+                router.dispose()
+            }
+        }
+
+        test("no control is offered for a capability this client doesn't have") {
+            val (host, router) = mountAt("/book/42")
+
+            try {
+                val page = (host.querySelector(".bd") as HTMLElement).textContent.orEmpty()
+                page.contains("Resume") shouldBe false
+                page.contains("Download") shouldBe false
+                // The byline names its people but doesn't link them: there is no contributor route.
+                (host.querySelector(".bd-by a") == null) shouldBe true
+            } finally {
+                router.dispose()
+            }
+        }
+    })


### PR DESCRIPTION
Implements two of the three deltas from `Web/Book Detail.html` in the Claude Design project, after a round of syncing the comp against what the code can actually do.

## What's here

**A Files tab** — the pane a self-hoster opens the web client to check. An audio-files table (File / Duration / Size / Codec) with the book's total size, plus an "Audio" rail panel driven by the shared `audioFormatDisplay`: Format, Bitrate, Sample rate, Channels. Every row is dropped when the scanner couldn't determine it, because a row reading "Unknown" is a row that shouldn't be drawn. This is a render of `BookDetail.audioFiles` — the same data the mobile Details section already reads — not a new capability.

**States that offer a way forward** — `.empty` in the sheet has always carried an `.ico` slot the code never drew, so every bookless state was a bare heading and a sentence. Now it has a mark, and a missing book offers *Back to Library*.

## What's deliberately absent

Each of these would be a control that can't keep its promise, and each is pinned by a spec so it can't drift back in:

- **No Resume / Download.** `browserPlaybackModule` binds `playbackAvailable = false`, and `BrowserDownloadEnqueuer` refuses by design ("offline audio in a browser is undesigned, so the truthful binding refuses rather than pretends").
- **No filesystem path.** `BookDetail` carries `folderId`; a library folder's `rootPath` is the library root, not this book's directory. Showing the root under a "Path" label sends someone to the wrong directory. A per-book path is a contract→server→client change.
- **No sync button** on the empty state. Web sync is unwritten — the action would have nothing behind it.
- **No linked contributors.** The byline names its people but doesn't link them: web has no contributor route yet.

## Design sync

The comp originally drew an Activity tab, a waveform, a six-tab header and a full Resume/Download row. Reviewing it against the code retired all of those, and Claude Design has since updated the project to match — it now documents the shipped page as built and states the bar explicitly: *"an affordance for a capability web doesn't have is a dead control."* The comp also corrected me: the real breakpoints are 1280 / 1023 / 760 from shipped `web.css`, so there was nothing responsive to build.

## Verification

All four Linux CI jobs run locally on this commit:

| Gate | Result |
|---|---|
| `verifyLocal` (Lint + Test JVM) | ✅ 9,800 tests, 0 failures |
| `:server:linuxX64Test` | ✅ 82 tests, 0 failures |
| `:app:webApp:webKotest` | ✅ 151 specs, 0 failed |
| **Total** | **9,882 + 151, zero failures** |

TDD throughout: 6 specs RED first (the page rendered only "Overview | Chapters"), then GREEN.

## Next

`Add to shelf` is the comp's one live action and is **not** in this PR. The ViewModel has the surface (`addBookToShelf`, `showShelfPicker`, `createShelfAndAddBook`), but picking a shelf needs a list of all shelves — `shelvesContainingBook` is the inverse — and a modal picker component web doesn't have. Same bar: the button waits for the picker.
